### PR TITLE
Use trace level logging for logging in tick

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -219,7 +219,7 @@ impl<H: Handler> EventLoop<H> {
         let mut messages;
         let mut pending;
 
-        debug!("event loop tick");
+        trace!("event loop tick");
 
         // Check the notify channel for any pending messages. If there are any,
         // avoid blocking when polling for IO events. Messages will be
@@ -282,7 +282,7 @@ impl<H: Handler> EventLoop<H> {
         while i < cnt {
             let evt = self.poll.event(i);
 
-            debug!("event={:?}", evt);
+            trace!("event={:?}", evt);
 
             match evt.token() {
                 NOTIFY => self.notify.cleanup(),

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -16,7 +16,7 @@ impl Poll {
     }
 
     pub fn register<E: Evented>(&mut self, io: &E, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
-        debug!("registering  with poller");
+        trace!("registering with poller");
 
         // Register interests for this socket
         try!(io.register(&mut self.selector, token, interest, opts));
@@ -25,7 +25,7 @@ impl Poll {
     }
 
     pub fn reregister<E: Evented>(&mut self, io: &E, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
-        debug!("registering  with poller");
+        trace!("registering with poller");
 
         // Register interests for this socket
         try!(io.reregister(&mut self.selector, token, interest, opts));
@@ -34,7 +34,7 @@ impl Poll {
     }
 
     pub fn deregister<E: Evented>(&mut self, io: &E) -> io::Result<()> {
-        debug!("deregistering IO with poller");
+        trace!("deregistering IO with poller");
 
         // Deregister interests for this socket
         try!(io.deregister(&mut self.selector));

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -34,7 +34,7 @@ impl Selector {
     }
 
     pub fn register(&mut self, fd: RawFd, token: Token, interests: Interest, opts: PollOpt) -> io::Result<()> {
-        debug!("registering; token={:?}; interests={:?}", token, interests);
+        trace!("registering; token={:?}; interests={:?}", token, interests);
 
         try!(self.ev_register(fd, token.as_usize(), EventFilter::EVFILT_READ, interests.contains(Interest::readable()), opts));
         try!(self.ev_register(fd, token.as_usize(), EventFilter::EVFILT_WRITE, interests.contains(Interest::writable()), opts));
@@ -126,7 +126,7 @@ impl Events {
         let ev = &self.events[idx];
         let token = ev.udata;
 
-        debug!("get event; token={}; ev.filter={:?}; ev.flags={:?}", token, ev.filter, ev.flags);
+        trace!("get event; token={}; ev.filter={:?}; ev.flags={:?}", token, ev.filter, ev.flags);
 
         // When the read end of the socket is closed, EV_EOF is set on the
         // flags, and fflags contains the error, if any.

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -195,12 +195,12 @@ impl<T> Timer<T> {
     }
 
     pub fn tick_to(&mut self, now: u64) -> Option<T> {
-        debug!("tick_to; now={}; tick={}", now, self.tick);
+        trace!("tick_to; now={}; tick={}", now, self.tick);
 
         while self.tick <= now {
             let curr = self.next;
 
-            debug!("ticking; curr={:?}", curr);
+            trace!("ticking; curr={:?}", curr);
 
             if curr == EMPTY {
                 self.tick += 1;
@@ -209,7 +209,7 @@ impl<T> Timer<T> {
                 let links = self.entries[curr].links;
 
                 if links.tick <= self.tick {
-                    debug!("triggering; token={:?}", curr);
+                    trace!("triggering; token={:?}", curr);
 
                     // Unlink will also advance self.next
                     self.unlink(&links, curr);


### PR DESCRIPTION
The mio debug logging output is very verbose, which makes it hard to have a readable debug log a program that's using mio. I've therefore moved the most often occurring debug log calls to the trace level.

This change should allow somebody working on mio to have very detailed logging output, while not making a host processes's debug logs hard to read. Let me know what you think.