### PR TITLE
Error events are sent to readable in handler along with error in the readhint

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -310,7 +310,7 @@ impl<H: Handler> EventLoop<H> {
         }
 
         if evt.is_error() {
-            println!(" + ERROR");
+            handler.readable(self, tok, evt.read_hint());
         }
     }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -301,16 +301,12 @@ impl<H: Handler> EventLoop<H> {
     fn io_event(&mut self, handler: &mut H, evt: IoEvent) {
         let tok = evt.token();
 
-        if evt.is_readable() {
+        if evt.is_readable() | evt.is_error() {
             handler.readable(self, tok, evt.read_hint());
         }
 
         if evt.is_writable() {
             handler.writable(self, tok);
-        }
-
-        if evt.is_error() {
-            handler.readable(self, tok, evt.read_hint());
         }
     }
 


### PR DESCRIPTION
Updated to send error event plus readhint to the readable method in handlers.  This should allow for the handlers to properly respond to error events.