### PR TITLE
Added getsockname for TcpSocket. 

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -191,9 +191,13 @@ pub mod tcp {
             try!(os::bind(&self.desc, addr));
             Ok(TcpListener { desc: self.desc })
         }
-        
-        pub fn getpeername(self) -> MioResult<SockAddr> {
+
+        pub fn getpeername(&self) -> MioResult<SockAddr> {
             os::getpeername(&self.desc)
+        }
+
+        pub fn getsockname(&self) -> MioResult<SockAddr> {
+            os::getsockname(&self.desc)
         }
     }
 

--- a/src/os/posix.rs
+++ b/src/os/posix.rs
@@ -232,8 +232,17 @@ pub fn linger(io: &IoDesc) -> MioResult<uint> {
 pub fn getpeername(io: &IoDesc) -> MioResult<SockAddr> {
     let sa : nix::sockaddr_in = unsafe { mem::zeroed() };
     let mut a = nix::SockAddr::SockIpV4(sa);
-    
+
     try!(nix::getpeername(io.fd, &mut a).map_err(MioError::from_sys_error));
+
+    Ok(to_sockaddr(&a))
+}
+
+pub fn getsockname(io: &IoDesc) -> MioResult<SockAddr> {
+    let sa : nix::sockaddr_in = unsafe { mem::zeroed() };
+    let mut a = nix::SockAddr::SockIpV4(sa);
+
+    try!(nix::getsockname(io.fd, &mut a).map_err(MioError::from_sys_error));
 
     Ok(to_sockaddr(&a))
 }


### PR DESCRIPTION
Also changed moving to borrowing in TcpSocket::getpeername.

I had problems building it with latest nix-rust:
`/Users/aleksandrpak/Projects/nix-rust/src/sched.rs:65:22: 65:23 error: obsolete syntax: ``|uint| -> bool`` closure type syntax
/Users/aleksandrpak/Projects/nix-rust/src/sched.rs:65 pub type CloneCb<'a> = ||:'a -> int;
note: use unboxed closures instead, no type annotation needed`

I have not found usage of this type so I just removed and it was OK for building mio but don't know about other projects. If you want I can send PR for this too.