### PR TITLE
Add missing trait annotations for rust nightly

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,7 +1,7 @@
 use {EventLoop, EventSet, Token};
 
 #[allow(unused_variables)]
-pub trait Handler {
+pub trait Handler: Sized {
     type Timeout;
     type Message: Send;
 

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -59,7 +59,7 @@ impl<M: Send> Clone for Notify<M> {
     }
 }
 
-impl<M> fmt::Debug for Notify<M> {
+impl<M: Send> fmt::Debug for Notify<M> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "Notify<?>")
     }


### PR DESCRIPTION
Warnings about these started appearning on nightly and they'll eventually turn
into hard errors, so may as well fix them now!