### PR TITLE
Fix assumption about queue order. Fixes #216 .

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -314,6 +314,11 @@ impl<H: Handler> EventLoop<H> {
                     handler.notify(self, msg);
                     cnt -= 1;
                 },
+                // If we expect messages, but the queue seems empty, a context
+                // switch has occurred in the queue's push() method between
+                // reserving a slot and marking that slot; let's spin for
+                // what should be a very brief period of time until the push
+                // is done.
                 None => thread::yield_now(),
             }
         }


### PR DESCRIPTION
The mpmc queue can fill slots out of order if a context switch occurs
between "reserving" a slot and marking that slot as filled.

So, insertion into slot 2 can look successful (and cause mio to
increment its own queue length counts) before an insertion into slot 1
is fully committed.

So, then when mio actually reads the queue, it gets None, because
slot 1, the "next" slot, isn't completely done yet.  Yielding the
scheduler to other threads will allow the partially-committed slot
to finish committing, and the queue will eventually be seen as having
both elements, slots 1 and 2.