### PR TITLE
Refactoring notify

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -1,5 +1,6 @@
 use std::default::Default;
 use std::time::duration::Duration;
+use std::sync::mpsc::SendError;
 use std::usize;
 use error::{MioResult, MioError};
 use handler::Handler;
@@ -322,7 +323,7 @@ impl<T, M: Send> EventLoop<T, M> {
                 handler.notify(self, msg);
                 cnt -= 1;
             } else {
-                error!("notify handler called, but the notification queue was empty"); 
+                info!("notify handler called, but the notification queue was empty"); 
             }
         }
     }
@@ -350,7 +351,7 @@ impl<M: Send> EventLoopSender<M> {
         EventLoopSender { notify: notify }
     }
 
-    pub fn send(&self, msg: M) -> Result<(), M> {
+    pub fn send(&self, msg: M) -> Result<(), SendError<M>> {
         self.notify.notify(msg)
     }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -296,7 +296,7 @@ impl<T, M: Send> EventLoop<T, M> {
         }
 
         if evt.is_error() {
-            println!(" + ERROR");
+            error!(" + ERROR");
         }
     }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -318,11 +318,12 @@ impl<T, M: Send> EventLoop<T, M> {
 
     fn notify<H: Handler<T, M>>(&mut self, handler: &mut H, mut cnt: usize) {
         while cnt > 0 {
-            let msg = self.notify.poll()
-                .expect("[BUG] at this point there should always be a message");
-
-            handler.notify(self, msg);
-            cnt -= 1;
+            if let Some(msg) = self.notify.poll() {
+                handler.notify(self, msg);
+                cnt -= 1;
+            } else {
+                error!("notify handler called, but the notification queue was empty"); 
+            }
         }
     }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -34,12 +34,12 @@ pub trait IoHandle {
 }
 
 pub trait IoReader {
-    fn read(&self, buf: &mut MutBuf) -> MioResult<NonBlock<usize>>;
+    fn read<B : MutBuf>(&self, buf: &mut B) -> MioResult<NonBlock<usize>>;
     fn read_slice(&self, buf: &mut [u8]) -> MioResult<NonBlock<usize>>;
 }
 
 pub trait IoWriter {
-    fn write(&self, buf: &mut Buf) -> MioResult<NonBlock<usize>>;
+    fn write<B : Buf>(&self, buf: &mut B) -> MioResult<NonBlock<usize>>;
     fn write_slice(&self, buf: &[u8]) -> MioResult<NonBlock<usize>>;
 }
 
@@ -74,7 +74,7 @@ impl IoHandle for PipeWriter {
 }
 
 impl IoReader for PipeReader {
-    fn read(&self, buf: &mut MutBuf) -> MioResult<NonBlock<usize>> {
+    fn read<B : MutBuf>(&self, buf: &mut B) -> MioResult<NonBlock<usize>> {
         read(self, buf)
     }
 
@@ -84,7 +84,7 @@ impl IoReader for PipeReader {
 }
 
 impl IoWriter for PipeWriter {
-    fn write(&self, buf: &mut Buf) -> MioResult<NonBlock<usize>> {
+    fn write<B : Buf>(&self, buf: &mut B) -> MioResult<NonBlock<usize>> {
         write(self, buf)
     }
 
@@ -99,7 +99,7 @@ impl IoWriter for PipeWriter {
 /// ensure that your buffer is large enough to hold an entire segment (1532 bytes if not jumbo
 /// frames)
 #[inline]
-pub fn read<I: IoHandle>(io: &I, buf: &mut MutBuf) -> MioResult<NonBlock<usize>> {
+pub fn read<I: IoHandle, B : MutBuf>(io: &I, buf: &mut B) -> MioResult<NonBlock<usize>> {
 
     let res = read_slice(io, buf.mut_bytes());
     match res {
@@ -113,7 +113,7 @@ pub fn read<I: IoHandle>(io: &I, buf: &mut MutBuf) -> MioResult<NonBlock<usize>>
 ///writes the length of the slice supplied by Buf.bytes into the socket
 ///then advances the buffer that many bytes
 #[inline]
-pub fn write<O: IoHandle>(io: &O, buf: &mut Buf) -> MioResult<NonBlock<usize>> {
+pub fn write<O: IoHandle, B : Buf>(io: &O, buf: &mut B) -> MioResult<NonBlock<usize>> {
     let res = write_slice(io, buf.bytes());
     match res {
         Ok(Ready(cnt)) => buf.advance(cnt),

--- a/src/net.rs
+++ b/src/net.rs
@@ -48,8 +48,8 @@ pub trait MulticastSocket : Socket {
 }
 
 pub trait UnconnectedSocket {
-    fn send_to(&mut self, buf: &mut Buf, tgt: &SockAddr) -> MioResult<NonBlock<()>>;
-    fn recv_from(&mut self, buf: &mut MutBuf) -> MioResult<NonBlock<SockAddr>>;
+    fn send_to<B : Buf>(&mut self, buf: &mut B, tgt: &SockAddr) -> MioResult<NonBlock<()>>;
+    fn recv_from<B : MutBuf>(&mut self, buf: &mut B) -> MioResult<NonBlock<SockAddr>>;
 }
 
 // Types of sockets
@@ -208,7 +208,7 @@ pub mod tcp {
     }
 
     impl IoReader for TcpSocket {
-        fn read(&self, buf: &mut MutBuf) -> MioResult<NonBlock<(usize)>> {
+        fn read<B : MutBuf>(&self, buf: &mut B) -> MioResult<NonBlock<(usize)>> {
             io::read(self, buf)
         }
 
@@ -218,7 +218,7 @@ pub mod tcp {
     }
 
     impl IoWriter for TcpSocket {
-        fn write(&self, buf: &mut Buf) -> MioResult<NonBlock<(usize)>> {
+        fn write<B : Buf>(&self, buf: &mut B) -> MioResult<NonBlock<(usize)>> {
             io::write(self, buf)
         }
 
@@ -343,7 +343,7 @@ pub mod udp {
     }
 
     impl IoReader for UdpSocket {
-        fn read(&self, buf: &mut MutBuf) -> MioResult<NonBlock<(usize)>> {
+        fn read<B : MutBuf>(&self, buf: &mut B) -> MioResult<NonBlock<(usize)>> {
             io::read(self, buf)
         }
 
@@ -353,7 +353,7 @@ pub mod udp {
     }
 
     impl IoWriter for UdpSocket {
-        fn write(&self, buf: &mut Buf) -> MioResult<NonBlock<(usize)>> {
+        fn write<B : Buf>(&self, buf: &mut B) -> MioResult<NonBlock<(usize)>> {
             io::write(self, buf)
         }
 
@@ -364,7 +364,7 @@ pub mod udp {
 
     // Unconnected socket sender -- trait unique to sockets
     impl UnconnectedSocket for UdpSocket {
-        fn send_to(&mut self, buf: &mut Buf, tgt: &SockAddr) -> MioResult<NonBlock<()>> {
+        fn send_to<B : Buf>(&mut self, buf: &mut B, tgt: &SockAddr) -> MioResult<NonBlock<()>> {
             match os::sendto(&self.desc, buf.bytes(), tgt) {
                 Ok(cnt) => {
                     buf.advance(cnt);
@@ -380,7 +380,7 @@ pub mod udp {
             }
         }
 
-        fn recv_from(&mut self, buf: &mut MutBuf) -> MioResult<NonBlock<SockAddr>> {
+        fn recv_from<B : MutBuf>(&mut self, buf: &mut B) -> MioResult<NonBlock<SockAddr>> {
             match os::recvfrom(&self.desc, buf.mut_bytes()) {
                 Ok((cnt, saddr)) => {
                     buf.advance(cnt);
@@ -451,7 +451,7 @@ pub mod pipe {
     }
 
     impl IoReader for UnixSocket {
-        fn read(&self, buf: &mut MutBuf) -> MioResult<NonBlock<usize>> {
+        fn read<B : MutBuf>(&self, buf: &mut B) -> MioResult<NonBlock<usize>> {
             io::read(self, buf)
         }
 
@@ -461,7 +461,7 @@ pub mod pipe {
     }
 
     impl IoWriter for UnixSocket {
-        fn write(&self, buf: &mut Buf) -> MioResult<NonBlock<usize>> {
+        fn write<B : Buf>(&self, buf: &mut B) -> MioResult<NonBlock<usize>> {
             io::write(self, buf)
         }
 

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -114,9 +114,9 @@ impl<M: Send> NotifyInner<M> {
 
     fn notify(&self, value: M) -> Result<(), M> {
         // First, push the message onto the queue
-        if !self.queue.push(value) {
-            // TODO: Don't fail
-            panic!("queue full");
+        let res = self.queue.push(value);
+        if res.is_err(){
+            return res
         }
 
         let mut cur = self.state.load(Relaxed);

--- a/src/util/mpmc_bounded_queue.rs
+++ b/src/util/mpmc_bounded_queue.rs
@@ -91,7 +91,7 @@ impl<T: Send> State<T> {
         }
     }
 
-    fn push(&self, value: T) -> bool {
+    fn push(&self, value: T) -> Result<(), T> {
         let mask = self.mask;
         let mut pos = self.enqueue_pos.load(Relaxed);
         loop {
@@ -111,12 +111,12 @@ impl<T: Send> State<T> {
                     pos = enqueue_pos;
                 }
             } else if diff < 0 {
-                return false
+                return Err(value)
             } else {
                 pos = self.enqueue_pos.load(Relaxed);
             }
         }
-        true
+        Ok(())
     }
 
     fn pop(&self) -> Option<T> {
@@ -153,7 +153,7 @@ impl<T: Send> Queue<T> {
         }
     }
 
-    pub fn push(&self, value: T) -> bool {
+    pub fn push(&self, value: T) -> Result<(), T> {
         self.state.push(value)
     }
 
@@ -188,7 +188,7 @@ mod tests {
             Thread::spawn(move || {
                 let q = q;
                 for i in range(0, nmsgs) {
-                    assert!(q.push(i));
+                    assert!(q.push(i).is_ok());
                 }
                 tx.send(()).unwrap();
             });

--- a/test/test.rs
+++ b/test/test.rs
@@ -5,8 +5,11 @@ extern crate mio;
 #[macro_use]
 extern crate log;
 
+extern crate collections;
+
 pub use ports::localhost;
 
+mod test_battery;
 mod test_close_on_drop;
 mod test_echo_server;
 mod test_notify;

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -1,0 +1,269 @@
+use mio::*;
+use mio::net::*;
+use mio::net::tcp::*;
+use mio::buf::{ByteBuf, SliceBuf};
+use mio::util::Slab;
+use super::localhost;
+use mio::event as evt;
+use collections::DList;
+use std::thread::Thread;
+use std::io::timer::Timer;
+use std::time::duration::Duration;
+
+type TestEventLoop = EventLoop<usize, String>;
+
+const SERVER: Token = Token(0);
+const CLIENT: Token = Token(1);
+
+struct EchoConn {
+    sock: TcpSocket,
+    token: Token,
+    count: u32,
+    buf: Vec<u8>
+}
+
+impl EchoConn {
+    fn new(sock: TcpSocket) -> EchoConn {
+        let mut ec =
+        EchoConn {
+            sock: sock,
+            token: Token(-1),
+            buf: Vec::with_capacity(22),
+            count: 0
+        };
+        unsafe { ec.buf.set_len(22) };
+        ec
+    }
+
+    fn writable(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
+
+        event_loop.reregister(&self.sock, self.token, evt::READABLE, evt::PollOpt::edge())
+    }
+
+    fn readable(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
+        loop {
+            match self.sock.read_slice(self.buf.as_mut_slice()) {
+                Ok(NonBlock::WouldBlock) => {
+                    break;
+                }
+                Ok(NonBlock::Ready(r)) => {
+                    self.count += 1;
+                    if self.count % 10000 == 0 {
+                        println!("Received {} messages", self.count);
+                    }
+                    if self.count == 1_000_000 {
+                        event_loop.shutdown();
+                    }
+                }
+                Err(e) => {
+                    break;
+                }
+
+            };
+        }
+
+        event_loop.reregister(&self.sock, self.token, evt::READABLE, evt::PollOpt::edge())
+    }
+}
+
+struct EchoServer {
+    sock: TcpAcceptor,
+    conns: Slab<EchoConn>
+}
+
+impl EchoServer {
+    fn accept(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
+        debug!("server accepting socket");
+
+        let sock = self.sock.accept().unwrap().unwrap();
+        let conn = EchoConn::new(sock,);
+        let tok = self.conns.insert(conn)
+            .ok().expect("could not add connection to slab");
+
+        // Register the connection
+        self.conns[tok].token = tok;
+        event_loop.register_opt(&self.conns[tok].sock, tok, evt::READABLE, evt::PollOpt::edge())
+            .ok().expect("could not register socket with event loop");
+
+        Ok(())
+    }
+
+    fn conn_readable(&mut self, event_loop: &mut TestEventLoop, tok: Token) -> MioResult<()> {
+        debug!("server conn readable; tok={:?}", tok);
+        self.conn(tok).readable(event_loop)
+    }
+
+    fn conn_writable(&mut self, event_loop: &mut TestEventLoop, tok: Token) -> MioResult<()> {
+        debug!("server conn writable; tok={:?}", tok);
+        self.conn(tok).writable(event_loop)
+    }
+
+    fn conn<'a>(&'a mut self, tok: Token) -> &'a mut EchoConn {
+        &mut self.conns[tok]
+    }
+}
+
+struct EchoClient {
+    sock: TcpSocket,
+    backlog: DList<String>,
+    token: Token,
+    count: u32
+}
+
+
+// Sends a message and expects to receive the same exact message, one at a time
+impl EchoClient {
+    fn new(sock: TcpSocket, tok: Token) -> EchoClient {
+
+        EchoClient {
+            sock: sock,
+            backlog: DList::new(),
+            token: tok,
+            count: 0
+        }
+    }
+
+    fn readable(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
+        Ok(())
+    }
+
+    fn writable(&mut self, event_loop: &mut TestEventLoop) -> MioResult<()> {
+        debug!("client socket writable");
+
+        while self.backlog.len() > 0 {
+            match self.sock.write_slice(self.backlog.front().unwrap().as_bytes()) {
+                Ok(NonBlock::WouldBlock) => {
+                    break;
+                }
+                Ok(NonBlock::Ready(r)) => {
+                    self.backlog.pop_front();
+                    self.count += 1;
+                    if self.count % 10000 == 0 {
+                        println!("Sent {} messages", self.count);
+                    }
+                }
+                Err(e) => { debug!("not implemented; client err={:?}", e); break; }
+            }
+        }
+        if self.backlog.len() > 0 {
+            event_loop.reregister(&self.sock, self.token, evt::WRITABLE, evt::PollOpt::edge());
+        }
+
+        Ok(())
+    }
+}
+
+struct EchoHandler {
+    server: EchoServer,
+    client: EchoClient,
+    count: u32
+}
+
+impl EchoHandler {
+    fn new(srv: TcpAcceptor, client: TcpSocket) -> EchoHandler {
+        EchoHandler {
+            server: EchoServer {
+                sock: srv,
+                conns: Slab::new_starting_at(Token(2), 128),
+            },
+            client: EchoClient::new(client, CLIENT),
+            count: 0
+        }
+    }
+}
+
+impl Handler<usize, String> for EchoHandler {
+    fn readable(&mut self, event_loop: &mut TestEventLoop, token: Token, hint: evt::ReadHint) {
+        assert_eq!(hint, evt::DATAHINT);
+
+        match token {
+            SERVER => self.server.accept(event_loop).unwrap(),
+            CLIENT => self.client.readable(event_loop).unwrap(),
+            i => self.server.conn_readable(event_loop, i).unwrap()
+        };
+    }
+
+    fn writable(&mut self, event_loop: &mut TestEventLoop, token: Token) {
+        match token {
+            SERVER => panic!("received writable for token 0"),
+            CLIENT => self.client.writable(event_loop).unwrap(),
+            _ => self.server.conn_writable(event_loop, token).unwrap()
+        };
+    }
+
+    fn notify(&mut self, event_loop: &mut TestEventLoop, msg: String) {
+        match self.client.sock.write_slice(msg.as_bytes()) {
+            Ok(NonBlock::Ready(n)) => {
+                self.client.count += 1;
+                if self.client.count % 10000 == 0 {
+                    println!("Sent {} bytes:   count {}", n, self.client.count);
+                }
+            },
+
+            _ => {
+                self.client.backlog.push_back(msg);
+                event_loop.reregister(&self.client.sock, self.client.token, evt::WRITABLE, evt::PollOpt::edge());
+            }
+        }
+    }
+}
+
+#[test]
+pub fn test_echo_server() {
+    debug!("Starting TEST_ECHO_SERVER");
+    let config =
+        EventLoopConfig {
+            io_poll_timeout_ms: 1_000,
+            notify_capacity: 1_048_576,
+            messages_per_tick: 64,
+            timer_tick_ms: 100,
+            timer_wheel_size: 1_024,
+            timer_capacity: 65_536,
+        };
+    let mut event_loop = EventLoop::configured(config).unwrap();
+
+    let addr = SockAddr::parse(localhost().as_slice())
+        .expect("could not parse InetAddr");
+
+    let srv = TcpSocket::v4().unwrap();
+
+    info!("setting re-use addr");
+    srv.set_reuseaddr(true).unwrap();
+
+    let srv = srv.bind(&addr).unwrap()
+        .listen(256).unwrap();
+
+    info!("listen for connections");
+    event_loop.register_opt(&srv, SERVER, evt::READABLE, evt::PollOpt::edge()).unwrap();
+
+    let sock = TcpSocket::v4().unwrap();
+
+    // Connect to the server
+    event_loop.register_opt(&sock, CLIENT, evt::WRITABLE, evt::PollOpt::edge()).unwrap();
+    sock.connect(&addr).unwrap();
+    let chan = event_loop.channel();
+
+    let go = move|:| {
+        let mut i = 1_000_000;
+
+        let mut timer = Timer::new().unwrap();
+        timer.sleep(Duration::seconds(1));
+
+        let message = String::from_str("THIS IS A TEST MESSAGE");
+        while i > 0 {
+            chan.send(message.clone());
+            i -= 1;
+            if i % 10000 == 0 {
+                println!("Enqueued {} messages", 1_000_000 - i);
+            }
+        }
+    };
+
+    let guard = Thread::spawn(go);
+
+
+    // Start the event loop
+    event_loop.run(EchoHandler::new(srv, sock))
+        .ok().expect("failed to execute event loop");
+
+}


### PR DESCRIPTION
I ran into some issues when I tried to push more than 10,000 msgs/sec out of an eventloop.   This scheme simplifies notification, removes the queue count and moves to a simpler boolean hint as to whether or not it needs to kick the awakener.  I have tested this approach with well over 30,000 messages per second with positive results. (26 microsecond round trip times in aggregate for messages) 