### PR TITLE
Remove UnsafeCell from Unix Awakener

### DIFF
--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -197,6 +197,12 @@ impl Read for PipeReader {
     }
 }
 
+impl<'a> Read for &'a PipeReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (&self.io).read(buf)
+    }
+}
+
 impl Evented for PipeReader {
     fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.io.register(selector, token, interest, opts)
@@ -229,6 +235,16 @@ impl Write for PipeWriter {
 
     fn flush(&mut self) -> io::Result<()> {
         self.io.flush()
+    }
+}
+
+impl<'a> Write for &'a PipeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        (&self.io).write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        (&self.io).flush()
     }
 }
 

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -53,6 +53,12 @@ impl Evented for Io {
 
 impl Read for Io {
     fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        <&Io as Read>::read(&mut &*self, dst)
+    }
+}
+
+impl<'a> Read for &'a Io {
+    fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
         use nix::unistd::read;
 
         read(self.as_raw_fd(), dst)
@@ -61,6 +67,16 @@ impl Read for Io {
 }
 
 impl Write for Io {
+    fn write(&mut self, src: &[u8]) -> io::Result<usize> {
+        <&Io as Write>::write(&mut &*self, src)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> Write for &'a Io {
     fn write(&mut self, src: &[u8]) -> io::Result<usize> {
         use nix::unistd::write;
 


### PR DESCRIPTION
Add some impls of Read/Write for `&T` (like the stdlib does) to express that a
mutable borrow isn't needed, allowing removal of the unsafe cells in the
awakener.