### PR TITLE
Allow error events to be handled in Handlers

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -310,7 +310,7 @@ impl<H: Handler> EventLoop<H> {
         }
 
         if evt.is_error() {
-            println!(" + ERROR");
+            handler.error(self, tok);
         }
     }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -310,7 +310,7 @@ impl<H: Handler> EventLoop<H> {
         }
 
         if evt.is_error() {
-            handler.error(self, tok);
+            handler.error(self, tok, evt.read_hint());
         }
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -11,7 +11,7 @@ pub trait Handler {
     fn writable(&mut self, event_loop: &mut EventLoop<Self>, token: Token) {
     }
 
-    fn error(&mut self, event_loop: &mut EventLoop<Self>, token: Token) {
+    fn error(&mut self, event_loop: &mut EventLoop<Self>, token: Token, hint: ReadHint) {
     }
 
     fn notify(&mut self, event_loop: &mut EventLoop<Self>, msg: Self::Message) {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -11,6 +11,9 @@ pub trait Handler {
     fn writable(&mut self, event_loop: &mut EventLoop<Self>, token: Token) {
     }
 
+    fn error(&mut self, event_loop: &mut EventLoop<Self>, token: Token) {
+    }
+
     fn notify(&mut self, event_loop: &mut EventLoop<Self>, msg: Self::Message) {
     }
 


### PR DESCRIPTION
Currently error events just spit out the error message.  This allows the handler to react to error events outside of readable and writable.