### PR TITLE
Fix error type for latest rust nightly

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -185,9 +185,9 @@ pub fn from_nix_error(err: ::nix::NixError) -> Error {
 }
 
 pub fn to_non_block<T>(err: Error) -> Result<Option<T>> {
-    use std::io::ErrorKind::ResourceUnavailable;
+    use std::io::ErrorKind::WouldBlock;
 
-    if let ResourceUnavailable = err.kind() {
+    if let WouldBlock = err.kind() {
         return Ok(None);
     }
 


### PR DESCRIPTION
I'm guessing that this is the intended error type now. Apologies if I guessed wrong :-)