### PR TITLE
Implement IntoInterator instances for Slab

### DIFF
--- a/src/util/slab.rs
+++ b/src/util/slab.rs
@@ -1,4 +1,5 @@
 use std::{fmt, mem, usize};
+use std::iter::IntoIterator;
 use std::ops::{Index, IndexMut};
 use token::Token;
 
@@ -275,6 +276,23 @@ impl<'a, 'b, T> Iterator for SlabMutIter<'a, T> {
     }
 }
 
+impl<'a, T> IntoIterator for &'a Slab<T> {
+    type Item = &'a T;
+    type IntoIter = SlabIter<'a, T>;
+
+    fn into_iter(self) -> SlabIter<'a, T> {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut Slab<T> {
+    type Item = &'a mut T;
+    type IntoIter = SlabMutIter<'a, T>;
+
+    fn into_iter(self) -> SlabMutIter<'a, T> {
+        self.iter_mut()
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Since we have `IntoIterator` now, why not use it?
I'm not sure if these should replace the `iter` and `iter_mut` methods. What do you think? The `std::collections` types still have explicit `iter` methods as well as `IntoIterator` implementations, but that may just be because they wanted to avoid breaking too much existing code.