### PR TITLE
Update README to reflect eventual Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ extern crate mio;
 __Eventually__
 
 * Signal handling
+* Windows support
 
 ## Non goals
 
@@ -43,7 +44,6 @@ or higher level libraries.
 
 * File operations
 * Thread pools / multi-threaded event loop
-* Windows support
 
 ## Platforms
 


### PR DESCRIPTION
Moved 'Windows support' from the 'Non Goals' section of the feature list to the 'Eventually' section. In light of [recent](https://twitter.com/carllerche/status/589561120211374080) [developments](https://github.com/carllerche/mio/issues/155), I think this change might more accurately reflect the roadmap for the project.