### PR TITLE
commit -> rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clock_ticks = "0.0.5"
 
 [dependencies.bytes]
 git = "https://github.com/carllerche/bytes"
-commit = "b4abd1431a"
+rev = "b4abd1431a"
 
 [dev-dependencies]
 env_logger = "0.3.0"


### PR DESCRIPTION
The right key to use to pin a Cargo git dependency is `rev`, not `commit`; this was causing mio to depend on the latest master of `"https://github.com/carllerche/bytes"`. Unfortunately Cargo doesn't seem to warn about the unused key in this case!