### PR TITLE
Change 'register' functions to use Evented Trait Object

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -180,17 +180,17 @@ impl<H: Handler> EventLoop<H> {
     }
 
     /// Registers an IO handle with the event loop.
-    pub fn register<E: Evented>(&mut self, io: &E, token: Token) -> io::Result<()> {
+    pub fn register(&mut self, io: &Evented, token: Token) -> io::Result<()> {
         self.poll.register(io, token, Interest::all(), PollOpt::level())
     }
 
     /// Registers an IO handle with the event loop.
-    pub fn register_opt<E: Evented>(&mut self, io: &E, token: Token, interest: Interest, opt: PollOpt) -> io::Result<()> {
+    pub fn register_opt(&mut self, io: &Evented, token: Token, interest: Interest, opt: PollOpt) -> io::Result<()> {
         self.poll.register(io, token, interest, opt)
     }
 
     /// Re-Registers an IO handle with the event loop.
-    pub fn reregister<E: Evented>(&mut self, io: &E, token: Token, interest: Interest, opt: PollOpt) -> io::Result<()> {
+    pub fn reregister(&mut self, io: &Evented, token: Token, interest: Interest, opt: PollOpt) -> io::Result<()> {
         self.poll.reregister(io, token, interest, opt)
     }
 
@@ -208,7 +208,7 @@ impl<H: Handler> EventLoop<H> {
     }
 
     /// Deregisters an IO handle with the event loop.
-    pub fn deregister<E: Evented>(&mut self, io: &E) -> io::Result<()> {
+    pub fn deregister(&mut self, io: &Evented) -> io::Result<()> {
         self.poll.deregister(io)
     }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -15,7 +15,7 @@ impl Poll {
         })
     }
 
-    pub fn register<E: Evented>(&mut self, io: &E, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    pub fn register(&mut self, io: &Evented, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
         debug!("registering  with poller");
 
         // Register interests for this socket
@@ -24,7 +24,7 @@ impl Poll {
         Ok(())
     }
 
-    pub fn reregister<E: Evented>(&mut self, io: &E, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    pub fn reregister(&mut self, io: &Evented, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
         debug!("registering  with poller");
 
         // Register interests for this socket
@@ -33,7 +33,7 @@ impl Poll {
         Ok(())
     }
 
-    pub fn deregister<E: Evented>(&mut self, io: &E) -> io::Result<()> {
+    pub fn deregister(&mut self, io: &Evented) -> io::Result<()> {
         debug!("deregistering IO with poller");
 
         // Deregister interests for this socket

--- a/src/util/slab.rs
+++ b/src/util/slab.rs
@@ -148,6 +148,22 @@ impl<T> Slab<T> {
         }
     }
 
+    pub fn replace(&mut self, idx: Token, t : T) -> Option<T> {
+        let idx = self.token_to_idx(idx);
+
+        if idx > self.entries.len() {
+            return None;
+        }
+
+        if idx <= MAX {
+            if idx < self.entries.len() {
+                let val = self.entries[idx].val.as_mut().unwrap();
+                return Some(mem::replace(val, t))
+            }
+        }
+        None
+    }
+
     pub fn iter(&self) -> SlabIter<T> {
         SlabIter {
             slab: self,


### PR DESCRIPTION
When attempting to make an event-loop wrapper which can conveniently manage multiple protocol handlers, the one problem I ran into with mio is being able to provide Sized Evented objects for consumption.  In some cases I was able to know the exact Evented impl and Any::downcast down to the type, in other cases I was not so lucky.  

I have a branch which simply changes deregister/register/register_opt in EventLoop and Poll to take an &Evented rather than  E : Evented.  This requires no code change for customers as a ref will already coerce. All tests pass.  

Also,  I have added a Slab::replace which works like std::mem::replace. Very handy for moving values in and out of a Slab without giving up a token. 