### PR TITLE
Handler callback for when EINTR occurs from polling

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -13,4 +13,7 @@ pub trait Handler<T, M: Send> {
 
     fn timeout(&mut self, event_loop: &mut EventLoop<T, M>, timeout: T) {
     }
+
+    fn interrupted(&mut self, event_loop: &mut EventLoop<T, M>) {
+    }
 }


### PR DESCRIPTION
Currently, an EINTR occurrence when polling will cause the event loop to exit. This fix handles EINTR in a more elegant way- calling a handler callback and continuing the event loop.