### PR TITLE
Introduce `Listener` trait.

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -69,6 +69,12 @@ impl<T: Write> TryWrite for T {
     }
 }
 
+pub trait TryAccept {
+    type Output;
+
+    fn accept(&self) -> Result<Option<Self::Output>>;
+}
+
 /*
  *
  * ===== Helpers =====

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ pub use io::{
     TryRead,
     TryWrite,
     Evented,
+    TryAccept,
 };
 pub use net::{
     tcp,

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -1,4 +1,4 @@
-use {io, sys, Evented, EventSet, PollOpt, Selector, Token};
+use {io, sys, Evented, EventSet, PollOpt, Selector, Token, TryAccept};
 use std::io::{Read, Write};
 use std::net::SocketAddr;
 
@@ -258,6 +258,14 @@ impl Evented for TcpListener {
 
     fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
         self.sys.deregister(selector)
+    }
+}
+
+impl TryAccept for TcpListener {
+    type Output = TcpStream;
+
+    fn accept(&self) -> io::Result<Option<TcpStream>> {
+        TcpListener::accept(self)
     }
 }
 

--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -1,4 +1,4 @@
-use {io, sys, Evented, EventSet, Io, PollOpt, Selector, Token};
+use {io, sys, Evented, EventSet, Io, PollOpt, Selector, Token, TryAccept};
 use std::io::{Read, Write};
 use std::path::Path;
 
@@ -158,6 +158,14 @@ impl Evented for UnixListener {
 
     fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
         self.sys.deregister(selector)
+    }
+}
+
+impl TryAccept for UnixListener {
+    type Output = UnixStream;
+
+    fn accept(&self) -> io::Result<Option<UnixStream>> {
+        UnixListener::accept(self)
     }
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,4 +1,4 @@
-use {io, Evented, EventSet, Io, PollOpt, Selector, Token};
+use {io, Evented, EventSet, Io, PollOpt, Selector, Token, TryAccept};
 use sys::unix::{net, nix, Socket};
 use std::io::{Read, Write};
 use std::net::SocketAddr;
@@ -120,6 +120,14 @@ impl Evented for TcpSocket {
 
     fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
         self.io.deregister(selector)
+    }
+}
+
+impl TryAccept for TcpSocket {
+    type Output = TcpSocket;
+
+    fn accept(&self) -> io::Result<Option<TcpSocket>> {
+        TcpSocket::accept(self)
     }
 }
 

--- a/src/sys/unix/uds.rs
+++ b/src/sys/unix/uds.rs
@@ -1,4 +1,4 @@
-use {io, Evented, EventSet, Io, PollOpt, Selector, Token};
+use {io, Evented, EventSet, Io, PollOpt, Selector, Token, TryAccept};
 use sys::unix::{net, nix, Socket};
 use std::io::{Read, Write};
 use std::path::Path;
@@ -74,6 +74,14 @@ impl Evented for UnixSocket {
 
     fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
         self.io.deregister(selector)
+    }
+}
+
+impl TryAccept for UnixSocket {
+    type Output = UnixSocket;
+
+    fn accept(&self) -> io::Result<Option<UnixSocket>> {
+        UnixSocket::accept(self)
     }
 }
 


### PR DESCRIPTION
As per discussion in #204.

Abstract `accept()` operation, so that `mioco` can have a generic wrapper over them.