### PR TITLE
Use `FromRawFd` from std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: false
 rust:
   - nightly
-  - 1.0.0
+  - 1.1.0
 
 os:
   - linux
@@ -27,7 +27,7 @@ deploy:
   upload-dir: mio/${TRAVIS_BRANCH}
   acl: public_read
   on:
-    condition: $TRAVIS_RUST_VERSION == "1.0.0" && $TRAVIS_OS_NAME == "linux"
+    condition: $TRAVIS_RUST_VERSION == "1.1.0" && $TRAVIS_OS_NAME == "linux"
     repo: carllerche/mio
     branch:
       - master

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -268,10 +268,7 @@ impl Evented for TcpListener {
  */
 
 #[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd};
-
-#[cfg(unix)]
-use unix::FromRawFd;
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 #[cfg(unix)]
 impl AsRawFd for TcpSocket {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -102,10 +102,7 @@ impl From<sys::UdpSocket> for UdpSocket {
  */
 
 #[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd};
-
-#[cfg(unix)]
-use unix::FromRawFd;
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 #[cfg(unix)]
 impl AsRawFd for UdpSocket {

--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -2,14 +2,6 @@ use {io, sys, Evented, Interest, Io, PollOpt, Selector, Token};
 use std::io::{Read, Write};
 use std::path::Path;
 
-/// A trait to express the ability to construct an object from a raw file descriptor.
-///
-/// Once `std::os::unix::io::FromRawFd` is stable, this will go away
-#[cfg(unix)]
-pub trait FromRawFd {
-    unsafe fn from_raw_fd(fd: RawFd) -> Self;
-}
-
 #[derive(Debug)]
 pub struct UnixSocket {
     sys: sys::UnixSocket,
@@ -258,7 +250,7 @@ impl From<Io> for PipeWriter {
  *
  */
 
-use std::os::unix::io::{RawFd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd, FromRawFd};
 
 impl AsRawFd for UnixSocket {
     fn as_raw_fd(&self) -> RawFd {

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -1,7 +1,6 @@
 use {io, Evented, Interest, PollOpt, Selector, Token};
-use unix::FromRawFd;
 use std::io::{Read, Write};
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 /*
  *

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,9 +1,8 @@
 use {io, Evented, Interest, Io, PollOpt, Selector, Token};
-use unix::FromRawFd;
 use sys::unix::{net, nix, Socket};
 use std::io::{Read, Write};
 use std::net::SocketAddr;
-use std::os::unix::io::{RawFd, AsRawFd};
+use std::os::unix::io::{RawFd, FromRawFd, AsRawFd};
 
 #[derive(Debug)]
 pub struct TcpSocket {

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,9 +1,8 @@
 use {io, Evented, Interest, Io, IpAddr, PollOpt, Selector, Token};
 use buf::{Buf, MutBuf};
-use unix::FromRawFd;
 use sys::unix::{net, nix, Socket};
 use std::net::SocketAddr;
-use std::os::unix::io::{RawFd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd, FromRawFd};
 
 #[derive(Debug)]
 pub struct UdpSocket {

--- a/src/sys/unix/uds.rs
+++ b/src/sys/unix/uds.rs
@@ -1,9 +1,8 @@
 use {io, Evented, Interest, Io, PollOpt, Selector, Token};
-use unix::FromRawFd;
 use sys::unix::{net, nix, Socket};
 use std::io::{Read, Write};
 use std::path::Path;
-use std::os::unix::io::{RawFd, AsRawFd};
+use std::os::unix::io::{RawFd, AsRawFd, FromRawFd};
 
 #[derive(Debug)]
 pub struct UnixSocket {


### PR DESCRIPTION
Now that the `FromRawFd` trait can be used from rust stable, I've removed the mio-specific `FromRawFd`. I've also updated the .travis.yml file to use rust 1.1, since this won't build on 1.0 anymore (incidentally: would it be a good idea to use `stable` instead of hard-coded version numbers?).