### PR TITLE
Implement Read+Write under TryRead+TryWrite for Io types where applicable, and rename TryRead+TryWrite methods

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -412,7 +412,7 @@ mod tests {
         let wcount = Arc::new(AtomicIsize::new(0));
         let mut handler = Funtimes::new(rcount.clone(), wcount.clone());
 
-        writer.write(&mut buf::SliceBuf::wrap("hello".as_bytes())).unwrap();
+        writer.try_write_buf(&mut buf::SliceBuf::wrap("hello".as_bytes())).unwrap();
         event_loop.register(&reader, Token(10)).unwrap();
 
         let _ = event_loop.run_once(&mut handler);
@@ -420,7 +420,7 @@ mod tests {
 
         assert_eq!((*rcount).load(SeqCst), 1);
 
-        reader.read(&mut b).unwrap();
+        reader.try_read_buf(&mut b).unwrap();
 
         assert_eq!(str::from_utf8(b.flip().bytes()).unwrap(), "hello");
     }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -1,4 +1,5 @@
-use {io, sys, Evented, Interest, PollOpt, Selector, Token, TryRead, TryWrite};
+use {io, sys, Evented, Interest, PollOpt, Selector, Token};
+use std::io::{Read, Write};
 use std::net::SocketAddr;
 
 /*
@@ -117,15 +118,19 @@ impl TcpStream {
     }
 }
 
-impl TryRead for TcpStream {
-    fn read_slice(&mut self, buf: &mut [u8]) -> io::Result<Option<usize>> {
-        self.sys.read_slice(buf)
+impl Read for TcpStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.sys.read(buf)
     }
 }
 
-impl TryWrite for TcpStream {
-    fn write_slice(&mut self, buf: &[u8]) -> io::Result<Option<usize>> {
-        self.sys.write_slice(buf)
+impl Write for TcpStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.sys.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.sys.flush()
     }
 }
 

--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -1,4 +1,5 @@
-use {io, sys, Evented, Interest, Io, PollOpt, Selector, Token, TryRead, TryWrite};
+use {io, sys, Evented, Interest, Io, PollOpt, Selector, Token};
+use std::io::{Read, Write};
 use std::path::Path;
 
 /// A trait to express the ability to construct an object from a raw file descriptor.
@@ -88,15 +89,19 @@ impl UnixStream {
     }
 }
 
-impl io::TryRead for UnixStream {
-    fn read_slice(&mut self, buf: &mut [u8]) -> io::Result<Option<usize>> {
-        self.sys.read_slice(buf)
+impl Read for UnixStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.sys.read(buf)
     }
 }
 
-impl io::TryWrite for UnixStream {
-    fn write_slice(&mut self, buf: &[u8]) -> io::Result<Option<usize>> {
-        self.sys.write_slice(buf)
+impl Write for UnixStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.sys.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.sys.flush()
     }
 }
 
@@ -186,9 +191,9 @@ pub struct PipeReader {
     io: Io,
 }
 
-impl TryRead for PipeReader {
-    fn read_slice(&mut self, buf: &mut [u8]) -> io::Result<Option<usize>> {
-        self.io.read_slice(buf)
+impl Read for PipeReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.io.read(buf)
     }
 }
 
@@ -217,9 +222,13 @@ pub struct PipeWriter {
     io: Io,
 }
 
-impl TryWrite for PipeWriter {
-    fn write_slice(&mut self, buf: &[u8]) -> io::Result<Option<usize>> {
-        self.io.write_slice(buf)
+impl Write for PipeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.io.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.io.flush()
     }
 }
 

--- a/src/sys/unix/awakener.rs
+++ b/src/sys/unix/awakener.rs
@@ -33,7 +33,7 @@ mod pipe {
             // is thread safe.
             unsafe {
                 let wr: &mut PipeWriter = mem::transmute(self.writer.get());
-                wr.write_slice(b"0x01").map(|_| ())
+                wr.try_write(b"0x01").map(|_| ())
             }
         }
 
@@ -48,7 +48,7 @@ mod pipe {
                     let rd: &mut PipeReader = mem::transmute(self.reader.get());
 
                     // Consume data until all bytes are purged
-                    match rd.read_slice(&mut buf) {
+                    match rd.try_read(&mut buf) {
                         Ok(Some(i)) if i > 0 => {},
                         _ => return,
                     }

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -1,5 +1,6 @@
-use {io, Evented, Interest, PollOpt, Selector, Token, TryRead, TryWrite};
+use {io, Evented, Interest, PollOpt, Selector, Token};
 use unix::FromRawFd;
+use std::io::{Read, Write};
 use std::os::unix::io::{AsRawFd, RawFd};
 
 /*
@@ -51,25 +52,25 @@ impl Evented for Io {
     }
 }
 
-impl TryRead for Io {
-    fn read_slice(&mut self, dst: &mut [u8]) -> io::Result<Option<usize>> {
+impl Read for Io {
+    fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
         use nix::unistd::read;
 
         read(self.as_raw_fd(), dst)
-            .map(|cnt| Some(cnt))
             .map_err(super::from_nix_error)
-            .or_else(io::to_non_block)
     }
 }
 
-impl TryWrite for Io {
-    fn write_slice(&mut self, src: &[u8]) -> io::Result<Option<usize>> {
+impl Write for Io {
+    fn write(&mut self, src: &[u8]) -> io::Result<usize> {
         use nix::unistd::write;
 
         write(self.as_raw_fd(), src)
             .map_err(super::from_nix_error)
-            .map(|cnt| Some(cnt))
-            .or_else(io::to_non_block)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,6 +1,7 @@
-use {io, Evented, Interest, Io, PollOpt, Selector, Token, TryRead, TryWrite};
+use {io, Evented, Interest, Io, PollOpt, Selector, Token};
 use unix::FromRawFd;
 use sys::unix::{net, nix, Socket};
+use std::io::{Read, Write};
 use std::net::SocketAddr;
 use std::os::unix::io::{RawFd, AsRawFd};
 
@@ -69,15 +70,19 @@ impl TcpSocket {
     }
 }
 
-impl TryRead for TcpSocket {
-    fn read_slice(&mut self, buf: &mut [u8]) -> io::Result<Option<usize>> {
-        self.io.read_slice(buf)
+impl Read for TcpSocket {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.io.read(buf)
     }
 }
 
-impl TryWrite for TcpSocket {
-    fn write_slice(&mut self, buf: &[u8]) -> io::Result<Option<usize>> {
-        self.io.write_slice(buf)
+impl Write for TcpSocket {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.io.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.io.flush()
     }
 }
 

--- a/src/sys/unix/uds.rs
+++ b/src/sys/unix/uds.rs
@@ -1,6 +1,7 @@
-use {io, Evented, Interest, Io, PollOpt, Selector, Token, TryRead, TryWrite};
+use {io, Evented, Interest, Io, PollOpt, Selector, Token};
 use unix::FromRawFd;
 use sys::unix::{net, nix, Socket};
+use std::io::{Read, Write};
 use std::path::Path;
 use std::os::unix::io::{RawFd, AsRawFd};
 
@@ -47,15 +48,19 @@ impl UnixSocket {
     }
 }
 
-impl TryRead for UnixSocket {
-    fn read_slice(&mut self, buf: &mut [u8]) -> io::Result<Option<usize>> {
-        self.io.read_slice(buf)
+impl Read for UnixSocket {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.io.read(buf)
     }
 }
 
-impl TryWrite for UnixSocket {
-    fn write_slice(&mut self, buf: &[u8]) -> io::Result<Option<usize>> {
-        self.io.write_slice(buf)
+impl Write for UnixSocket {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.io.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.io.flush()
     }
 }
 

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -35,7 +35,7 @@ impl EchoConn {
 
     fn readable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
         loop {
-            match self.sock.read_slice(&mut self.buf[..]) {
+            match self.sock.try_read(&mut self.buf[..]) {
                 Ok(None) => {
                     break;
                 }
@@ -124,7 +124,7 @@ impl EchoClient {
         debug!("client socket writable");
 
         while self.backlog.len() > 0 {
-            match self.sock.write_slice(self.backlog.front().unwrap().as_bytes()) {
+            match self.sock.try_write(self.backlog.front().unwrap().as_bytes()) {
                 Ok(None) => {
                     break;
                 }
@@ -186,7 +186,7 @@ impl Handler for Echo {
     }
 
     fn notify(&mut self, event_loop: &mut EventLoop<Echo>, msg: String) {
-        match self.client.sock.write_slice(msg.as_bytes()) {
+        match self.client.sock.try_write(msg.as_bytes()) {
             Ok(Some(n)) => {
                 self.client.count += 1;
                 if self.client.count % 10000 == 0 {

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -49,7 +49,7 @@ impl Handler for TestHandler {
                 match self.state {
                     Initial => {
                         let mut buf = [0; 4096];
-                        debug!("GOT={:?}", self.cli.read_slice(&mut buf[..]));
+                        debug!("GOT={:?}", self.cli.try_read(&mut buf[..]));
                         assert!(hint.is_data(), "unexpected hint {:?}", hint);
 
                         // Whether or not Hup is included with actual data is platform specific
@@ -68,7 +68,7 @@ impl Handler for TestHandler {
 
                 let mut buf = ByteBuf::mut_with_capacity(1024);
 
-                match self.cli.read(&mut buf) {
+                match self.cli.try_read_buf(&mut buf) {
                     Ok(Some(0)) => event_loop.shutdown(),
                     _ => panic!("the client socket should not be readable")
                 }

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -30,7 +30,7 @@ impl EchoConn {
     fn writable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
         let mut buf = self.buf.take().unwrap();
 
-        match self.sock.write(&mut buf) {
+        match self.sock.try_write_buf(&mut buf) {
             Ok(None) => {
                 debug!("client flushing buf; WOULDBLOCK");
 
@@ -54,7 +54,7 @@ impl EchoConn {
     fn readable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
         let mut buf = self.mut_buf.take().unwrap();
 
-        match self.sock.read(&mut buf) {
+        match self.sock.try_read_buf(&mut buf) {
             Ok(None) => {
                 panic!("We just got readable, but were unable to read from the socket?");
             }
@@ -145,7 +145,7 @@ impl EchoClient {
 
         let mut buf = self.mut_buf.take().unwrap();
 
-        match self.sock.read(&mut buf) {
+        match self.sock.try_read_buf(&mut buf) {
             Ok(None) => {
                 panic!("We just got readable, but were unable to read from the socket?");
             }
@@ -181,7 +181,7 @@ impl EchoClient {
     fn writable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
         debug!("client socket writable");
 
-        match self.sock.write(&mut self.tx) {
+        match self.sock.try_write_buf(&mut self.tx) {
             Ok(None) => {
                 debug!("client flushing buf; WOULDBLOCK");
                 self.interest.insert(Interest::writable());

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -29,7 +29,7 @@ impl Handler for TestHandler {
         match token {
             SERVER => {
                 let mut sock = self.server.accept().unwrap().unwrap();
-                sock.write(&mut buf::SliceBuf::wrap("foobar".as_bytes())).unwrap();
+                sock.try_write_buf(&mut buf::SliceBuf::wrap("foobar".as_bytes())).unwrap();
             }
             CLIENT => {
                 assert!(self.state == 0, "unexpected state {}", self.state);

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -71,7 +71,7 @@ impl Handler for TestHandler {
 
                 let mut buf = buf::ByteBuf::mut_with_capacity(2048);
 
-                match self.cli.read(&mut buf) {
+                match self.cli.try_read_buf(&mut buf) {
                     Ok(n) => {
                         debug!("read {:?} bytes", n);
                         assert!(b"zomg" == buf.flip().bytes());
@@ -99,7 +99,7 @@ impl Handler for TestHandler {
 
     fn timeout(&mut self, _event_loop: &mut EventLoop<TestHandler>, mut sock: TcpStream) {
         debug!("timeout handler : writing to socket");
-        sock.write(&mut buf::SliceBuf::wrap(b"zomg")).unwrap().unwrap();
+        sock.try_write_buf(&mut buf::SliceBuf::wrap(b"zomg")).unwrap().unwrap();
     }
 }
 

--- a/test/test_unix_echo_server.rs
+++ b/test/test_unix_echo_server.rs
@@ -31,7 +31,7 @@ impl EchoConn {
     fn writable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
         let mut buf = self.buf.take().unwrap();
 
-        match self.sock.write(&mut buf) {
+        match self.sock.try_write_buf(&mut buf) {
             Ok(None) => {
                 debug!("client flushing buf; WOULDBLOCK");
 
@@ -54,7 +54,7 @@ impl EchoConn {
     fn readable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
         let mut buf = self.mut_buf.take().unwrap();
 
-        match self.sock.read(&mut buf) {
+        match self.sock.try_read_buf(&mut buf) {
             Ok(None) => {
                 panic!("We just got readable, but were unable to read from the socket?");
             }
@@ -146,7 +146,7 @@ impl EchoClient {
 
         let mut buf = self.mut_buf.take().unwrap();
 
-        match self.sock.read(&mut buf) {
+        match self.sock.try_read_buf(&mut buf) {
             Ok(None) => {
                 panic!("We just got readable, but were unable to read from the socket?");
             }
@@ -183,7 +183,7 @@ impl EchoClient {
     fn writable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
         debug!("client socket writable");
 
-        match self.sock.write(&mut self.tx) {
+        match self.sock.try_write_buf(&mut self.tx) {
             Ok(None) => {
                 debug!("client flushing buf; WOULDBLOCK");
                 self.interest.insert(Interest::writable());


### PR DESCRIPTION
…, TcpStream and UnixStream.