### PR TITLE
DList now called LinkedList

### DIFF
--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -3,7 +3,7 @@ use mio::net::*;
 use mio::net::tcp::*;
 use mio::util::Slab;
 use super::localhost;
-use std::collections::DList;
+use std::collections::LinkedList;
 use std::thread::Thread;
 use std::old_io::timer::Timer;
 use std::time::duration::Duration;
@@ -102,7 +102,7 @@ impl EchoServer {
 
 struct EchoClient {
     sock: TcpSocket,
-    backlog: DList<String>,
+    backlog: LinkedList<String>,
     token: Token,
     count: u32
 }
@@ -114,7 +114,7 @@ impl EchoClient {
 
         EchoClient {
             sock: sock,
-            backlog: DList::new(),
+            backlog: LinkedList::new(),
             token: tok,
             count: 0
         }


### PR DESCRIPTION
As of [RFC 580](https://github.com/rust-lang/rust/pull/22483), `DList` is now called `LinkedList`