### PR TITLE
rustup

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -419,7 +419,7 @@ impl fmt::Debug for ReadHint {
 }
 
 
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct IoEvent {
     kind: Interest,
     token: Token

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,5 +1,5 @@
 use buf::{Buf, MutBuf};
-use std::os::unix::io::{Fd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd};
 
 // Re-export the io::Result / Error types for convenience
 pub use std::io::{Read, Write, Result, Error};
@@ -10,7 +10,7 @@ pub trait Evented : AsRawFd {
 
 /// Create a value with a FD
 pub trait FromFd {
-    fn from_fd(fd: Fd) -> Self;
+    fn from_fd(fd: RawFd) -> Self;
 }
 
 pub trait TryRead {
@@ -54,17 +54,17 @@ pub trait TryWrite {
 
 #[derive(Debug)]
 pub struct Io {
-    fd: Fd,
+    fd: RawFd,
 }
 
 impl Io {
-    pub fn new(fd: Fd) -> Io {
+    pub fn new(fd: RawFd) -> Io {
         Io { fd: fd }
     }
 }
 
 impl AsRawFd for Io {
-    fn as_raw_fd(&self) -> Fd {
+    fn as_raw_fd(&self) -> RawFd {
         self.fd
     }
 }
@@ -125,13 +125,13 @@ pub struct PipeReader {
 }
 
 impl FromFd for PipeReader {
-    fn from_fd(fd: Fd) -> PipeReader {
+    fn from_fd(fd: RawFd) -> PipeReader {
         PipeReader { io: Io::new(fd) }
     }
 }
 
 impl AsRawFd for PipeReader {
-    fn as_raw_fd(&self) -> Fd {
+    fn as_raw_fd(&self) -> RawFd {
         self.io.as_raw_fd()
     }
 }
@@ -149,13 +149,13 @@ pub struct PipeWriter {
 }
 
 impl FromFd for PipeWriter {
-    fn from_fd(fd: Fd) -> PipeWriter {
+    fn from_fd(fd: RawFd) -> PipeWriter {
         PipeWriter { io: Io::new(fd) }
     }
 }
 
 impl AsRawFd for PipeWriter {
-    fn as_raw_fd(&self) -> Fd {
+    fn as_raw_fd(&self) -> RawFd {
         self.io.fd
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 // mio is still in rapid development
 #![unstable]
 
-#![feature(alloc, convert, io, io_ext, unsafe_destructor)]
+#![feature(alloc, io, unsafe_destructor)]
 
 extern crate alloc;
 extern crate bytes;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -3,7 +3,7 @@
 use {NonBlock};
 use io::{self, Io};
 use std::net::SocketAddr;
-use std::os::unix::io::{Fd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd};
 
 pub mod tcp;
 pub mod udp;
@@ -126,7 +126,7 @@ mod nix {
     };
 }
 
-fn socket(family: nix::AddressFamily, ty: nix::SockType, nonblock: bool) -> io::Result<Fd> {
+fn socket(family: nix::AddressFamily, ty: nix::SockType, nonblock: bool) -> io::Result<RawFd> {
     let opts = if nonblock {
         nix::SOCK_NONBLOCK | nix::SOCK_CLOEXEC
     } else {
@@ -159,7 +159,7 @@ fn listen(io: &Io, backlog: usize) -> io::Result<()> {
         .map_err(io::from_nix_error)
 }
 
-fn accept(io: &Io, nonblock: bool) -> io::Result<Fd> {
+fn accept(io: &Io, nonblock: bool) -> io::Result<RawFd> {
     let opts = if nonblock {
         nix::SOCK_NONBLOCK | nix::SOCK_CLOEXEC
     } else {

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -3,7 +3,7 @@ use io::{self, Evented, FromFd, Io};
 use net::{self, nix, Socket};
 use std::mem;
 use std::net::SocketAddr;
-use std::os::unix::io::{Fd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd};
 
 pub use std::net::{TcpStream, TcpListener};
 
@@ -100,13 +100,13 @@ impl Evented for TcpSocket {
 }
 
 impl AsRawFd for TcpSocket {
-    fn as_raw_fd(&self) -> Fd {
+    fn as_raw_fd(&self) -> RawFd {
         self.io.as_raw_fd()
     }
 }
 
 impl FromFd for TcpSocket {
-    fn from_fd(fd: Fd) -> TcpSocket {
+    fn from_fd(fd: RawFd) -> TcpSocket {
         TcpSocket { io: Io::new(fd) }
     }
 }
@@ -121,7 +121,7 @@ impl Socket for TcpSocket {
  */
 
 impl FromFd for TcpStream {
-    fn from_fd(fd: Fd) -> TcpStream {
+    fn from_fd(fd: RawFd) -> TcpStream {
         to_tcp_stream(Io::new(fd))
     }
 }
@@ -139,7 +139,7 @@ impl Socket for TcpStream {
  */
 
 impl FromFd for TcpListener {
-    fn from_fd(fd: Fd) -> TcpListener {
+    fn from_fd(fd: RawFd) -> TcpListener {
         to_tcp_listener(Io::new(fd))
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -4,7 +4,7 @@ use io::{self, Evented, FromFd, Result};
 use net::{self, nix, Socket};
 use std::mem;
 use std::net::SocketAddr;
-use std::os::unix::io::Fd;
+use std::os::unix::io::RawFd;
 
 pub use std::net::UdpSocket;
 
@@ -35,7 +35,7 @@ impl Evented for UdpSocket {
 }
 
 impl FromFd for UdpSocket {
-    fn from_fd(fd: Fd) -> UdpSocket {
+    fn from_fd(fd: RawFd) -> UdpSocket {
         unsafe { mem::transmute(Io::new(fd)) }
     }
 }

--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -5,7 +5,7 @@ use net::{self, nix, Socket};
 use std::usize;
 use std::iter::IntoIterator;
 use std::path::Path;
-use std::os::unix::io::{Fd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd};
 
 pub fn stream() -> io::Result<NonBlock<UnixSocket>> {
     UnixSocket::stream(true)
@@ -58,7 +58,7 @@ impl UnixSocket {
 }
 
 impl AsRawFd for UnixSocket {
-    fn as_raw_fd(&self) -> Fd {
+    fn as_raw_fd(&self) -> RawFd {
         self.io.as_raw_fd()
     }
 }
@@ -67,7 +67,7 @@ impl Evented for UnixSocket {
 }
 
 impl FromFd for UnixSocket {
-    fn from_fd(fd: Fd) -> UnixSocket {
+    fn from_fd(fd: RawFd) -> UnixSocket {
         UnixSocket { io: Io::new(fd) }
     }
 }
@@ -125,7 +125,7 @@ impl UnixListener {
 }
 
 impl AsRawFd for UnixListener {
-    fn as_raw_fd(&self) -> Fd {
+    fn as_raw_fd(&self) -> RawFd {
         self.io.as_raw_fd()
     }
 }
@@ -144,7 +144,7 @@ impl IntoNonBlock for UnixListener {
 }
 
 impl FromFd for UnixListener {
-    fn from_fd(fd: Fd) -> UnixListener {
+    fn from_fd(fd: RawFd) -> UnixListener {
         UnixListener { io: Io::new(fd) }
     }
 }
@@ -230,7 +230,7 @@ impl io::Write for UnixStream {
 }
 
 impl AsRawFd for UnixStream {
-    fn as_raw_fd(&self) -> Fd {
+    fn as_raw_fd(&self) -> RawFd {
         self.io.as_raw_fd()
     }
 }
@@ -239,7 +239,7 @@ impl Evented for UnixStream {
 }
 
 impl FromFd for UnixStream {
-    fn from_fd(fd: Fd) -> UnixStream {
+    fn from_fd(fd: RawFd) -> UnixStream {
         UnixStream { io: Io::new(fd) }
     }
 }

--- a/src/nonblock.rs
+++ b/src/nonblock.rs
@@ -1,7 +1,7 @@
 use io::{self, Evented, FromFd, TryRead, TryWrite, Result};
 use std::io::{Read, Write};
 use std::ops::{Deref, DerefMut};
-use std::os::unix::io::{Fd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd};
 
 #[derive(Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct NonBlock<T> {
@@ -49,13 +49,13 @@ impl<T: Write> TryWrite for NonBlock<T> {
 }
 
 impl<T: AsRawFd> AsRawFd for NonBlock<T> {
-    fn as_raw_fd(&self) -> Fd {
+    fn as_raw_fd(&self) -> RawFd {
         (**self).as_raw_fd()
     }
 }
 
 impl<T: FromFd> FromFd for NonBlock<T> {
-    fn from_fd(fd: Fd) -> NonBlock<T> {
+    fn from_fd(fd: RawFd) -> NonBlock<T> {
         NonBlock::new(FromFd::from_fd(fd))
     }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -4,7 +4,7 @@ use std::{fmt, cmp, io};
 use std::sync::Arc;
 use std::sync::atomic::AtomicIsize;
 use std::sync::atomic::Ordering::Relaxed;
-use std::os::unix::io::{Fd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd};
 
 const SLEEP: isize = -1;
 
@@ -157,7 +157,7 @@ impl<M: Send> NotifyInner<M> {
 }
 
 impl<M: Send> AsRawFd for Notify<M> {
-    fn as_raw_fd(&self) -> Fd {
+    fn as_raw_fd(&self) -> RawFd {
         self.inner.awaken.as_raw_fd()
     }
 }

--- a/src/os/kqueue.rs
+++ b/src/os/kqueue.rs
@@ -3,10 +3,10 @@ use nix::sys::event::EventFilter::*;
 use io;
 use event::{IoEvent, Interest, PollOpt};
 use std::slice;
-use std::os::unix::io::Fd;
+use std::os::unix::io::RawFd;
 
 pub struct Selector {
-    kq: Fd,
+    kq: RawFd,
     changes: Events
 }
 
@@ -32,7 +32,7 @@ impl Selector {
         Ok(())
     }
 
-    pub fn register(&mut self, fd: Fd, token: usize, interests: Interest, opts: PollOpt) -> io::Result<()> {
+    pub fn register(&mut self, fd: RawFd, token: usize, interests: Interest, opts: PollOpt) -> io::Result<()> {
         debug!("registering; token={}; interests={:?}", token, interests);
 
         try!(self.ev_register(fd, token, EVFILT_READ, interests.contains(Interest::readable()), opts));
@@ -41,20 +41,20 @@ impl Selector {
         Ok(())
     }
 
-    pub fn reregister(&mut self, fd: Fd, token: usize, interests: Interest, opts: PollOpt) -> io::Result<()> {
+    pub fn reregister(&mut self, fd: RawFd, token: usize, interests: Interest, opts: PollOpt) -> io::Result<()> {
         // Just need to call register here since EV_ADD is a mod if already
         // registered
         self.register(fd, token, interests, opts)
     }
 
-    pub fn deregister(&mut self, fd: Fd) -> io::Result<()> {
+    pub fn deregister(&mut self, fd: RawFd) -> io::Result<()> {
         try!(self.ev_push(fd, 0, EVFILT_READ, EV_DELETE));
         try!(self.ev_push(fd, 0, EVFILT_WRITE, EV_DELETE));
 
         Ok(())
     }
 
-    fn ev_register(&mut self, fd: Fd, token: usize, filter: EventFilter, enable: bool, opts: PollOpt) -> io::Result<()> {
+    fn ev_register(&mut self, fd: RawFd, token: usize, filter: EventFilter, enable: bool, opts: PollOpt) -> io::Result<()> {
         let mut flags = EV_ADD;
 
         if enable {
@@ -74,7 +74,7 @@ impl Selector {
         self.ev_push(fd, token, filter, flags)
     }
 
-    fn ev_push(&mut self, fd: Fd, token: usize, filter: EventFilter, flags: EventFlag) -> io::Result<()> {
+    fn ev_push(&mut self, fd: RawFd, token: usize, filter: EventFilter, flags: EventFlag) -> io::Result<()> {
         try!(self.maybe_flush_changes());
 
         let idx = self.changes.len();

--- a/src/os/posix.rs
+++ b/src/os/posix.rs
@@ -1,7 +1,7 @@
 use {TryRead, TryWrite};
 use io::{self, PipeReader, PipeWriter};
 use std::mem;
-use std::os::unix::io::{Fd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd};
 
 /*
  *
@@ -24,7 +24,7 @@ impl Awakener {
         })
     }
 
-    pub fn as_raw_fd(&self) -> Fd {
+    pub fn as_raw_fd(&self) -> RawFd {
         self.reader.as_raw_fd()
     }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -35,7 +35,7 @@ pub struct Timer<T> {
     mask: u64,
 }
 
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub struct Timeout {
     // Reference into the timer entry slab
     token: Token,
@@ -275,7 +275,7 @@ impl<T> Entry<T> {
     }
 }
 
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 struct EntryLinks {
     tick: u64,
     prev: Token,

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,4 +1,4 @@
-#![feature(convert, collections, std_misc, udp)]
+#![feature(collections, negate_unsigned, udp)]
 
 extern crate mio;
 extern crate time;
@@ -50,7 +50,6 @@ mod ports {
 
 pub fn sleep_ms(ms: usize) {
     use std::thread;
-    use std::time::Duration;
     use time::precise_time_ns;
 
     let start = precise_time_ns();
@@ -63,6 +62,6 @@ pub fn sleep_ms(ms: usize) {
             return;
         }
 
-        thread::park_timeout(Duration::nanoseconds((target - now) as i64));
+        thread::park_timeout_ms(((target - now) / 1_000_000) as u32);
     }
 }


### PR DESCRIPTION
Fixups for latest rust nightly, mostly related to `Fd` being renamed to `RawFd` and `Clone` becoming a supertrait of `Copy`.