### PR TITLE
Slab refactor

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -1,3 +1,5 @@
+use util::Index;
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Token(pub usize);
 
@@ -6,5 +8,15 @@ impl Token {
     pub fn as_usize(self) -> usize {
         let Token(inner) = self;
         inner
+    }
+}
+
+impl Index for Token {
+    fn from_usize(i : usize) -> Token {
+        Token(i)
+    }
+
+    fn as_usize(&self) -> usize {
+        Token::as_usize(*self)
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,7 +1,10 @@
 //! Utilities for non-blocking IO programs
 
 pub use self::mpmc_bounded_queue::Queue as BoundedQueue;
-pub use self::slab::Slab;
+pub use self::slab::Index;
+
+use token::Token;
+pub type Slab<T> = slab::Slab<T, Token>;
 
 mod mpmc_bounded_queue;
 mod slab;

--- a/src/util/slab.rs
+++ b/src/util/slab.rs
@@ -109,7 +109,7 @@ impl<T> Slab<T> {
         if idx == self.entries.capacity() {
             Err(val)
         } else {
-            match self.insert_with(move |_| { val }) {
+            match self.insert_with(move |_| val ) {
                 None => panic!("Slab::insert_with() should"),
                 Some(token) => Ok(token)
             }

--- a/src/util/slab.rs
+++ b/src/util/slab.rs
@@ -1,32 +1,47 @@
 use std::{fmt, mem, usize};
 use std::iter::IntoIterator;
-use std::ops::{Index, IndexMut};
-use token::Token;
+use std::ops;
 
 /// A preallocated chunk of memory for storing objects of the same type.
-pub struct Slab<T> {
+pub struct Slab<T, I : Index> {
     // Chunk of memory
     entries: Vec<Entry<T>>,
     // Number of elements currently in the slab
     len: usize,
-    // The token offset
-    off: usize,
+    // The index offset
+    off: I,
     // Offset of the next available slot in the slab. Set to the slab's
     // capacity when the slab is full.
     nxt: usize,
 }
 
-const MAX: usize = usize::MAX;
+/// Slab can be indexed by any type implementing `Index` trait.
+pub trait Index {
+    fn from_usize(i : usize) -> Self;
+    fn as_usize(&self) -> usize;
+}
 
-unsafe impl<T> Send for Slab<T> where T: Send {}
-
-// TODO: Once NonZero lands, use it to optimize the layout
-impl<T> Slab<T> {
-    pub fn new(cap: usize) -> Slab<T> {
-        Slab::new_starting_at(Token(0), cap)
+impl Index for usize {
+    fn from_usize(i : usize) -> usize {
+        i
     }
 
-    pub fn new_starting_at(offset: Token, cap: usize) -> Slab<T> {
+    fn as_usize(&self) -> usize {
+        *self
+    }
+}
+
+const MAX: usize = usize::MAX;
+
+unsafe impl<T, I : Index> Send for Slab<T, I> where T: Send {}
+
+// TODO: Once NonZero lands, use it to optimize the layout
+impl<T, I : Index> Slab<T, I> {
+    pub fn new(cap: usize) -> Slab<T, I> {
+        Slab::new_starting_at(I::from_usize(0), cap)
+    }
+
+    pub fn new_starting_at(offset: I, cap: usize) -> Slab<T, I> {
         assert!(cap <= MAX, "capacity too large");
         // TODO:
         // - Rename to with_capacity
@@ -38,7 +53,7 @@ impl<T> Slab<T> {
         Slab {
             entries: entries,
             len: 0,
-            off: offset.as_usize(),
+            off: offset,
             nxt: 0,
         }
     }
@@ -64,12 +79,12 @@ impl<T> Slab<T> {
     }
 
     #[inline]
-    pub fn contains(&self, idx: Token) -> bool {
-        if idx.as_usize() < self.off {
+    pub fn contains(&self, idx : I) -> bool {
+        if idx.as_usize() < self.off.as_usize() {
             return false;
         }
 
-        let idx = self.token_to_idx(idx);
+        let idx = self.global_to_local_idx(idx);
 
         if idx < self.entries.len() {
             return self.entries[idx].in_use();
@@ -78,8 +93,8 @@ impl<T> Slab<T> {
         false
     }
 
-    pub fn get(&self, idx: Token) -> Option<&T> {
-        let idx = self.token_to_idx(idx);
+    pub fn get(&self, idx: I) -> Option<&T> {
+        let idx = self.global_to_local_idx(idx);
 
         if idx <= MAX {
             if idx < self.entries.len() {
@@ -90,8 +105,8 @@ impl<T> Slab<T> {
         None
     }
 
-    pub fn get_mut(&mut self, idx: Token) -> Option<&mut T> {
-        let idx = self.token_to_idx(idx);
+    pub fn get_mut(&mut self, idx: I) -> Option<&mut T> {
+        let idx = self.global_to_local_idx(idx);
 
         if idx <= MAX {
             if idx < self.entries.len() {
@@ -102,7 +117,7 @@ impl<T> Slab<T> {
         None
     }
 
-    pub fn insert(&mut self, val: T) -> Result<Token, T> {
+    pub fn insert(&mut self, val: T) -> Result<I, T> {
         let idx = self.nxt;
         // check fail condition before val gets moved by insert_with,
         // so `Err(val)` can be returned
@@ -111,15 +126,15 @@ impl<T> Slab<T> {
         } else {
             match self.insert_with(move |_| val ) {
                 None => panic!("Slab::insert_with() should"),
-                Some(token) => Ok(token)
+                Some(idx) => Ok(idx)
             }
         }
     }
 
     /// Like `insert` but for objects that require newly allocated
-    /// Token in their constructor.
-    pub fn insert_with<F>(&mut self, f : F) -> Option<Token>
-    where F : FnOnce(Token) -> T {
+    /// usize in their constructor.
+    pub fn insert_with<F>(&mut self, f : F) -> Option<I>
+    where F : FnOnce(I) -> T {
         let idx = self.nxt;
 
         if idx == self.entries.len() {
@@ -130,7 +145,7 @@ impl<T> Slab<T> {
                 return None;
             }
 
-            let val = f(self.idx_to_token(idx));
+            let val = f(self.local_to_global_idx(idx));
             self.entries.push(Entry {
                 nxt: MAX,
                 val: Some(val),
@@ -140,18 +155,17 @@ impl<T> Slab<T> {
             self.nxt = self.len;
         }
         else {
-            let val = f(self.idx_to_token(idx));
+            let val = f(self.local_to_global_idx(idx));
             self.len += 1;
             self.nxt = self.entries[idx].put(val);
         }
 
-        Some(self.idx_to_token(idx))
+        Some(self.local_to_global_idx(idx))
     }
 
     /// Releases the given slot
-    pub fn remove(&mut self, idx: Token) -> Option<T> {
-        // Cast to usize
-        let idx = self.token_to_idx(idx);
+    pub fn remove(&mut self, idx: I) -> Option<T> {
+        let idx = self.global_to_local_idx(idx);
 
         if idx > self.entries.len() {
             return None;
@@ -167,8 +181,8 @@ impl<T> Slab<T> {
         }
     }
 
-    pub fn replace(&mut self, idx: Token, t : T) -> Option<T> {
-        let idx = self.token_to_idx(idx);
+    pub fn replace(&mut self, idx: I, t : T) -> Option<T> {
+        let idx = self.global_to_local_idx(idx);
 
         if idx > self.entries.len() {
             return None;
@@ -184,7 +198,7 @@ impl<T> Slab<T> {
     }
 
 
-    pub fn iter(&self) -> SlabIter<T> {
+    pub fn iter(&self) -> SlabIter<T, I> {
         SlabIter {
             slab: self,
             cur_idx: 0,
@@ -192,7 +206,7 @@ impl<T> Slab<T> {
         }
     }
 
-    pub fn iter_mut(&mut self) -> SlabMutIter<T> {
+    pub fn iter_mut(&mut self) -> SlabMutIter<T, I> {
         SlabMutIter { iter: self.iter() }
     }
 
@@ -205,20 +219,20 @@ impl<T> Slab<T> {
         panic!("invalid index {} -- greater than capacity {}", idx, self.entries.capacity());
     }
 
-    fn token_to_idx(&self, token: Token) -> usize {
-        token.as_usize() - self.off
+    fn global_to_local_idx(&self, idx: I) -> usize {
+        idx.as_usize() - self.off.as_usize()
     }
 
-    fn idx_to_token(&self, idx: usize) -> Token {
-        Token(idx as usize + self.off)
+    fn local_to_global_idx(&self, idx: usize) -> I {
+        I::from_usize(idx + self.off.as_usize())
     }
 }
 
-impl<T> Index<Token> for Slab<T> {
+impl<T, I : Index> ops::Index<I> for Slab<T, I> {
     type Output = T;
 
-    fn index<'a>(&'a self, idx: Token) -> &'a T {
-        let idx = self.token_to_idx(idx);
+    fn index<'a>(&'a self, idx: I) -> &'a T {
+        let idx = self.global_to_local_idx(idx);
         let idx = self.validate_idx(idx);
 
         self.entries[idx].val.as_ref()
@@ -226,9 +240,9 @@ impl<T> Index<Token> for Slab<T> {
     }
 }
 
-impl<T> IndexMut<Token> for Slab<T> {
-    fn index_mut<'a>(&'a mut self, idx: Token) -> &'a mut T {
-        let idx = self.token_to_idx(idx);
+impl<T, I : Index> ops::IndexMut<I> for Slab<T, I> {
+    fn index_mut<'a>(&'a mut self, idx: I) -> &'a mut T {
+        let idx = self.global_to_local_idx(idx);
         let idx = self.validate_idx(idx);
 
         self.entries[idx].val.as_mut()
@@ -236,7 +250,7 @@ impl<T> IndexMut<Token> for Slab<T> {
     }
 }
 
-impl<T> fmt::Debug for Slab<T> {
+impl<T, I : Index> fmt::Debug for Slab<T, I> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "Slab {{ len: {}, cap: {} }}", self.len, self.entries.capacity())
     }
@@ -250,7 +264,7 @@ struct Entry<T> {
 
 impl<T> Entry<T> {
     #[inline]
-    fn put(&mut self, val: T) -> usize{
+    fn put(&mut self, val: T) -> usize {
         let ret = self.nxt;
         self.val = Some(val);
         ret
@@ -271,13 +285,13 @@ impl<T> Entry<T> {
     }
 }
 
-pub struct SlabIter<'a, T: 'a> {
-    slab: &'a Slab<T>,
+pub struct SlabIter<'a, T: 'a, I : Index+'a> {
+    slab: &'a Slab<T, I>,
     cur_idx: usize,
     yielded: usize
 }
 
-impl<'a, T> Iterator for SlabIter<'a, T> {
+impl<'a, T, I : Index> Iterator for SlabIter<'a, T, I> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
@@ -298,11 +312,11 @@ impl<'a, T> Iterator for SlabIter<'a, T> {
     }
 }
 
-pub struct SlabMutIter<'a, T: 'a> {
-    iter: SlabIter<'a, T>,
+pub struct SlabMutIter<'a, T: 'a, I : Index+'a> {
+    iter: SlabIter<'a, T, I>,
 }
 
-impl<'a, T> Iterator for SlabMutIter<'a, T> {
+impl<'a, T, I : Index> Iterator for SlabMutIter<'a, T, I> {
     type Item = &'a mut T;
 
     fn next(&mut self) -> Option<&'a mut T> {
@@ -310,20 +324,20 @@ impl<'a, T> Iterator for SlabMutIter<'a, T> {
     }
 }
 
-impl<'a, T> IntoIterator for &'a Slab<T> {
+impl<'a, T, I : Index> IntoIterator for &'a Slab<T, I> {
     type Item = &'a T;
-    type IntoIter = SlabIter<'a, T>;
+    type IntoIter = SlabIter<'a, T, I>;
 
-    fn into_iter(self) -> SlabIter<'a, T> {
+    fn into_iter(self) -> SlabIter<'a, T, I> {
         self.iter()
     }
 }
 
-impl<'a, T> IntoIterator for &'a mut Slab<T> {
+impl<'a, T, I : Index> IntoIterator for &'a mut Slab<T, I> {
     type Item = &'a mut T;
-    type IntoIter = SlabMutIter<'a, T>;
+    type IntoIter = SlabMutIter<'a, T, I>;
 
-    fn into_iter(self) -> SlabMutIter<'a, T> {
+    fn into_iter(self) -> SlabMutIter<'a, T, I> {
         self.iter_mut()
     }
 }
@@ -331,22 +345,21 @@ impl<'a, T> IntoIterator for &'a mut Slab<T> {
 #[cfg(test)]
 mod tests {
     use super::Slab;
-    use {Token};
 
     #[test]
     fn test_insertion() {
-        let mut slab = Slab::new(1);
-        let token = slab.insert(10).ok().expect("Failed to insert");
-        assert_eq!(slab[token], 10);
+        let mut slab = Slab::<usize, usize>::new(1);
+        let idx = slab.insert(10).ok().expect("Failed to insert");
+        assert_eq!(slab[idx], 10);
     }
 
     #[test]
     fn test_repeated_insertion() {
-        let mut slab = Slab::new(10);
+        let mut slab = Slab::<usize, usize>::new(10);
 
         for i in (0..10) {
-            let token = slab.insert(i + 10).ok().expect("Failed to insert");
-            assert_eq!(slab[token], i + 10);
+            let idx= slab.insert(i + 10).ok().expect("Failed to insert");
+            assert_eq!(slab[idx], i + 10);
         }
 
         slab.insert(20).err().expect("Inserted when full");
@@ -354,16 +367,16 @@ mod tests {
 
     #[test]
     fn test_repeated_insertion_and_removal() {
-        let mut slab = Slab::new(10);
-        let mut tokens = vec![];
+        let mut slab = Slab::<usize, usize>::new(10);
+        let mut indices = vec![];
 
-        for i in (0..10) {
-            let token = slab.insert(i + 10).ok().expect("Failed to insert");
-            tokens.push(token);
-            assert_eq!(slab[token], i + 10);
+        for i in 0..10 {
+            let idx = slab.insert(i + 10).ok().expect("Failed to insert");
+            indices.push(idx);
+            assert_eq!(slab[idx], i + 10);
         }
 
-        for &i in tokens.iter() {
+        for &i in indices.iter() {
             slab.remove(i);
         }
 
@@ -372,14 +385,14 @@ mod tests {
 
     #[test]
     fn test_insertion_when_full() {
-        let mut slab = Slab::new(1);
+        let mut slab = Slab::<usize, usize>::new(1);
         slab.insert(10).ok().expect("Failed to insert");
         slab.insert(10).err().expect("Inserted into a full slab");
     }
 
     #[test]
     fn test_removal_is_successful() {
-        let mut slab = Slab::new(1);
+        let mut slab = Slab::<usize, usize>::new(1);
         let t1 = slab.insert(10).ok().expect("Failed to insert");
         slab.remove(t1);
         let t2 = slab.insert(20).ok().expect("Failed to insert");
@@ -388,7 +401,7 @@ mod tests {
 
     #[test]
     fn test_mut_retrieval() {
-        let mut slab = Slab::new(1);
+        let mut slab = Slab::<_, usize>::new(1);
         let t1 = slab.insert("foo".to_string()).ok().expect("Failed to insert");
 
         slab[t1].push_str("bar");
@@ -399,7 +412,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_reusing_slots_1() {
-        let mut slab = Slab::new(16);
+        let mut slab = Slab::<usize, usize>::new(16);
 
         let t0 = slab.insert(123).unwrap();
         let t1 = slab.insert(456).unwrap();
@@ -422,7 +435,7 @@ mod tests {
 
     #[test]
     fn test_reusing_slots_2() {
-        let mut slab = Slab::new(16);
+        let mut slab = Slab::<usize, usize>::new(16);
 
         let t0 = slab.insert(123).unwrap();
 
@@ -447,22 +460,22 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_accessing_out_of_bounds() {
-        let slab = Slab::<usize>::new(16);
-        slab[Token(0)];
+        let slab = Slab::<usize, usize>::new(16);
+        slab[0];
     }
 
     #[test]
     fn test_contains() {
-        let mut slab = Slab::new_starting_at(Token(5),16);
-        assert!(!slab.contains(Token(0)));
+        let mut slab = Slab::new_starting_at(5 ,16);
+        assert!(!slab.contains(0));
 
-        let tok = slab.insert(111).unwrap();
-        assert!(slab.contains(tok));
+        let idx = slab.insert(111).unwrap();
+        assert!(slab.contains(idx));
     }
 
     #[test]
     fn test_iter() {
-        let mut slab: Slab<u32> = Slab::new_starting_at(Token(0), 4);
+        let mut slab = Slab::<u32, usize>::new_starting_at(0, 4);
         for i in (0..4) {
             slab.insert(i).unwrap();
         }
@@ -470,7 +483,7 @@ mod tests {
         let vals: Vec<u32> = slab.iter().map(|r| *r).collect();
         assert_eq!(vals, vec![0, 1, 2, 3]);
 
-        slab.remove(Token(1));
+        slab.remove(1);
 
         let vals: Vec<u32> = slab.iter().map(|r| *r).collect();
         assert_eq!(vals, vec![0, 2, 3]);
@@ -478,7 +491,7 @@ mod tests {
 
     #[test]
     fn test_iter_mut() {
-        let mut slab: Slab<u32> = Slab::new_starting_at(Token(0), 4);
+        let mut slab = Slab::<u32, usize>::new_starting_at(0, 4);
         for i in (0..4) {
             slab.insert(i).unwrap();
         }
@@ -489,7 +502,7 @@ mod tests {
         let vals: Vec<u32> = slab.iter().map(|r| *r).collect();
         assert_eq!(vals, vec![1, 2, 3, 4]);
 
-        slab.remove(Token(2));
+        slab.remove(2);
         for e in slab.iter_mut() {
             *e = *e + 1;
         }
@@ -500,16 +513,16 @@ mod tests {
 
     #[test]
     fn test_get() {
-        let mut slab = Slab::new(16);
+        let mut slab = Slab::<usize, usize>::new(16);
         let tok = slab.insert(5).unwrap();
         assert_eq!(slab.get(tok), Some(&5));
-        assert_eq!(slab.get(Token(1)), None);
-        assert_eq!(slab.get(Token(23)), None);
+        assert_eq!(slab.get(1), None);
+        assert_eq!(slab.get(23), None);
     }
 
     #[test]
     fn test_get_mut() {
-        let mut slab = Slab::new(16);
+        let mut slab = Slab::<u32, usize>::new(16);
         let tok = slab.insert(5u32).unwrap();
         {
             let mut_ref = slab.get_mut(tok).unwrap();
@@ -517,7 +530,7 @@ mod tests {
             *mut_ref = 12;
         }
         assert_eq!(slab[tok], 12);
-        assert_eq!(slab.get_mut(Token(1)), None);
-        assert_eq!(slab.get_mut(Token(23)), None);
+        assert_eq!(slab.get_mut(1), None);
+        assert_eq!(slab.get_mut(23), None);
     }
 }


### PR DESCRIPTION
Slab could be moved into separate crate, as it is useful on it's own. This change breaks decency on `mio`'s `Token`, by abstracting it away to an `Index` trait.

It's rebased on my revious slab patches.