### PR TITLE
Coalesce readable & writable into `ready` event

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -133,78 +133,78 @@ impl fmt::Debug for PollOpt {
 }
 
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
-pub struct Interest(usize);
+pub struct EventSet(usize);
 
-impl Interest {
-    pub fn none() -> Interest {
-        Interest(0)
+impl EventSet {
+    pub fn none() -> EventSet {
+        EventSet(0)
     }
 
     #[inline]
-    pub fn readable() -> Interest {
-        Interest(0x001)
+    pub fn readable() -> EventSet {
+        EventSet(0x001)
     }
 
     #[inline]
-    pub fn writable() -> Interest {
-        Interest(0x002)
+    pub fn writable() -> EventSet {
+        EventSet(0x002)
     }
 
     #[inline]
-    pub fn error() -> Interest {
-        Interest(0x004)
+    pub fn error() -> EventSet {
+        EventSet(0x004)
     }
 
     #[inline]
-    pub fn hup() -> Interest {
-        Interest(0x008)
+    pub fn hup() -> EventSet {
+        EventSet(0x008)
     }
 
     #[inline]
-    pub fn hinted() -> Interest {
-        Interest(0x010)
+    pub fn hinted() -> EventSet {
+        EventSet(0x010)
     }
 
     #[inline]
-    pub fn all() -> Interest {
-        Interest::readable() |
-            Interest::writable() |
-            Interest::hup() |
-            Interest::error()
+    pub fn all() -> EventSet {
+        EventSet::readable() |
+            EventSet::writable() |
+            EventSet::hup() |
+            EventSet::error()
     }
 
     #[inline]
     pub fn is_readable(&self) -> bool {
-        self.contains(Interest::readable())
+        self.contains(EventSet::readable())
     }
 
     #[inline]
     pub fn is_writable(&self) -> bool {
-        self.contains(Interest::writable())
+        self.contains(EventSet::writable())
     }
 
     #[inline]
     pub fn is_error(&self) -> bool {
-        self.contains(Interest::error())
+        self.contains(EventSet::error())
     }
 
     #[inline]
     pub fn is_hup(&self) -> bool {
-        self.contains(Interest::hup())
+        self.contains(EventSet::hup())
     }
 
     #[inline]
     pub fn is_hinted(&self) -> bool {
-        self.contains(Interest::hinted())
+        self.contains(EventSet::hinted())
     }
 
     #[inline]
-    pub fn insert(&mut self, other: Interest) {
+    pub fn insert(&mut self, other: EventSet) {
         self.0 |= other.0;
     }
 
     #[inline]
-    pub fn remove(&mut self, other: Interest) {
+    pub fn remove(&mut self, other: EventSet) {
         self.0 &= !other.0;
     }
 
@@ -214,65 +214,65 @@ impl Interest {
     }
 
     #[inline]
-    pub fn contains(&self, other: Interest) -> bool {
+    pub fn contains(&self, other: EventSet) -> bool {
         (*self & other) == other
     }
 }
 
-impl ops::BitOr for Interest {
-    type Output = Interest;
+impl ops::BitOr for EventSet {
+    type Output = EventSet;
 
     #[inline]
-    fn bitor(self, other: Interest) -> Interest {
-        Interest(self.bits() | other.bits())
+    fn bitor(self, other: EventSet) -> EventSet {
+        EventSet(self.bits() | other.bits())
     }
 }
 
-impl ops::BitXor for Interest {
-    type Output = Interest;
+impl ops::BitXor for EventSet {
+    type Output = EventSet;
 
     #[inline]
-    fn bitxor(self, other: Interest) -> Interest {
-        Interest(self.bits() ^ other.bits())
+    fn bitxor(self, other: EventSet) -> EventSet {
+        EventSet(self.bits() ^ other.bits())
     }
 }
 
-impl ops::BitAnd for Interest {
-    type Output = Interest;
+impl ops::BitAnd for EventSet {
+    type Output = EventSet;
 
     #[inline]
-    fn bitand(self, other: Interest) -> Interest {
-        Interest(self.bits() & other.bits())
+    fn bitand(self, other: EventSet) -> EventSet {
+        EventSet(self.bits() & other.bits())
     }
 }
 
-impl ops::Sub for Interest {
-    type Output = Interest;
+impl ops::Sub for EventSet {
+    type Output = EventSet;
 
     #[inline]
-    fn sub(self, other: Interest) -> Interest {
-        Interest(self.bits() & !other.bits())
+    fn sub(self, other: EventSet) -> EventSet {
+        EventSet(self.bits() & !other.bits())
     }
 }
 
-impl ops::Not for Interest {
-    type Output = Interest;
+impl ops::Not for EventSet {
+    type Output = EventSet;
 
     #[inline]
-    fn not(self) -> Interest {
-        Interest(!self.bits() & Interest::all().bits())
+    fn not(self) -> EventSet {
+        EventSet(!self.bits() & EventSet::all().bits())
     }
 }
 
-impl fmt::Debug for Interest {
+impl fmt::Debug for EventSet {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut one = false;
         let flags = [
-            (Interest::readable(), "Readable"),
-            (Interest::writable(), "Writable"),
-            (Interest::error(),    "Error"),
-            (Interest::hup(),      "HupHint"),
-            (Interest::hinted(),   "Hinted")];
+            (EventSet::readable(), "Readable"),
+            (EventSet::writable(), "Writable"),
+            (EventSet::error(),    "Error"),
+            (EventSet::hup(),      "HupHint"),
+            (EventSet::hinted(),   "Hinted")];
 
         for &(flag, msg) in flags.iter() {
             if self.contains(flag) {
@@ -291,7 +291,7 @@ impl fmt::Debug for Interest {
 // Keep this struct internal to mio
 #[derive(Copy, Clone, Debug)]
 pub struct IoEvent {
-    pub kind: Interest,
+    pub kind: EventSet,
     pub token: Token
 }
 
@@ -303,7 +303,7 @@ pub struct IoEvent {
 /// Selector when they have events to report.
 impl IoEvent {
     /// Create a new IoEvent.
-    pub fn new(kind: Interest, token: Token) -> IoEvent {
+    pub fn new(kind: EventSet, token: Token) -> IoEvent {
         IoEvent {
             kind: kind,
             token: token,

--- a/src/event.rs
+++ b/src/event.rs
@@ -161,11 +161,6 @@ impl EventSet {
     }
 
     #[inline]
-    pub fn hinted() -> EventSet {
-        EventSet(0x010)
-    }
-
-    #[inline]
     pub fn all() -> EventSet {
         EventSet::readable() |
             EventSet::writable() |
@@ -191,11 +186,6 @@ impl EventSet {
     #[inline]
     pub fn is_hup(&self) -> bool {
         self.contains(EventSet::hup())
-    }
-
-    #[inline]
-    pub fn is_hinted(&self) -> bool {
-        self.contains(EventSet::hinted())
     }
 
     #[inline]
@@ -271,8 +261,7 @@ impl fmt::Debug for EventSet {
             (EventSet::readable(), "Readable"),
             (EventSet::writable(), "Writable"),
             (EventSet::error(),    "Error"),
-            (EventSet::hup(),      "HupHint"),
-            (EventSet::hinted(),   "Hinted")];
+            (EventSet::hup(),      "Hup")];
 
         for &(flag, msg) in flags.iter() {
             if self.contains(flag) {

--- a/src/event.rs
+++ b/src/event.rs
@@ -287,142 +287,12 @@ impl fmt::Debug for Interest {
     }
 }
 
-#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
-pub struct ReadHint(usize);
 
-impl ReadHint {
-    #[inline]
-    pub fn none() -> ReadHint {
-        ReadHint(0)
-    }
-
-    #[inline]
-    pub fn all() -> ReadHint {
-        ReadHint::data() | ReadHint::hup() | ReadHint::error()
-    }
-
-    #[inline]
-    pub fn data() -> ReadHint {
-        ReadHint(0x001)
-    }
-
-    #[inline]
-    pub fn hup() -> ReadHint {
-        ReadHint(0x002)
-    }
-
-    #[inline]
-    pub fn error() -> ReadHint {
-        ReadHint(0x004)
-    }
-
-    #[inline]
-    pub fn is_data(&self) -> bool {
-        self.contains(ReadHint::data())
-    }
-
-    #[inline]
-    pub fn is_hup(&self) -> bool {
-        self.contains(ReadHint::hup())
-    }
-
-    #[inline]
-    pub fn is_error(&self) -> bool {
-        self.contains(ReadHint::error())
-    }
-
-    #[inline]
-    pub fn insert(&mut self, other: ReadHint) {
-        self.0 |= other.0;
-    }
-
-    #[inline]
-    pub fn remove(&mut self, other: ReadHint) {
-        self.0 &= !other.0;
-    }
-
-    #[inline]
-    pub fn contains(&self, other: ReadHint) -> bool {
-        (*self & other) == other
-    }
-
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.0
-    }
-}
-
-impl ops::BitOr for ReadHint {
-    type Output = ReadHint;
-
-    #[inline]
-    fn bitor(self, other: ReadHint) -> ReadHint {
-        ReadHint(self.bits() | other.bits())
-    }
-}
-
-impl ops::BitXor for ReadHint {
-    type Output = ReadHint;
-
-    #[inline]
-    fn bitxor(self, other: ReadHint) -> ReadHint {
-        ReadHint(self.bits() ^ other.bits())
-    }
-}
-
-impl ops::BitAnd for ReadHint {
-    type Output = ReadHint;
-
-    #[inline]
-    fn bitand(self, other: ReadHint) -> ReadHint {
-        ReadHint(self.bits() & other.bits())
-    }
-}
-
-impl ops::Sub for ReadHint {
-    type Output = ReadHint;
-
-    #[inline]
-    fn sub(self, other: ReadHint) -> ReadHint {
-        ReadHint(self.bits() & !other.bits())
-    }
-}
-
-impl ops::Not for ReadHint {
-    type Output = ReadHint;
-
-    #[inline]
-    fn not(self) -> ReadHint {
-        ReadHint(!self.bits() & ReadHint::all().bits())
-    }
-}
-
-impl fmt::Debug for ReadHint {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let mut one = false;
-        let flags = [
-            (ReadHint::data(),  "DataHint"),
-            (ReadHint::hup(),   "HupHint"),
-            (ReadHint::error(), "ErrorHint")];
-
-        for &(flag, msg) in flags.iter() {
-            if self.contains(flag) {
-                if one { try!(write!(fmt, " | ")) }
-                try!(write!(fmt, "{}", msg));
-
-                one = true
-            }
-        }
-
-        Ok(())
-    }
-}
-
-
+// Keep this struct internal to mio
 #[derive(Copy, Clone, Debug)]
 pub struct IoEvent {
-    kind: Interest,
-    token: Token
+    pub kind: Interest,
+    pub token: Token
 }
 
 /// IoEvent represents the raw event that the OS-specific selector
@@ -433,56 +303,10 @@ pub struct IoEvent {
 /// Selector when they have events to report.
 impl IoEvent {
     /// Create a new IoEvent.
-    pub fn new(kind: Interest, token: usize) -> IoEvent {
+    pub fn new(kind: Interest, token: Token) -> IoEvent {
         IoEvent {
             kind: kind,
-            token: Token(token)
+            token: token,
         }
-    }
-
-    pub fn token(&self) -> Token {
-        self.token
-    }
-
-    /// Return an optional hint for a readable  handle. Currently,
-    /// this method supports the HupHint, which indicates that the
-    /// kernel reported that the remote side hung up. This allows a
-    /// consumer to avoid reading in order to discover the hangup.
-    pub fn read_hint(&self) -> ReadHint {
-        let mut hint = ReadHint::none();
-
-        // The backend doesn't support hinting
-        if !self.kind.is_hinted() {
-            return hint;
-        }
-
-        if self.kind.is_hup() {
-            hint = hint | ReadHint::hup();
-        }
-
-        if self.kind.is_readable() {
-            hint = hint | ReadHint::data();
-        }
-
-        if self.kind.is_error() {
-            hint = hint | ReadHint::error();
-        }
-
-        hint
-    }
-
-    /// This event indicated that the  handle is now readable
-    pub fn is_readable(&self) -> bool {
-        self.kind.is_readable() || self.kind.is_hup()
-    }
-
-    /// This event indicated that the  handle is now writable
-    pub fn is_writable(&self) -> bool {
-        self.kind.is_writable()
-    }
-
-    /// This event indicated that the  handle had an error
-    pub fn is_error(&self) -> bool {
-        self.kind.is_error()
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,4 +1,4 @@
-use {EventLoop, Interest, Token};
+use {EventLoop, EventSet, Token};
 
 #[allow(unused_variables)]
 pub trait Handler {
@@ -15,7 +15,7 @@ pub trait Handler {
     ///
     /// This function will only be invoked a single time per socket per event
     /// loop tick.
-    fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token, events: Interest) {
+    fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token, events: EventSet) {
     }
 
     /// Invoked when a message has been received via the event loop's channel.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,22 +1,32 @@
-use {EventLoop, ReadHint, Token};
+use {EventLoop, Interest, Token};
 
 #[allow(unused_variables)]
 pub trait Handler {
     type Timeout;
     type Message: Send;
 
-    fn readable(&mut self, event_loop: &mut EventLoop<Self>, token: Token, hint: ReadHint) {
+    /// Invoked when the socket represented by `token` is ready to be operated
+    /// on. `events` indicates the specific operations that are
+    /// ready to be performed.
+    ///
+    /// For example, when a TCP socket is ready to be read from, `events` will
+    /// have `readable` set. When the socket is ready to be written to,
+    /// `events` will have `writable` set.
+    ///
+    /// This function will only be invoked a single time per socket per event
+    /// loop tick.
+    fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token, events: Interest) {
     }
 
-    fn writable(&mut self, event_loop: &mut EventLoop<Self>, token: Token) {
-    }
-
+    /// Invoked when a message has been received via the event loop's channel.
     fn notify(&mut self, event_loop: &mut EventLoop<Self>, msg: Self::Message) {
     }
 
+    /// Invoked when a timeout has completed.
     fn timeout(&mut self, event_loop: &mut EventLoop<Self>, timeout: Self::Timeout) {
     }
 
+    /// Invoked when `EventLoop` has been interrupted by a signal interrupt.
     fn interrupted(&mut self, event_loop: &mut EventLoop<Self>) {
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,4 +1,4 @@
-use {Interest, Selector, PollOpt, Token};
+use {EventSet, Selector, PollOpt, Token};
 use buf::{Buf, MutBuf};
 
 // Re-export the io::Result / Error types for convenience
@@ -7,10 +7,10 @@ pub use std::io::{Read, Write, Result, Error};
 /// A value that may be registered with an `EventLoop`
 pub trait Evented {
     #[doc(hidden)]
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> Result<()>;
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> Result<()>;
 
     #[doc(hidden)]
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> Result<()>;
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> Result<()>;
 
     #[doc(hidden)]
     fn deregister(&self, selector: &mut Selector) -> Result<()>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!     type Timeout = ();
 //!     type Message = ();
 //!
-//!     fn ready(&mut self, event_loop: &mut EventLoop<MyHandler>, token: Token, _: Interest) {
+//!     fn ready(&mut self, event_loop: &mut EventLoop<MyHandler>, token: Token, _: EventSet) {
 //!         match token {
 //!             SERVER => {
 //!                 let MyHandler(ref mut server) = *self;
@@ -108,7 +108,7 @@ pub use buf::{
 };
 pub use event::{
     PollOpt,
-    Interest,
+    EventSet,
 };
 pub use event_loop::{
     EventLoop,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!     type Timeout = ();
 //!     type Message = ();
 //!
-//!     fn readable(&mut self, event_loop: &mut EventLoop<MyHandler>, token: Token, _: ReadHint) {
+//!     fn ready(&mut self, event_loop: &mut EventLoop<MyHandler>, token: Token, _: Interest) {
 //!         match token {
 //!             SERVER => {
 //!                 let MyHandler(ref mut server) = *self;
@@ -109,7 +109,6 @@ pub use buf::{
 pub use event::{
     PollOpt,
     Interest,
-    ReadHint,
 };
 pub use event_loop::{
     EventLoop,

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -1,4 +1,4 @@
-use {io, sys, Evented, Interest, PollOpt, Selector, Token};
+use {io, sys, Evented, EventSet, PollOpt, Selector, Token};
 use std::io::{Read, Write};
 use std::net::SocketAddr;
 
@@ -75,11 +75,11 @@ impl TcpSocket {
 }
 
 impl Evented for TcpSocket {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.reregister(selector, token, interest, opts)
     }
 
@@ -172,11 +172,11 @@ impl Write for TcpStream {
 }
 
 impl Evented for TcpStream {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.reregister(selector, token, interest, opts)
     }
 
@@ -248,11 +248,11 @@ impl From<sys::TcpSocket> for TcpListener {
 }
 
 impl Evented for TcpListener {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.reregister(selector, token, interest, opts)
     }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,4 +1,4 @@
-use {io, sys, Evented, Interest, IpAddr, PollOpt, Selector, Token};
+use {io, sys, Evented, EventSet, IpAddr, PollOpt, Selector, Token};
 use buf::{Buf, MutBuf};
 use std::net::SocketAddr;
 
@@ -76,11 +76,11 @@ impl UdpSocket {
 }
 
 impl Evented for UdpSocket {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.reregister(selector, token, interest, opts)
     }
 

--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -1,4 +1,4 @@
-use {io, sys, Evented, Interest, Io, PollOpt, Selector, Token};
+use {io, sys, Evented, EventSet, Io, PollOpt, Selector, Token};
 use std::io::{Read, Write};
 use std::path::Path;
 
@@ -38,11 +38,11 @@ impl UnixSocket {
 }
 
 impl Evented for UnixSocket {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.reregister(selector, token, interest, opts)
     }
 
@@ -98,11 +98,11 @@ impl Write for UnixStream {
 }
 
 impl Evented for UnixStream {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.reregister(selector, token, interest, opts)
     }
 
@@ -148,11 +148,11 @@ impl UnixListener {
 }
 
 impl Evented for UnixListener {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.reregister(selector, token, interest, opts)
     }
 
@@ -190,11 +190,11 @@ impl Read for PipeReader {
 }
 
 impl Evented for PipeReader {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.io.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.io.reregister(selector, token, interest, opts)
     }
 
@@ -225,11 +225,11 @@ impl Write for PipeWriter {
 }
 
 impl Evented for PipeWriter {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.io.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.io.reregister(selector, token, interest, opts)
     }
 

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,4 +1,4 @@
-use {sys, Evented, Interest, PollOpt, Selector, Token};
+use {sys, Evented, EventSet, PollOpt, Selector, Token};
 use util::BoundedQueue;
 use std::{fmt, cmp, io};
 use std::sync::Arc;
@@ -188,11 +188,11 @@ impl<M: Send> NotifyInner<M> {
 }
 
 impl<M: Send> Evented for Notify<M> {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.inner.awaken.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.inner.awaken.reregister(selector, token, interest, opts)
     }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -2,16 +2,18 @@ use {sys, Evented, Token};
 use event::{Interest, IoEvent, PollOpt};
 use std::{fmt, io};
 
+pub use sys::{Events};
+
 pub struct Poll {
     selector: sys::Selector,
-    events: sys::Events
+    events: sys::Events,
 }
 
 impl Poll {
     pub fn new() -> io::Result<Poll> {
         Ok(Poll {
             selector: try!(sys::Selector::new()),
-            events: sys::Events::new()
+            events: sys::Events::new(),
         })
     }
 
@@ -56,10 +58,6 @@ impl Poll {
     pub fn event(&self, idx: usize) -> IoEvent {
         self.events.get(idx)
     }
-
-    pub fn iter(&self) -> EventsIterator {
-        EventsIterator { events: &self.events, index: 0 }
-    }
 }
 
 impl fmt::Debug for Poll {
@@ -68,20 +66,3 @@ impl fmt::Debug for Poll {
     }
 }
 
-pub struct EventsIterator<'a> {
-    events: &'a sys::Events,
-    index: usize
-}
-
-impl<'a> Iterator for EventsIterator<'a> {
-    type Item = IoEvent;
-
-    fn next(&mut self) -> Option<IoEvent> {
-        if self.index == self.events.len() {
-            None
-        } else {
-            self.index += 1;
-            Some(self.events.get(self.index - 1))
-        }
-    }
-}

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,5 +1,5 @@
 use {sys, Evented, Token};
-use event::{Interest, IoEvent, PollOpt};
+use event::{EventSet, IoEvent, PollOpt};
 use std::{fmt, io};
 
 pub use sys::{Events};
@@ -17,7 +17,7 @@ impl Poll {
         })
     }
 
-    pub fn register<E: ?Sized>(&mut self, io: &E, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()>
+    pub fn register<E: ?Sized>(&mut self, io: &E, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()>
         where E: Evented
     {
         trace!("registering with poller");
@@ -28,7 +28,7 @@ impl Poll {
         Ok(())
     }
 
-    pub fn reregister<E: ?Sized>(&mut self, io: &E, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()>
+    pub fn reregister<E: ?Sized>(&mut self, io: &E, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()>
         where E: Evented
     {
         trace!("registering with poller");

--- a/src/sys/unix/awakener.rs
+++ b/src/sys/unix/awakener.rs
@@ -2,7 +2,7 @@ pub use self::pipe::Awakener;
 
 /// Default *nix awakener implementation
 mod pipe {
-    use {io, Evented, Interest, PollOpt, Selector, Token, TryRead, TryWrite};
+    use {io, Evented, EventSet, PollOpt, Selector, Token, TryRead, TryWrite};
     use unix::{self, PipeReader, PipeWriter};
     use std::mem;
     use std::cell::UnsafeCell;
@@ -62,11 +62,11 @@ mod pipe {
     }
 
     impl Evented for Awakener {
-        fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+        fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
             self.reader().register(selector, token, interest, opts)
         }
 
-        fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+        fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
             self.reader().reregister(selector, token, interest, opts)
         }
 

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -133,7 +133,7 @@ impl Events {
     #[inline]
     pub fn get(&self, idx: usize) -> IoEvent {
         let epoll = self.events[idx].events;
-        let mut kind = EventSet::hinted();
+        let mut kind = EventSet::none();
 
         if epoll.contains(EPOLLIN) {
             kind = kind | EventSet::readable();

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -120,7 +120,9 @@ pub struct Events {
 
 impl Events {
     pub fn new() -> Events {
-        Events { events: Vec::with_capacity(1024) }
+        Events {
+            events: Vec::with_capacity(1024),
+        }
     }
 
     #[inline]
@@ -130,10 +132,6 @@ impl Events {
 
     #[inline]
     pub fn get(&self, idx: usize) -> IoEvent {
-        if idx >= self.len() {
-            panic!("invalid index");
-        }
-
         let epoll = self.events[idx].events;
         let mut kind = Interest::hinted();
 
@@ -156,6 +154,6 @@ impl Events {
 
         let token = self.events[idx].data;
 
-        IoEvent::new(kind, token as usize)
+        IoEvent::new(kind, Token(token as usize))
     }
 }

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -1,4 +1,4 @@
-use {io, Evented, Interest, PollOpt, Selector, Token};
+use {io, Evented, EventSet, PollOpt, Selector, Token};
 use std::io::{Read, Write};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
@@ -38,11 +38,11 @@ impl AsRawFd for Io {
 }
 
 impl Evented for Io {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         selector.register(self.fd, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         selector.reregister(self.fd, token, interest, opts)
     }
 

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -139,11 +139,10 @@ impl Events {
 
             let idx = *self.event_map.entry(token)
                 .or_insert(len);
-                // .or_insert(IoEvent::new(EventSet::hinted(), token));
 
             if idx == len {
                 // New entry, insert the default
-                self.events.push(IoEvent::new(EventSet::hinted(), token));
+                self.events.push(IoEvent::new(EventSet::none(), token));
 
             }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,4 +1,4 @@
-use {io, Evented, Interest, Io, PollOpt, Selector, Token};
+use {io, Evented, EventSet, Io, PollOpt, Selector, Token};
 use sys::unix::{net, nix, Socket};
 use std::io::{Read, Write};
 use std::net::SocketAddr;
@@ -110,11 +110,11 @@ impl Write for TcpSocket {
 }
 
 impl Evented for TcpSocket {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.io.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.io.reregister(selector, token, interest, opts)
     }
 

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,4 +1,4 @@
-use {io, Evented, Interest, Io, IpAddr, PollOpt, Selector, Token};
+use {io, Evented, EventSet, Io, IpAddr, PollOpt, Selector, Token};
 use buf::{Buf, MutBuf};
 use sys::unix::{net, nix, Socket};
 use std::net::SocketAddr;
@@ -121,11 +121,11 @@ impl UdpSocket {
 }
 
 impl Evented for UdpSocket {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.io.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.io.reregister(selector, token, interest, opts)
     }
 

--- a/src/sys/unix/uds.rs
+++ b/src/sys/unix/uds.rs
@@ -1,4 +1,4 @@
-use {io, Evented, Interest, Io, PollOpt, Selector, Token};
+use {io, Evented, EventSet, Io, PollOpt, Selector, Token};
 use sys::unix::{net, nix, Socket};
 use std::io::{Read, Write};
 use std::path::Path;
@@ -64,11 +64,11 @@ impl Write for UnixSocket {
 }
 
 impl Evented for UnixSocket {
-    fn register(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.io.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: Interest, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.io.reregister(selector, token, interest, opts)
     }
 

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -167,22 +167,22 @@ impl Handler for Echo {
     type Timeout = usize;
     type Message = String;
 
-    fn readable(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, hint: ReadHint) {
-        assert_eq!(hint, ReadHint::data());
+    fn ready(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, events: Interest) {
 
-        match token {
-            SERVER => self.server.accept(event_loop).unwrap(),
-            CLIENT => self.client.readable(event_loop).unwrap(),
-            i => self.server.conn_readable(event_loop, i).unwrap()
-        };
-    }
-
-    fn writable(&mut self, event_loop: &mut EventLoop<Echo>, token: Token) {
-        match token {
-            SERVER => panic!("received writable for token 0"),
-            CLIENT => self.client.writable(event_loop).unwrap(),
-            _ => self.server.conn_writable(event_loop, token).unwrap()
-        };
+        if events.is_readable() {
+            match token {
+                SERVER => self.server.accept(event_loop).unwrap(),
+                CLIENT => self.client.readable(event_loop).unwrap(),
+                i => self.server.conn_readable(event_loop, i).unwrap()
+            }
+        }
+        if events.is_writable() {
+            match token {
+                SERVER => panic!("received writable for token 0"),
+                CLIENT => self.client.writable(event_loop).unwrap(),
+                _ => self.server.conn_writable(event_loop, token).unwrap()
+            }
+        }
     }
 
     fn notify(&mut self, event_loop: &mut EventLoop<Echo>, msg: String) {

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -30,7 +30,7 @@ impl EchoConn {
     }
 
     fn writable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
-        event_loop.reregister(&self.sock, self.token.unwrap(), Interest::readable(), PollOpt::edge() | PollOpt::oneshot())
+        event_loop.reregister(&self.sock, self.token.unwrap(), EventSet::readable(), PollOpt::edge() | PollOpt::oneshot())
     }
 
     fn readable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
@@ -55,7 +55,7 @@ impl EchoConn {
             };
         }
 
-        event_loop.reregister(&self.sock, self.token.unwrap(), Interest::readable(), PollOpt::edge() | PollOpt::oneshot())
+        event_loop.reregister(&self.sock, self.token.unwrap(), EventSet::readable(), PollOpt::edge() | PollOpt::oneshot())
     }
 }
 
@@ -75,7 +75,7 @@ impl EchoServer {
 
         // Register the connection
         self.conns[tok].token = Some(tok);
-        event_loop.register_opt(&self.conns[tok].sock, tok, Interest::readable(), PollOpt::edge() | PollOpt::oneshot())
+        event_loop.register_opt(&self.conns[tok].sock, tok, EventSet::readable(), PollOpt::edge() | PollOpt::oneshot())
             .ok().expect("could not register socket with event loop");
 
         Ok(())
@@ -139,7 +139,7 @@ impl EchoClient {
             }
         }
         if self.backlog.len() > 0 {
-            event_loop.reregister(&self.sock, self.token, Interest::writable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+            event_loop.reregister(&self.sock, self.token, EventSet::writable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
         }
 
         Ok(())
@@ -167,7 +167,7 @@ impl Handler for Echo {
     type Timeout = usize;
     type Message = String;
 
-    fn ready(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, events: Interest) {
+    fn ready(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, events: EventSet) {
 
         if events.is_readable() {
             match token {
@@ -199,7 +199,7 @@ impl Handler for Echo {
                 event_loop.reregister(
                     &self.client.sock,
                     self.client.token,
-                    Interest::writable(),
+                    EventSet::writable(),
                     PollOpt::edge() | PollOpt::oneshot()).unwrap();
             }
         }
@@ -231,13 +231,13 @@ pub fn test_echo_server() {
     let srv = srv.listen(256).unwrap();
 
     info!("listen for connections");
-    event_loop.register_opt(&srv, SERVER, Interest::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    event_loop.register_opt(&srv, SERVER, EventSet::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
     let (sock, _) = TcpSocket::v4().unwrap()
         .connect(&addr).unwrap();
 
     // Connect to the server
-    event_loop.register_opt(&sock, CLIENT, Interest::writable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    event_loop.register_opt(&sock, CLIENT, EventSet::writable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
     let chan = event_loop.channel();
 
     let go = move || {

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -27,7 +27,7 @@ impl UdpHandler {
         }
     }
 
-    fn handle_read(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, events: Interest) {
+    fn handle_read(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, events: EventSet) {
         match token {
             LISTENER => {
                 debug!("We are receiving a datagram now...");
@@ -44,7 +44,7 @@ impl UdpHandler {
         }
     }
 
-    fn handle_write(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, events: Interest) {
+    fn handle_write(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, events: EventSet) {
         match token {
             SENDER => {
                 self.tx.send_to(&mut self.buf, &self.rx.local_addr().unwrap()).unwrap();
@@ -58,7 +58,7 @@ impl Handler for UdpHandler {
     type Timeout = usize;
     type Message = ();
 
-    fn ready(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, events: Interest) {
+    fn ready(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, events: EventSet) {
         if events.is_readable() {
             self.handle_read(event_loop, token, events);
         }
@@ -87,10 +87,10 @@ pub fn test_multicast() {
     rx.join_multicast(&"227.1.1.101".parse().unwrap()).unwrap();
 
     info!("Registering SENDER");
-    event_loop.register_opt(&tx, SENDER, Interest::writable(), PollOpt::edge()).unwrap();
+    event_loop.register_opt(&tx, SENDER, EventSet::writable(), PollOpt::edge()).unwrap();
 
     info!("Registering LISTENER");
-    event_loop.register_opt(&rx, LISTENER, Interest::readable(), PollOpt::edge()).unwrap();
+    event_loop.register_opt(&rx, LISTENER, EventSet::readable(), PollOpt::edge()).unwrap();
 
     info!("Starting event loop to test with...");
     event_loop.run(&mut UdpHandler::new(tx, rx, "hello world")).unwrap();

--- a/test/test_notify.rs
+++ b/test/test_notify.rs
@@ -53,7 +53,7 @@ pub fn test_notify() {
 
     let srv = srv.listen(256).unwrap();
 
-    event_loop.register_opt(&srv, Token(0), Interest::all(), PollOpt::edge()).unwrap();
+    event_loop.register_opt(&srv, Token(0), EventSet::all(), PollOpt::edge()).unwrap();
 
     let sender = event_loop.channel();
 

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -51,7 +51,7 @@ impl TestHandler {
                         }
                     }
                     AfterRead => {
-                        assert_eq!(events, EventSet::readable() | EventSet::hup() | EventSet::hinted());
+                        assert_eq!(events, EventSet::readable() | EventSet::hup());
                         self.state = AfterHup;
                     }
                     AfterHup => panic!("Shouldn't get here"),

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -31,24 +31,27 @@ impl Handler for UdpHandler {
     type Timeout = usize;
     type Message = ();
 
-    fn readable(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, _: ReadHint) {
-        match token {
-            LISTENER => {
-                debug!("We are receiving a datagram now...");
-                self.rx.recv_from(&mut self.rx_buf).unwrap();
-                assert!(str::from_utf8(self.rx_buf.bytes()).unwrap() == self.msg);
-                event_loop.shutdown();
-            },
-            _ => ()
-        }
-    }
+    fn ready(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, events: Interest) {
 
-    fn writable(&mut self, _: &mut EventLoop<UdpHandler>, token: Token) {
-        match token {
-            SENDER => {
-                self.tx.send_to(&mut self.buf, &self.rx.local_addr().unwrap()).unwrap();
-            },
-            _ => {}
+        if events.is_readable() {
+            match token {
+                LISTENER => {
+                    debug!("We are receiving a datagram now...");
+                    self.rx.recv_from(&mut self.rx_buf).unwrap();
+                    assert!(str::from_utf8(self.rx_buf.bytes()).unwrap() == self.msg);
+                    event_loop.shutdown();
+                },
+                _ => ()
+            }
+        }
+
+        if events.is_writable() {
+            match token {
+                SENDER => {
+                    self.tx.send_to(&mut self.buf, &self.rx.local_addr().unwrap()).unwrap();
+                },
+                _ => {}
+            }
         }
     }
 }

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -31,7 +31,7 @@ impl Handler for UdpHandler {
     type Timeout = usize;
     type Message = ();
 
-    fn ready(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, events: Interest) {
+    fn ready(&mut self, event_loop: &mut EventLoop<UdpHandler>, token: Token, events: EventSet) {
 
         if events.is_readable() {
             match token {
@@ -72,10 +72,10 @@ pub fn test_udp_socket() {
     assert!(rx.recv_from(&mut MutSliceBuf::wrap(&mut buf)).unwrap().is_none());
 
     info!("Registering SENDER");
-    event_loop.register_opt(&tx, SENDER, Interest::writable(), PollOpt::edge()).unwrap();
+    event_loop.register_opt(&tx, SENDER, EventSet::writable(), PollOpt::edge()).unwrap();
 
     info!("Registering LISTENER");
-    event_loop.register_opt(&rx, LISTENER, Interest::readable(), PollOpt::edge()).unwrap();
+    event_loop.register_opt(&rx, LISTENER, EventSet::readable(), PollOpt::edge()).unwrap();
 
     info!("Starting event loop to test with...");
     event_loop.run(&mut UdpHandler::new(tx, rx, "hello world")).unwrap();

--- a/test/test_unix_echo_server.rs
+++ b/test/test_unix_echo_server.rs
@@ -237,22 +237,22 @@ impl Handler for Echo {
     type Timeout = usize;
     type Message = ();
 
-    fn readable(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, hint: ReadHint) {
-        assert!(hint.is_data());
+    fn ready(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, events: Interest) {
+        if events.is_readable() {
+            match token {
+                SERVER => self.server.accept(event_loop).unwrap(),
+                CLIENT => self.client.readable(event_loop).unwrap(),
+                i => self.server.conn_readable(event_loop, i).unwrap()
+            };
+        }
 
-        match token {
-            SERVER => self.server.accept(event_loop).unwrap(),
-            CLIENT => self.client.readable(event_loop).unwrap(),
-            i => self.server.conn_readable(event_loop, i).unwrap()
-        };
-    }
-
-    fn writable(&mut self, event_loop: &mut EventLoop<Echo>, token: Token) {
-        match token {
-            SERVER => panic!("received writable for token 0"),
-            CLIENT => self.client.writable(event_loop).unwrap(),
-            _ => self.server.conn_writable(event_loop, token).unwrap()
-        };
+        if events.is_writable() {
+            match token {
+                SERVER => panic!("received writable for token 0"),
+                CLIENT => self.client.writable(event_loop).unwrap(),
+                _ => self.server.conn_writable(event_loop, token).unwrap()
+            };
+        }
     }
 }
 


### PR DESCRIPTION
Having separate readable & writable events makes cleanly closing the socket
and freeing up resources a bit tricky. Instead, a single `ready` event is
used. The guarantees are that the event will be invoked only a single time per
socket per event loop tick.

Fixes #184