### PR TITLE
Drop notifications

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -335,6 +335,12 @@ impl<H: Handler> EventLoop<H> {
 
 unsafe impl<H: Handler> Sync for EventLoop<H> { }
 
+impl <H: Handler> Drop for EventLoop<H> {
+    fn drop(&mut self) {
+        self.notify.close();
+    }
+}
+
 /// Sends messages to the EventLoop from other threads.
 pub struct Sender<M: Send> {
     notify: Notify<M>


### PR DESCRIPTION
Here is the fix for #178

I have made a couple of implementation choices:

* Named the new state `CLOSED` instead of `DROPPED`, as potentially you could want to expose the `close()` function
* As currently the `Notify` structure is only used in mpsc mode and `close()` is not exposed, I do not check for the `CLOSED` state when reading the channel in `check()`, and only inserted a `debug_assert!()`
* To ensure that all messages are dropped from the queue, a `send()` will in very special cases have to drop a notification. That could potentially be a problem when the drop is expensive, and with panicking destructors (which are already a bad idea in Rust)

Potential enhancements:

* Expose the `close()` function if you think it could be useful. This will require to handle the `CLOSED` case in the `check()` function
    * You could then think about a `reopen()` function, but it could be tricky to implement, and I am not sure there would be use cases

