### PR TITLE
Make ByteBuf Sync and Send

### DIFF
--- a/src/buf/byte.rs
+++ b/src/buf/byte.rs
@@ -112,6 +112,9 @@ impl Writer for ByteBuf {
     }
 }
 
+unsafe impl Send for ByteBuf { }
+unsafe impl Sync for ByteBuf { }
+
 #[cfg(test)]
 mod test {
     use buf::*;


### PR DESCRIPTION
Implement Sync and Send for ByteBuf. I believe this is safe, since `ByteBuf` is basically just a fancy `Vec<u8>` and has no internal mutability or similar problems.