### PR TITLE
Implement Handler::tick()

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -263,6 +263,7 @@ impl<H: Handler> EventLoop<H> {
         self.io_process(handler, events);
         self.notify(handler, messages);
         self.timer_process(handler);
+        handler.tick(self);
         Ok(())
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -29,4 +29,8 @@ pub trait Handler: Sized {
     /// Invoked when `EventLoop` has been interrupted by a signal interrupt.
     fn interrupted(&mut self, event_loop: &mut EventLoop<Self>) {
     }
+
+    /// Invoked at the end of an event loop tick.
+    fn tick(&mut self, event_loop: &mut EventLoop<Self>) {
+    }
 }

--- a/test/test.rs
+++ b/test/test.rs
@@ -14,6 +14,7 @@ mod test_echo_server;
 mod test_multicast;
 mod test_notify;
 mod test_register_deregister;
+mod test_tick;
 mod test_timer;
 mod test_udp_socket;
 mod test_unix_echo_server;

--- a/test/test_tick.rs
+++ b/test/test_tick.rs
@@ -1,0 +1,59 @@
+use mio::*;
+use std::io::Write;
+
+struct TestHandler {
+    tick: usize,
+    state: usize,
+}
+
+impl TestHandler {
+    fn new() -> TestHandler {
+        TestHandler {
+            tick: 0,
+            state: 0,
+        }
+    }
+}
+
+impl Handler for TestHandler {
+    type Timeout = usize;
+    type Message = String;
+
+    fn tick(&mut self, _event_loop: &mut EventLoop<TestHandler>) {
+        debug!("Handler::tick()");
+        self.tick += 1;
+
+        assert_eq!(self.state, 1);
+        self.state = 0;
+    }
+
+    fn ready(&mut self, _event_loop: &mut EventLoop<TestHandler>, token: Token, events: EventSet) {
+        if events.is_readable() {
+            debug!("Handler::ready() readable event");
+            assert_eq!(token, Token(0));
+            assert_eq!(self.state, 0);
+            self.state = 1;
+        }
+    }
+}
+
+#[test]
+pub fn test_tick() {
+    debug!("Starting TEST_TICK");
+    let mut event_loop = EventLoop::new().ok().expect("Couldn't make event loop");
+
+    let (reader, mut writer) = unix::pipe().unwrap();
+
+    event_loop.register(&reader, Token(0)).unwrap();
+
+    let mut handler = TestHandler::new();
+    writer.write(&[0u8]).unwrap();
+
+    for _ in 0..2 {
+
+        event_loop.run_once(&mut handler).unwrap();
+    }
+
+    assert!(handler.tick == 2, "actual={}", handler.tick);
+    assert!(handler.state == 0, "actual={}", handler.state);
+}


### PR DESCRIPTION
The `Handler::tick()` method is called at the beginning of each event
loop tick.

Fixes #219