### PR TITLE
Fix rustc warnings

### DIFF
--- a/src/buf/byte.rs
+++ b/src/buf/byte.rs
@@ -83,7 +83,7 @@ impl Buf for ByteBuf {
     }
 
     fn bytes<'a>(&'a self) -> &'a [u8] {
-        self.as_slice().slice(self.pos, self.lim)
+        &self.as_slice()[self.pos..self.lim]
     }
 
     fn advance(&mut self, mut cnt: usize) {
@@ -96,7 +96,7 @@ impl MutBuf for ByteBuf {
     fn mut_bytes<'a>(&'a mut self) -> &'a mut [u8] {
         let pos = self.pos;
         let lim = self.lim;
-        self.as_mut_slice().slice_mut(pos, lim)
+        &mut self.as_mut_slice()[pos..lim]
     }
 }
 

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -76,7 +76,7 @@ fn read<B: Buf>(buf: &mut B, dst: &mut [u8]) -> old_io::IoResult<usize> {
             let cnt = cmp::min(src.len(), dst.len() - curr);
 
             // copy the bytes
-            bytes::copy_memory(dst.slice_from_mut(curr), src.slice_to(cnt));
+            bytes::copy_memory(&mut dst[curr..], &src[..cnt]);
 
             // advance cursors
             cnt
@@ -103,7 +103,7 @@ fn write<B: MutBuf>(buf: &mut B, src: &[u8]) -> old_io::IoResult<()> {
             let dst = buf.mut_bytes();
             let cnt = cmp::min(dst.len(), src.len() - curr);
 
-            bytes::copy_memory(dst, src.slice(curr, cnt));
+            bytes::copy_memory(dst, &src[curr..cnt]);
             cnt
         };
 

--- a/src/buf/ring.rs
+++ b/src/buf/ring.rs
@@ -137,7 +137,7 @@ impl Clone for RingBuf {
     // re-uses the buffer
 }
 
-impl fmt::Show for RingBuf {
+impl fmt::Debug for RingBuf {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "RingBuf[.. {}]", self.len)
     }
@@ -170,7 +170,7 @@ impl<'a> Buf for RingBufReader<'a> {
             to = self.ring.cap
         }
 
-        self.ring.as_slice().slice(self.ring.pos, to)
+        &self.ring.as_slice()[self.ring.pos..to]
     }
 
     fn advance(&mut self, cnt: usize) {
@@ -207,7 +207,7 @@ impl<'a> Buf for RingBufWriter<'a> {
             to = self.ring.cap;
         }
 
-        self.ring.as_slice().slice(from, to)
+        &self.ring.as_slice()[from..to]
     }
 
     fn advance(&mut self, cnt: usize) {

--- a/src/buf/slice.rs
+++ b/src/buf/slice.rs
@@ -19,7 +19,7 @@ impl<'a> Buf for SliceBuf<'a> {
     }
 
     fn bytes<'b>(&'b self) -> &'b [u8] {
-        self.bytes.slice_from(self.pos)
+        &self.bytes[self.pos..]
     }
 
     fn advance(&mut self, mut cnt: usize) {
@@ -54,7 +54,7 @@ impl<'a> Buf for MutSliceBuf<'a> {
     }
 
     fn bytes<'b>(&'b self) -> &'b [u8] {
-        self.bytes.slice_from(self.pos)
+        &self.bytes[self.pos..]
     }
 
     fn advance(&mut self, mut cnt: usize) {
@@ -65,7 +65,7 @@ impl<'a> Buf for MutSliceBuf<'a> {
 
 impl<'a> MutBuf for MutSliceBuf<'a> {
     fn mut_bytes<'b>(&'b mut self) -> &'b mut [u8] {
-        self.bytes.slice_from_mut(self.pos)
+        &mut self.bytes[self.pos..]
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,13 +13,13 @@ use self::MioErrorKind::{
 
 pub type MioResult<T> = Result<T, MioError>;
 
-#[derive(Copy, Show, PartialEq, Clone)]
+#[derive(Copy, Debug, PartialEq, Clone)]
 pub struct MioError {
     pub kind: MioErrorKind,
     sys: Option<SysError>
 }
 
-#[derive(Copy, Show, PartialEq, Clone)]
+#[derive(Copy, Debug, PartialEq, Clone)]
 pub enum MioErrorKind {
     Eof,                    // End of file or socket closed
     WouldBlock,             // The operation would have blocked

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -11,7 +11,7 @@ use timer::{Timer, Timeout, TimerResult};
 use os::token::Token;
 
 /// Configure EventLoop runtime details
-#[derive(Copy, Clone, Show)]
+#[derive(Copy, Clone, Debug)]
 pub struct EventLoopConfig {
     pub io_poll_timeout_ms: usize,
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -7,7 +7,7 @@ use os;
 pub use os::IoDesc;
 
 /// The result of a non-blocking operation.
-#[derive(Show)]
+#[derive(Debug)]
 pub enum NonBlock<T> {
     Ready(T),
     WouldBlock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,9 +83,8 @@
 // mio is still in rapid development
 #![unstable]
 
-#![feature(unsafe_destructor)]
+#![feature(unsafe_destructor, alloc, core, io, libc, path, hash, std_misc)]
 
-#![allow(unstable)]
 #![allow(dead_code)]
 
 extern crate alloc;

--- a/src/net.rs
+++ b/src/net.rs
@@ -120,7 +120,7 @@ impl FromStr for SockAddr {
     }
 }
 
-impl fmt::Show for SockAddr {
+impl fmt::Debug for SockAddr {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             InetAddr(ip, port) => write!(fmt, "{}:{}", ip, port),
@@ -148,7 +148,7 @@ pub mod tcp {
     use net::SocketType::Stream;
     use net::AddressFamily::{self, Inet, Inet6};
 
-    #[derive(Show)]
+    #[derive(Debug)]
     pub struct TcpSocket {
         desc: os::IoDesc
     }
@@ -230,7 +230,7 @@ pub mod tcp {
     impl Socket for TcpSocket {
     }
 
-    #[derive(Show)]
+    #[derive(Debug)]
     pub struct TcpListener {
         desc: os::IoDesc,
     }
@@ -248,7 +248,7 @@ pub mod tcp {
         }
     }
 
-    #[derive(Show)]
+    #[derive(Debug)]
     pub struct TcpAcceptor {
         desc: os::IoDesc,
     }
@@ -300,7 +300,7 @@ pub mod udp {
     use net::AddressFamily::Inet;
     use super::UnconnectedSocket;
 
-    #[derive(Show)]
+    #[derive(Debug)]
     pub struct UdpSocket {
         desc: os::IoDesc
     }
@@ -410,7 +410,7 @@ pub mod pipe {
     use net::SocketType::Stream;
     use net::AddressFamily::Unix;
 
-    #[derive(Show)]
+    #[derive(Debug)]
     pub struct UnixSocket {
         desc: os::IoDesc
     }
@@ -473,7 +473,7 @@ pub mod pipe {
     impl Socket for UnixSocket {
     }
 
-    #[derive(Show)]
+    #[derive(Debug)]
     pub struct UnixListener {
         desc: os::IoDesc,
     }
@@ -491,7 +491,7 @@ pub mod pipe {
         }
     }
 
-    #[derive(Show)]
+    #[derive(Debug)]
     pub struct UnixAcceptor {
         desc: os::IoDesc,
     }

--- a/src/os/event.rs
+++ b/src/os/event.rs
@@ -92,7 +92,7 @@ impl Not for PollOpt {
     }
 }
 
-impl fmt::Show for PollOpt {
+impl fmt::Debug for PollOpt {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut one = false;
         let flags = [
@@ -152,7 +152,7 @@ impl Interest {
 }
 
 
-impl fmt::Show for Interest {
+impl fmt::Debug for Interest {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut one = false;
         let flags = [
@@ -183,7 +183,7 @@ bitflags!(
     }
 );
 
-impl fmt::Show for ReadHint {
+impl fmt::Debug for ReadHint {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut one = false;
         let flags = [
@@ -205,7 +205,7 @@ impl fmt::Show for ReadHint {
 }
 
 
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 pub struct IoEvent {
     kind: Interest,
     token: Token

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -158,7 +158,7 @@ impl Events {
     }
 
     fn as_slice(&self) -> &[KEvent] {
-        self.events.slice_to(self.len)
+        &self.events[..self.len]
     }
 
     fn as_mut_slice(&mut self) -> &mut [KEvent] {

--- a/src/os/posix.rs
+++ b/src/os/posix.rs
@@ -60,7 +60,7 @@ impl PipeAwakener {
 
 /// Represents the OS's handle to the IO instance. In this case, it is the file
 /// descriptor.
-#[derive(Show)]
+#[derive(Debug)]
 pub struct IoDesc {
     pub fd: nix::Fd
 }

--- a/src/os/token.rs
+++ b/src/os/token.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Show, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Token(pub usize);
 
 impl Token {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -284,7 +284,7 @@ struct EntryLinks {
 
 pub type TimerResult<T> = Result<T, TimerError>;
 
-#[derive(Show)]
+#[derive(Debug)]
 pub struct TimerError {
     kind: TimerErrorKind,
     desc: &'static str,
@@ -299,7 +299,7 @@ impl TimerError {
     }
 }
 
-#[derive(Show)]
+#[derive(Debug)]
 pub enum TimerErrorKind {
     TimerOverflow,
 }


### PR DESCRIPTION
This is pretty trivial:
  - replace `fmt::Show` by `fmt::Debug`
  - use slicing syntax instead of `slice` and relatives
  - explicitly allow specific features instead of `#[allow(unstable)]`