### PR TITLE
Memory orderings moved into new enum std::sync::atomic::Ordering

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -370,7 +370,8 @@ impl<H> EventLoopError<H> {
 mod tests {
     use std::str;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicInt, SeqCst};
+    use std::sync::atomic::AtomicInt;
+    use std::sync::atomic::Ordering::SeqCst;
     use super::EventLoop;
     use io::{IoWriter, IoReader};
     use {io, buf, Buf, Handler, Token};

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicInt, Relaxed};
+use std::sync::atomic::AtomicInt;
+use std::sync::atomic::Ordering::{Relaxed};
 use error::MioResult;
 use io::IoHandle;
 use os;

--- a/src/util/mpmc_bounded_queue.rs
+++ b/src/util/mpmc_bounded_queue.rs
@@ -35,7 +35,8 @@ use std::sync::Arc;
 use std::num::UnsignedInt;
 use std::cell::UnsafeCell;
 
-use std::sync::atomic::{AtomicUint,Relaxed,Release,Acquire};
+use std::sync::atomic::AtomicUint;
+use std::sync::atomic::Ordering::{Relaxed,Release,Acquire};
 
 struct Node<T> {
     sequence: AtomicUint,

--- a/test/test.rs
+++ b/test/test.rs
@@ -18,11 +18,12 @@ mod test_register_deregister;
 mod test_unix_echo_server;
 
 mod ports {
-    use std::sync::atomic::{AtomicUint, SeqCst, INIT_ATOMIC_UINT};
+    use std::sync::atomic::{AtomicUint, ATOMIC_UINT_INIT};
+    use std::sync::atomic::Ordering::SeqCst;
 
     // Helper for getting a unique port for the task run
     // TODO: Reuse ports to not spam the system
-    static mut NEXT_PORT: AtomicUint = INIT_ATOMIC_UINT;
+    static mut NEXT_PORT: AtomicUint = ATOMIC_UINT_INIT;
     const FIRST_PORT: uint = 18080;
 
     fn next_port() -> uint {


### PR DESCRIPTION
Updates to to rustc 0.13.0-nightly

The memory ordering moved from std::sync::atomic into the std::sync::atomic::Ordering enum. These commits fix the unresolve-issues.