### PR TITLE
Get mio to build with rust nightly

### DIFF
--- a/src/buf/byte.rs
+++ b/src/buf/byte.rs
@@ -1,6 +1,6 @@
 use std::{cmp, mem, ptr};
 use std::num::UnsignedInt;
-use std::io::IoResult;
+use std::old_io::IoResult;
 use std::raw;
 use alloc::heap;
 use super::{Buf, MutBuf};
@@ -107,7 +107,7 @@ impl Reader for ByteBuf {
 }
 
 impl Writer for ByteBuf {
-    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+    fn write_all(&mut self, buf: &[u8]) -> IoResult<()> {
         super::write(self, buf)
     }
 }

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -1,7 +1,7 @@
 //! Various strategies for non-blocking sequential byte access
 //!
 use std::slice::bytes;
-use std::{cmp, io};
+use std::{cmp, old_io};
 
 pub use self::byte::ByteBuf;
 pub use self::ring::{RingBuf, RingBufReader, RingBufWriter};
@@ -57,7 +57,7 @@ pub fn wrap_mut<'a>(bytes: &'a mut [u8]) -> MutSliceBuf<'a> {
 //
 // Instead, we provide these two fns we call in all the concrete implementations
 
-fn read<B: Buf>(buf: &mut B, dst: &mut [u8]) -> io::IoResult<usize> {
+fn read<B: Buf>(buf: &mut B, dst: &mut [u8]) -> old_io::IoResult<usize> {
     let nread = cmp::min(buf.remaining(), dst.len());
 
     if nread == 0 {
@@ -65,7 +65,7 @@ fn read<B: Buf>(buf: &mut B, dst: &mut [u8]) -> io::IoResult<usize> {
             return Ok(0);
         }
 
-        return Err(io::standard_error(io::EndOfFile));
+        return Err(old_io::standard_error(old_io::EndOfFile));
     }
 
     let mut curr = 0us;
@@ -89,11 +89,11 @@ fn read<B: Buf>(buf: &mut B, dst: &mut [u8]) -> io::IoResult<usize> {
     Ok(nread)
 }
 
-fn write<B: MutBuf>(buf: &mut B, src: &[u8]) -> io::IoResult<()> {
+fn write<B: MutBuf>(buf: &mut B, src: &[u8]) -> old_io::IoResult<()> {
     debug!("buf::write; buf={}; src={}", buf.remaining(), src.len());
 
     if src.len() > buf.remaining() {
-        return Err(io::standard_error(io::EndOfFile));
+        return Err(old_io::standard_error(old_io::EndOfFile));
     }
 
     let mut curr = 0us;

--- a/src/buf/ring.rs
+++ b/src/buf/ring.rs
@@ -1,6 +1,6 @@
 use std::{cmp, fmt, mem, ptr};
 use std::num::UnsignedInt;
-use std::io::IoResult;
+use std::old_io::IoResult;
 use std::raw::Slice as RawSlice;
 use alloc::heap;
 use super::{Buf, MutBuf};
@@ -222,14 +222,14 @@ impl<'a> MutBuf for RingBufWriter<'a> {
 }
 
 impl<'a> Writer for RingBufWriter<'a> {
-    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+    fn write_all(&mut self, buf: &[u8]) -> IoResult<()> {
         super::write(self, buf)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::io::EndOfFile;
+    use std::old_io::EndOfFile;
     use buf::{Buf, RingBuf};
 
     #[test]

--- a/src/buf/slice.rs
+++ b/src/buf/slice.rs
@@ -1,5 +1,5 @@
 use std::cmp;
-use std::io::IoResult;
+use std::old_io::IoResult;
 use super::{Buf, MutBuf};
 
 pub struct SliceBuf<'a> {
@@ -76,7 +76,7 @@ impl<'a> Reader for MutSliceBuf<'a> {
 }
 
 impl<'a> Writer for MutSliceBuf<'a> {
-    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+    fn write_all(&mut self, buf: &[u8]) -> IoResult<()> {
         super::write(self, buf)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::old_io;
 use nix::errno::{SysError, EAGAIN, EADDRINUSE};
 
 use self::MioErrorKind::{
@@ -93,18 +93,18 @@ impl MioError {
         }
     }
 
-    pub fn as_io_error(&self) -> io::IoError {
-        use std::io::OtherIoError;
+    pub fn as_io_error(&self) -> old_io::IoError {
+        use std::old_io::OtherIoError;
 
         match self.kind {
-            Eof | BufUnderflow | BufOverflow => io::standard_error(io::EndOfFile),
-            WouldBlock => io::standard_error(io::ResourceUnavailable),
-            AddrInUse => io::standard_error(io::PathAlreadyExists),
+            Eof | BufUnderflow | BufOverflow => old_io::standard_error(old_io::EndOfFile),
+            WouldBlock => old_io::standard_error(old_io::ResourceUnavailable),
+            AddrInUse => old_io::standard_error(old_io::PathAlreadyExists),
             OtherError => match self.sys {
-                Some(err) => io::IoError::from_errno(err.kind as usize, false),
-                None => io::standard_error(io::OtherIoError)
+                Some(err) => old_io::IoError::from_errno(err.kind as usize, false),
+                None => old_io::standard_error(old_io::OtherIoError)
             },
-            EventLoopTerminated => io::standard_error(OtherIoError)
+            EventLoopTerminated => old_io::standard_error(OtherIoError)
         }
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -2,15 +2,15 @@
 //!
 use std::fmt;
 use std::str::FromStr;
-use std::io::net::ip::SocketAddr as StdSocketAddr;
+use std::old_io::net::ip::SocketAddr as StdSocketAddr;
 use io::{IoHandle, NonBlock};
 use error::MioResult;
 use buf::{Buf, MutBuf};
 use os;
 
-pub use std::io::net::ip::{IpAddr, Port};
-pub use std::io::net::ip::Ipv4Addr as IPv4Addr;
-pub use std::io::net::ip::Ipv6Addr as IPv6Addr;
+pub use std::old_io::net::ip::{IpAddr, Port};
+pub use std::old_io::net::ip::Ipv4Addr as IPv4Addr;
+pub use std::old_io::net::ip::Ipv6Addr as IPv6Addr;
 
 use self::SockAddr::{InetAddr,UnixAddr};
 use self::AddressFamily::{Unix,Inet,Inet6};

--- a/src/os/posix.rs
+++ b/src/os/posix.rs
@@ -5,7 +5,7 @@ use net::{AddressFamily, SockAddr, IPv4Addr, SocketType};
 use net::SocketType::{Dgram, Stream};
 use net::SockAddr::{InetAddr, UnixAddr};
 use net::AddressFamily::{Inet, Inet6, Unix};
-pub use std::io::net::ip::IpAddr;
+pub use std::old_io::net::ip::IpAddr;
 
 mod nix {
     pub use nix::c_int;

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -6,7 +6,7 @@ use super::localhost;
 use mio::event as evt;
 use std::collections::DList;
 use std::thread::Thread;
-use std::io::timer::Timer;
+use std::old_io::timer::Timer;
 use std::time::duration::Duration;
 
 type TestEventLoop = EventLoop<usize, String>;

--- a/test/test_notify.rs
+++ b/test/test_notify.rs
@@ -1,4 +1,4 @@
-use std::io::timer::sleep;
+use std::old_io::timer::sleep;
 use std::thread::Thread;
 use std::time::Duration;
 use mio::*;

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -4,7 +4,7 @@ use mio::net::udp::*;
 use mio::buf::{RingBuf, SliceBuf};
 use std::str;
 use super::localhost;
-use std::io::net::ip::{Ipv4Addr};
+use std::old_io::net::ip::{Ipv4Addr};
 use mio::event as evt;
 
 type TestEventLoop = EventLoop<usize, ()>;

--- a/test/test_udp_socket_connectionless.rs
+++ b/test/test_udp_socket_connectionless.rs
@@ -3,7 +3,7 @@ use mio::net::*;
 use mio::net::udp::*;
 use mio::buf::{RingBuf, SliceBuf};
 use std::str;
-use std::io::net::ip::{Ipv4Addr};
+use std::old_io::net::ip::{Ipv4Addr};
 use mio::event as evt;
 
 type TestEventLoop = EventLoop<usize, ()>;

--- a/test/test_unix_echo_server.rs
+++ b/test/test_unix_echo_server.rs
@@ -3,7 +3,7 @@ use mio::net::*;
 use mio::net::pipe::*;
 use mio::buf::{ByteBuf, SliceBuf};
 use mio::util::Slab;
-use std::io::TempDir;
+use std::old_io::TempDir;
 use mio::event as evt;
 
 type TestEventLoop = EventLoop<usize, ()>;


### PR DESCRIPTION
The `io` module is now called `old_io`, the `Writer`'s `write` method has been renamed to `write_all`.