### PR TITLE
consolidated the behavior of kqueue and epoll into IoEvent iterator (for #184)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 target
 libs
+.*.sw*

--- a/src/event.rs
+++ b/src/event.rs
@@ -290,7 +290,7 @@ impl fmt::Debug for Interest {
 
 #[derive(Copy, Clone, Debug)]
 pub struct IoEvent {
-    kind: Interest,
+    pub kind: Interest,
     token: Token
 }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -4,6 +4,7 @@ use notify::Notify;
 use timer::{Timer, Timeout, TimerResult};
 use std::default::Default;
 use std::{io, fmt, usize};
+use poll::Events;
 
 /// Configure EventLoop runtime details
 #[derive(Copy, Clone, Debug)]
@@ -241,7 +242,7 @@ impl<H: Handler> EventLoop<H> {
             Err(err) => {
                 if err.kind() == io::ErrorKind::Interrupted {
                     handler.interrupted(self);
-                    0
+                    return Err(err);
                 } else {
                     return Err(err);
                 }
@@ -258,12 +259,11 @@ impl<H: Handler> EventLoop<H> {
         self.io_process(handler, events);
         self.notify(handler, messages);
         self.timer_process(handler);
-
         Ok(())
     }
 
     #[inline]
-    fn io_poll(&mut self, immediate: bool) -> io::Result<usize> {
+    fn io_poll(&mut self, immediate: bool) -> io::Result<Events> {
         if immediate {
             self.poll.poll(0)
         } else {
@@ -278,15 +278,13 @@ impl<H: Handler> EventLoop<H> {
     }
 
     // Process IO events that have been previously polled
-    fn io_process(&mut self, handler: &mut H, cnt: usize) {
-        let mut i = 0;
-
+    fn io_process(&mut self, handler: &mut H, events: Events) {
         // Iterate over the notifications. Each event provides the token
         // it was registered with (which usually represents, at least, the
         // handle that the event is about) as well as information about
         // what kind of event occurred (readable, writable, signal, etc.)
-        while i < cnt {
-            let evt = self.poll.event(i);
+
+        for evt in events.iter() {
 
             trace!("event={:?}", evt);
 
@@ -294,21 +292,14 @@ impl<H: Handler> EventLoop<H> {
                 NOTIFY => self.notify.cleanup(),
                 _      => self.io_event(handler, evt)
             }
-
-            i += 1;
         }
+
+        self.poll.reset_events(events);
     }
 
     fn io_event(&mut self, handler: &mut H, evt: IoEvent) {
-        let tok = evt.token();
 
-        if evt.is_readable() | evt.is_error() {
-            handler.readable(self, tok, evt.read_hint());
-        }
-
-        if evt.is_writable() {
-            handler.writable(self, tok);
-        }
+        handler.ready(self, evt.token(), evt.events());
     }
 
     fn notify(&mut self, handler: &mut H, mut cnt: usize) {
@@ -377,7 +368,7 @@ mod tests {
     use std::sync::atomic::AtomicIsize;
     use std::sync::atomic::Ordering::SeqCst;
     use super::EventLoop;
-    use {buf, unix, Buf, Handler, Token, TryRead, TryWrite, ReadHint};
+    use {buf, unix, Buf, Handler, Token, TryRead, TryWrite, Interest};
 
     #[test]
     pub fn test_event_loop_size() {
@@ -403,14 +394,16 @@ mod tests {
         type Timeout = usize;
         type Message = ();
 
-        fn readable(&mut self, _event_loop: &mut EventLoop<Funtimes>, token: Token, _: ReadHint) {
-            (*self.rcount).fetch_add(1, SeqCst);
-            assert_eq!(token, Token(10));
-        }
+        fn ready(&mut self, _event_loop: &mut EventLoop<Funtimes>, token: Token, events: Interest) {
+            if events.is_readable() {
+                (*self.rcount).fetch_add(1, SeqCst);
+                assert_eq!(token, Token(10));
+            }
 
-        fn writable(&mut self, _event_loop: &mut EventLoop<Funtimes>, token: Token) {
-            (*self.wcount).fetch_add(1, SeqCst);
-            assert_eq!(token, Token(10));
+            if events.is_writable() {
+                (*self.wcount).fetch_add(1, SeqCst);
+                assert_eq!(token, Token(10));
+            }
         }
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,14 +1,11 @@
-use {EventLoop, ReadHint, Token};
+use {EventLoop, Interest, Token};
 
 #[allow(unused_variables)]
 pub trait Handler {
     type Timeout;
     type Message: Send;
 
-    fn readable(&mut self, event_loop: &mut EventLoop<Self>, token: Token, hint: ReadHint) {
-    }
-
-    fn writable(&mut self, event_loop: &mut EventLoop<Self>, token: Token) {
+    fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token, events: Interest) {
     }
 
     fn notify(&mut self, event_loop: &mut EventLoop<Self>, msg: Self::Message) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!     type Timeout = ();
 //!     type Message = ();
 //!
-//!     fn readable(&mut self, event_loop: &mut EventLoop<MyHandler>, token: Token, _: ReadHint) {
+//!     fn ready(&mut self, event_loop: &mut EventLoop<MyHandler>, token: Token, _: Interest) {
 //!         match token {
 //!             SERVER => {
 //!                 let MyHandler(ref mut server) = *self;
@@ -107,7 +107,6 @@ pub use buf::{
 pub use event::{
     PollOpt,
     Interest,
-    ReadHint,
 };
 pub use event_loop::{
     EventLoop,

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -53,7 +53,6 @@ impl Poll {
     pub fn poll(&mut self, timeout_ms: usize) -> io::Result<Events> {
         let mut evts = self.events.take().expect("poll run without events struct set. Call set_events");
         try!(self.selector.select(&mut evts, timeout_ms));
-        evts.coalesce();
         Ok(evts)
     }
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -2,6 +2,7 @@
 pub use self::unix::{
     Awakener,
     Events,
+    EventsIterator,
     Io,
     Selector,
     TcpSocket,

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -127,24 +127,24 @@ impl Events {
         for e in self.events.iter() {
             let ioe = self.token_evts.entry(e.udata).or_insert(Interest::hinted(), e.udata);
             if e.filter == EventFilter::EVFILT_READ {
-                ioe.insert(Interest::readable());
+                ioe.kind.insert(Interest::readable());
             } else if e.filter == EventFilter::EVFILT_WRITE {
-                ioe.insert(Interest::writable());
+                ioe.kind.insert(Interest::writable());
             }
 
             if e.flags.contains(EV_EOF) {
-                ioe.insert(Interest::hup());
+                ioe.kind.insert(Interest::hup());
 
                 // When the read end of the socket is closed, EV_EOF is set on
                 // flags, and fflags contains the error if there is one.
                 if !e.fflags.is_empty() {
-                    ioe.insert(Interest::error());
+                    ioe.kind.insert(Interest::error());
                 }
             }
         }
     }
 
-    pub fn iter<'a>(&self) -> EventsIterator<'a> {
+    pub fn iter<'a>(&'a self) -> EventsIterator<'a> {
         EventsIterator{ iter: self.token_evts.values() }
     }
 
@@ -182,6 +182,6 @@ impl<'a> Iterator for EventsIterator<'a> {
     type Item = IoEvent;
 
     fn next(&mut self) -> Option<IoEvent> {
-        self.iter.next()
+        self.iter.next().map(|x| *x)
     }
 }

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -125,7 +125,7 @@ impl Events {
     pub fn coalesce(&mut self) {
         self.token_evts.clear();
         for e in self.events.iter() {
-            let ioe = self.token_evts.entry(e.udata).or_insert(Interest::hinted(), e.udata);
+            let ioe = self.token_evts.entry(Token(e.udata as usize)).or_insert(IoEvent::new(Interest::hinted(), Token(e.udata as usize)));
             if e.filter == EventFilter::EVFILT_READ {
                 ioe.kind.insert(Interest::readable());
             } else if e.filter == EventFilter::EVFILT_WRITE {

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -4,6 +4,8 @@ use nix::sys::event::{EventFilter, EventFlag, FilterFlag, KEvent, ev_set, kqueue
 use nix::sys::event::{EV_ADD, EV_CLEAR, EV_DELETE, EV_DISABLE, EV_ENABLE, EV_EOF, EV_ONESHOT};
 use std::{fmt, slice};
 use std::os::unix::io::RawFd;
+use std::collections::HashMap;
+use std::collections::hash_map::Values;
 
 #[derive(Debug)]
 pub struct Selector {
@@ -29,6 +31,8 @@ impl Selector {
         unsafe {
             evts.events.set_len(cnt);
         }
+
+        evts.coalesce();
 
         Ok(())
     }
@@ -104,54 +108,44 @@ impl Selector {
 
 pub struct Events {
     events: Vec<KEvent>,
+    token_evts: HashMap<Token, IoEvent>
 }
 
 impl Events {
     pub fn new() -> Events {
-        Events { events: Vec::with_capacity(1024) }
+        Events { events: Vec::with_capacity(1024),
+                 token_evts: HashMap::with_capacity(1024) }
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.events.len()
+        self.token_evts.len()
     }
 
-    // TODO: We will get rid of this eventually in favor of an iterator
-    #[inline]
-    pub fn get(&self, idx: usize) -> IoEvent {
-        if idx >= self.len() {
-            panic!("invalid index");
-        }
+    pub fn coalesce(&mut self) {
+        self.token_evts.clear();
+        for e in self.events.iter() {
+            let ioe = self.token_evts.entry(e.udata).or_insert(Interest::hinted(), e.udata);
+            if ev.filter == EventFilter::EVFILT_READ {
+                ioe.insert(Interest::readable());
+            } else if ev.filter == EventFilter::EVFILT_WRITE {
+                ioe.insert(Interest::writable());
+            }
 
-        let ev = &self.events[idx];
-        let token = ev.udata;
+            if ev.flags.contains(EV_EOF) {
+                ioe.insert(Interest::hup());
 
-        trace!("get event; token={}; ev.filter={:?}; ev.flags={:?}", token, ev.filter, ev.flags);
-
-        // When the read end of the socket is closed, EV_EOF is set on the
-        // flags, and fflags contains the error, if any.
-
-        let mut kind = Interest::hinted();
-
-        if ev.filter == EventFilter::EVFILT_READ {
-            kind = kind | Interest::readable();
-        } else if ev.filter == EventFilter::EVFILT_WRITE {
-            kind = kind | Interest::writable();
-        } else {
-            panic!("GOT: {:?}", ev.filter);
-        }
-
-        if ev.flags.contains(EV_EOF) {
-            kind = kind | Interest::hup();
-
-            // When the read end of the socket is closed, EV_EOF is set on
-            // flags, and fflags contains the error if there is one.
-            if !ev.fflags.is_empty() {
-                kind = kind | Interest::error();
+                // When the read end of the socket is closed, EV_EOF is set on
+                // flags, and fflags contains the error if there is one.
+                if !ev.fflags.is_empty() {
+                    ioe.insert(Interest::error());
+                }
             }
         }
+    }
 
-        IoEvent::new(kind, token)
+    pub fn iter<'a>(&self) -> EventsIterator<'a> {
+        EventsIterator{ iter: self.token_evts.values() }
     }
 
     #[inline]
@@ -177,5 +171,17 @@ impl Events {
 impl fmt::Debug for Events {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "Events {{ len: {} }}", self.events.len())
+    }
+}
+
+pub struct EventsIterator<'a> {
+    iter: Values<'a, Token, IoEvent>
+}
+
+impl<'a> Iterator for EventsIterator<'a> {
+    type Item = IoEvent;
+
+    fn next(&mut self) -> Option<IoEvent> {
+        self.iter.next()
     }
 }

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -125,7 +125,7 @@ impl Events {
     pub fn coalesce(&mut self) {
         self.token_evts.clear();
         for e in self.events.iter() {
-            let ioe = self.token_evts.entry(Token(e.udata as usize)).or_insert(IoEvent::new(Interest::hinted(), Token(e.udata as usize)));
+            let ioe = self.token_evts.entry(Token(e.udata as usize)).or_insert(IoEvent::new(Interest::hinted(), e.udata as usize));
             if e.filter == EventFilter::EVFILT_READ {
                 ioe.kind.insert(Interest::readable());
             } else if e.filter == EventFilter::EVFILT_WRITE {

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -126,18 +126,18 @@ impl Events {
         self.token_evts.clear();
         for e in self.events.iter() {
             let ioe = self.token_evts.entry(e.udata).or_insert(Interest::hinted(), e.udata);
-            if ev.filter == EventFilter::EVFILT_READ {
+            if e.filter == EventFilter::EVFILT_READ {
                 ioe.insert(Interest::readable());
-            } else if ev.filter == EventFilter::EVFILT_WRITE {
+            } else if e.filter == EventFilter::EVFILT_WRITE {
                 ioe.insert(Interest::writable());
             }
 
-            if ev.flags.contains(EV_EOF) {
+            if e.flags.contains(EV_EOF) {
                 ioe.insert(Interest::hup());
 
                 // When the read end of the socket is closed, EV_EOF is set on
                 // flags, and fflags contains the error if there is one.
-                if !ev.fflags.is_empty() {
+                if !e.fflags.is_empty() {
                     ioe.insert(Interest::error());
                 }
             }

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -2,13 +2,13 @@
 mod epoll;
 
 #[cfg(target_os = "linux")]
-pub use self::epoll::{Events, Selector};
+pub use self::epoll::{Events, Selector, EventsIterator};
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod kqueue;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-pub use self::kqueue::{Events, Selector};
+pub use self::kqueue::{Events, Selector, EventsIterator};
 
 mod awakener;
 mod io;

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -167,22 +167,22 @@ impl Handler for Echo {
     type Timeout = usize;
     type Message = String;
 
-    fn readable(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, hint: ReadHint) {
-        assert_eq!(hint, ReadHint::data());
+    fn ready(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, events: Interest) {
 
-        match token {
-            SERVER => self.server.accept(event_loop).unwrap(),
-            CLIENT => self.client.readable(event_loop).unwrap(),
-            i => self.server.conn_readable(event_loop, i).unwrap()
-        };
-    }
-
-    fn writable(&mut self, event_loop: &mut EventLoop<Echo>, token: Token) {
-        match token {
-            SERVER => panic!("received writable for token 0"),
-            CLIENT => self.client.writable(event_loop).unwrap(),
-            _ => self.server.conn_writable(event_loop, token).unwrap()
-        };
+        if events.is_readable() {
+            match token {
+                SERVER => self.server.accept(event_loop).unwrap(),
+                CLIENT => self.client.readable(event_loop).unwrap(),
+                i => self.server.conn_readable(event_loop, i).unwrap()
+            }
+        }
+        if events.is_writable() {
+            match token {
+                SERVER => panic!("received writable for token 0"),
+                CLIENT => self.client.writable(event_loop).unwrap(),
+                _ => self.server.conn_writable(event_loop, token).unwrap()
+            }
+        }
     }
 
     fn notify(&mut self, event_loop: &mut EventLoop<Echo>, msg: String) {

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -31,24 +31,27 @@ impl Handler for UdpHandler {
     type Timeout = usize;
     type Message = ();
 
-    fn readable(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, _: ReadHint) {
-        match token {
-            LISTENER => {
-                debug!("We are receiving a datagram now...");
-                self.rx.recv_from(&mut self.rx_buf).unwrap();
-                assert!(str::from_utf8(self.rx_buf.bytes()).unwrap() == self.msg);
-                event_loop.shutdown();
-            },
-            _ => ()
-        }
-    }
+    fn ready(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, events: Interest) {
 
-    fn writable(&mut self, _: &mut EventLoop<UdpHandler>, token: Token) {
-        match token {
-            SENDER => {
-                self.tx.send_to(&mut self.buf, &self.rx.local_addr().unwrap()).unwrap();
-            },
-            _ => {}
+        if events.is_readable() {
+            match token {
+                LISTENER => {
+                    debug!("We are receiving a datagram now...");
+                    self.rx.recv_from(&mut self.rx_buf).unwrap();
+                    assert!(str::from_utf8(self.rx_buf.bytes()).unwrap() == self.msg);
+                    event_loop.shutdown();
+                },
+                _ => ()
+            }
+        }
+
+        if events.is_writable() {
+            match token {
+                SENDER => {
+                    self.tx.send_to(&mut self.buf, &self.rx.local_addr().unwrap()).unwrap();
+                },
+                _ => {}
+            }
         }
     }
 }

--- a/test/test_unix_echo_server.rs
+++ b/test/test_unix_echo_server.rs
@@ -237,22 +237,22 @@ impl Handler for Echo {
     type Timeout = usize;
     type Message = ();
 
-    fn readable(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, hint: ReadHint) {
-        assert!(hint.is_data());
+    fn ready(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, events: Interest) {
+        if events.is_readable() {
+            match token {
+                SERVER => self.server.accept(event_loop).unwrap(),
+                CLIENT => self.client.readable(event_loop).unwrap(),
+                i => self.server.conn_readable(event_loop, i).unwrap()
+            };
+        }
 
-        match token {
-            SERVER => self.server.accept(event_loop).unwrap(),
-            CLIENT => self.client.readable(event_loop).unwrap(),
-            i => self.server.conn_readable(event_loop, i).unwrap()
-        };
-    }
-
-    fn writable(&mut self, event_loop: &mut EventLoop<Echo>, token: Token) {
-        match token {
-            SERVER => panic!("received writable for token 0"),
-            CLIENT => self.client.writable(event_loop).unwrap(),
-            _ => self.server.conn_writable(event_loop, token).unwrap()
-        };
+        if events.is_writable() {
+            match token {
+                SERVER => panic!("received writable for token 0"),
+                CLIENT => self.client.writable(event_loop).unwrap(),
+                _ => self.server.conn_writable(event_loop, token).unwrap()
+            };
+        }
     }
 }
 


### PR DESCRIPTION
~~*Note*: I am only able to test this on linux, so I am not sure if the kqueue impl works correctly. If someone on a bsd machine could test that would be fabulous.~~  Thanks, Travis

Major attractions:

* No more ReadHint, everything is included into Interest which is passed to ready()
* EventsIterator is now defined inside sys/unix (this is because epoll and kqueue use different data structures for their IoEvent iterator) 
* event_loop.poll now uses EventsIterator 
* All tests use the new ready() handler and all tests pass. 


Two potential issues: 

* Interest should probably be renamed, since it reflects both inbound and outbound event bitmasks. 
* In order to iterate through self.poll.events iterator from event_loop and pass &mut self into the handler, I had to move the events struct out poll temporarily during the poll() and then return it. I'm not totally stoked about this.  The other potential option is to use a loop {} until events.iter().next() returns None, and copy the contents out of each cell.  The 2nd option might be a tad faster, but is uglier :) One involves a guaranteed memcpy of the Events struct into and out of Poll.  The 2nd copies Token and Interest out of each event. 