### PR TITLE
Iterator for Poller

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -10,6 +10,11 @@ pub struct Poll {
     events: os::Events
 }
 
+pub struct EventsIterator<'a> {
+    events: &'a os::Events,
+    index: uint
+}
+
 impl Poll {
     pub fn new() -> MioResult<Poll> {
         Ok(Poll {
@@ -34,6 +39,21 @@ impl Poll {
 
     pub fn event(&self, idx: uint) -> IoEvent {
         self.events.get(idx)
+    }
+
+    pub fn iter(&self) -> EventsIterator {
+        EventsIterator { events: &self.events, index: 0 }
+    }
+}
+
+impl<'a> Iterator<IoEvent> for EventsIterator<'a> {
+    fn next(&mut self) -> Option<IoEvent> {
+        if self.index == self.events.len() {
+            None
+        } else {
+            self.index += 1;
+            Some(self.events.get(self.index - 1))
+        }
     }
 }
 


### PR DESCRIPTION
While switching EventLoop to iterator instead of indexing, I spotted a
potencial problem: io_process expects list of events not to change during it's
execution, but self is passed as &mut to the handler, making it possible (at
least in theory) to break it. After switch to an iterator, this issue is caught
by borrow checker actually. I switched the code to collect()ing all events into
a Vec as a workaround for now and looking forward to better ideas.