### PR TITLE
Rustup

### DIFF
--- a/src/util/slab.rs
+++ b/src/util/slab.rs
@@ -267,10 +267,10 @@ pub struct SlabMutIter<'a, T: 'a> {
     iter: SlabIter<'a, T>,
 }
 
-impl<'a, 'b, T> Iterator for SlabMutIter<'a, T> {
-    type Item = &'b mut T;
+impl<'a, T> Iterator for SlabMutIter<'a, T> {
+    type Item = &'a mut T;
 
-    fn next(&mut self) -> Option<&'b mut T> {
+    fn next(&mut self) -> Option<&'a mut T> {
         unsafe { mem::transmute(self.iter.next()) }
     }
 }

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -255,8 +255,9 @@ pub fn test_echo_server() {
         }
     };
 
-    let _t = thread::scoped(go);
+    let t = thread::spawn(go);
 
     // Start the event loop
     event_loop.run(&mut Echo::new(srv, sock)).unwrap();
+    t.join().unwrap();
 }

--- a/test/test_notify.rs
+++ b/test/test_notify.rs
@@ -101,7 +101,7 @@ pub fn test_notify_capacity() {
     let mut event_loop = EventLoop::configured(config).unwrap();
     let notify = event_loop.channel();
 
-    let guard = thread::scoped(move || {
+    let handle = thread::spawn(move || {
         let mut handler = Capacity(rx);
         event_loop.run(&mut handler).unwrap();
     });
@@ -122,5 +122,5 @@ pub fn test_notify_capacity() {
         }
     }
 
-    drop(guard);
+    handle.join().unwrap();
 }

--- a/test/test_sock_to.rs
+++ b/test/test_sock_to.rs
@@ -9,7 +9,7 @@ pub fn test_sock_to() {
     let addr = localhost();
     let srv = TcpListener::bind(&addr).unwrap();
 
-    let t = thread::scoped(move || {
+    let t = thread::spawn(move || {
         let mut buf = [0; 1024];
 
         let (mut s, _) = srv.accept().unwrap();
@@ -27,5 +27,5 @@ pub fn test_sock_to() {
     let res = cli.read(&mut buf);
     assert!(res.is_err());
 
-    drop(t);
+    t.join().unwrap();
 }


### PR DESCRIPTION
This mostly fixes the build on the latest nightly, and it also fixes a lifetime bug in `SlabMutIter`'s `Iterator` instance.
For this to build, the nix package still needs to be fixed and the version bound bumped.