### PR TITLE
Export TimerResult and TimerError, as requested in #61

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,8 @@ pub use event_loop::{
 };
 pub use timer::{
     Timeout,
+    TimerError,
+    TimerResult
 };
 pub use os::token::{
     Token,


### PR DESCRIPTION
EventLoopError and EventLoopResult, as well as IoHandle, have all already
been made public.

Fixes #61