### PR TITLE
Fix errors and warnings with current rustc nightly

### DIFF
--- a/src/buf/byte.rs
+++ b/src/buf/byte.rs
@@ -138,7 +138,7 @@ mod test {
     pub fn test_writing_bytes() {
         let mut buf = ByteBuf::new(8);
 
-        buf.write(b"hello").unwrap();
+        buf.write_all(b"hello").unwrap();
         assert!(buf.remaining() == 3);
 
         buf.flip();

--- a/src/buf/ring.rs
+++ b/src/buf/ring.rs
@@ -246,7 +246,7 @@ mod test {
     pub fn test_using_ring_buffer() {
         let mut buf = RingBuf::new(128);
 
-        buf.writer().write(b"hello").unwrap();
+        buf.writer().write_all(b"hello").unwrap();
         assert!(buf.writer().remaining() == 123);
 
         let read = buf.reader().read_exact(5).unwrap();
@@ -257,7 +257,7 @@ mod test {
     pub fn test_restarting_ring_buffer() {
         let mut buf = RingBuf::new(8);
 
-        buf.writer().write(b"hello").unwrap();
+        buf.writer().write_all(b"hello").unwrap();
         assert!(buf.writer().remaining() == 3);
 
         let read = buf.reader().read_exact(5).unwrap();
@@ -269,7 +269,7 @@ mod test {
     pub fn test_overflowing_ring_buffer() {
         let mut buf = RingBuf::new(8);
 
-        buf.writer().write(b"hello").unwrap();
+        buf.writer().write_all(b"hello").unwrap();
         assert!(buf.writer().write(b"world").unwrap_err().kind == EndOfFile);
     }
 }

--- a/src/util/slab.rs
+++ b/src/util/slab.rs
@@ -235,8 +235,6 @@ impl<T> Index<Token> for Slab<T> {
 }
 
 impl<T> IndexMut<Token> for Slab<T> {
-    type Output = T;
-
     fn index_mut<'a>(&'a mut self, idx: &Token) -> &'a mut T {
         let idx = self.token_to_idx(*idx);
         let idx = self.validate_idx(idx);

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,4 +1,4 @@
-#![allow(unstable)]
+#![feature(path, io, std_misc, core, collections)]
 
 extern crate mio;
 

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -243,7 +243,7 @@ pub fn test_echo_server() {
     sock.connect(&addr).unwrap();
     let chan = event_loop.channel();
 
-    let go = move|:| {
+    let go = move || {
         let mut i = 1_000_000;
 
         let mut timer = Timer::new().unwrap();

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -10,7 +10,7 @@ use self::TestState::{Initial, AfterRead, AfterHup};
 type TestEventLoop = EventLoop<usize, ()>;
 
 
-#[derive(Show, PartialEq)]
+#[derive(Debug, PartialEq)]
 enum TestState {
     Initial,
     AfterRead,

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -12,7 +12,7 @@ type TestEventLoop = EventLoop<TcpSocket, ()>;
 const SERVER: Token = Token(0);
 const CLIENT: Token = Token(1);
 
-#[derive(Show, PartialEq)]
+#[derive(Debug, PartialEq)]
 enum TestState {
     Initial,
     AfterRead,


### PR DESCRIPTION
Fix in non-test code:
- remove associated type from `IndexMut` impl

Fixes in tests:
- fix obsolete closure syntax
- use `write_all` instead of `write`, which is deprecated
- `Show` -> `Debug`
- allow individual features instead of `#![allow(unstable)]`, which has been removed