### PR TITLE
Make Slab<T> Send if T is.

### DIFF
--- a/src/util/slab.rs
+++ b/src/util/slab.rs
@@ -26,6 +26,8 @@ const MAX: uint = int::MAX as uint;
 // When Entry.nxt is set to this, the entry is in use
 const IN_USE: int = -1;
 
+unsafe impl<T> Send for Slab<T> where T: Send {}
+
 impl<T> Slab<T> {
     pub fn new(cap: uint) -> Slab<T> {
         Slab::new_starting_at(Token(0), cap)


### PR DESCRIPTION
Nothing prevents `Slab<T>` to be `Send` if `T` is `Send`, and it is the only obstacle to `EventLoop` being `Send`.

Closes #90 .