### PR TITLE
Preliminary Windows TCP/UDP support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,18 +22,24 @@ log   = "0.3.1"
 nix   = "0.3.9"
 libc  = "0.1.8"
 slab  = "0.1.0"
-winapi = "0.1.23"
 clock_ticks = "0.0.5"
-
-[dependencies.bytes]
-git = "https://github.com/carllerche/bytes"
-rev = "7edb577d0a"
+bytes = { git = "https://github.com/carllerche/bytes", rev = "7edb577d0a" }
+winapi = "0.2.1"
+wio = { git = "https://github.com/alexcrichton/wio" }
+net2 = "0.2.7"
 
 [dev-dependencies]
 env_logger = "0.3.0"
 tempdir    = "0.3.4"
 
 [[test]]
-
 name = "test"
 path = "test/test.rs"
+
+[[test]]
+name = "tcp"
+path = "test/tcp.rs"
+
+[[test]]
+name = "smoke"
+path = "test/smoke.rs"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+environment:
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+  - TARGET: i686-pc-windows-msvc
+  - TARGET: i686-pc-windows-gnu
+install:
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
+  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - SET PATH=%PATH%;C:\MinGW\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo test

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -375,6 +375,7 @@ impl<M: Send> Sender<M> {
 }
 
 #[cfg(test)]
+#[cfg(unix)]
 mod tests {
     use std::str;
     use std::sync::Arc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@
 //! // for which socket.
 //! const SERVER: Token = Token(0);
 //! const CLIENT: Token = Token(1);
+//! #
+//! # // level() isn't implemented on windows yet
+//! # if cfg!(windows) { return }
 //!
 //! let addr = "127.0.0.1:13265".parse().unwrap();
 //!
@@ -75,13 +78,19 @@
 //! ```
 
 #![crate_name = "mio"]
-#![deny(warnings)]
+#![cfg_attr(unix, deny(warnings))]
 
 extern crate bytes;
-extern crate nix;
 extern crate clock_ticks;
 extern crate slab;
 extern crate libc;
+
+#[cfg(unix)]
+extern crate nix;
+
+extern crate winapi;
+extern crate wio;
+extern crate net2;
 
 #[macro_use]
 extern crate log;
@@ -144,10 +153,9 @@ pub use timer::{
 pub use token::{
     Token,
 };
-pub use sys::{
-    Io,
-    Selector,
-};
+#[cfg(unix)]
+pub use sys::Io;
+pub use sys::Selector;
 
 pub mod prelude {
     pub use super::{

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -12,3 +12,15 @@ pub use self::unix::{
 
 #[cfg(unix)]
 mod unix;
+
+#[cfg(windows)]
+pub use self::windows::{
+    Awakener,
+    Events,
+    Selector,
+    TcpSocket,
+    UdpSocket,
+};
+
+#[cfg(windows)]
+mod windows;

--- a/src/sys/windows/awakener.rs
+++ b/src/sys/windows/awakener.rs
@@ -1,0 +1,63 @@
+use std::sync::{Mutex, Arc};
+
+use {io, Evented, EventSet, PollOpt, Selector, Token};
+use sys::windows::selector::SelectorInner;
+use wio::iocp::CompletionStatus;
+
+pub struct Awakener {
+    iocp: Mutex<Option<Registration>>,
+}
+
+struct Registration {
+    iocp: Arc<SelectorInner>,
+    token: Token,
+}
+
+impl Awakener {
+    pub fn new() -> io::Result<Awakener> {
+        Ok(Awakener {
+            iocp: Mutex::new(None),
+        })
+    }
+
+    pub fn wakeup(&self) -> io::Result<()> {
+        // Each wakeup notification has NULL as its `OVERLAPPED` pointer to
+        // indicate that it's from this awakener and not part of an I/O
+        // operation. This is specially recognized by the selector.
+        //
+        // If we haven't been registered with an event loop yet just silently
+        // succeed.
+        let iocp = self.iocp.lock().unwrap();
+        if let Some(ref r) = *iocp {
+            let status = CompletionStatus::new(0, r.token.as_usize(),
+                                               0 as *mut _);
+            try!(r.iocp.port().post(status));
+        }
+        Ok(())
+    }
+
+    pub fn cleanup(&self) {
+        // noop
+    }
+}
+
+impl Evented for Awakener {
+    fn register(&self, selector: &mut Selector, token: Token, _events: EventSet,
+                _opts: PollOpt) -> io::Result<()> {
+        *self.iocp.lock().unwrap() = Some(Registration {
+            iocp: selector.inner().clone(),
+            token: token,
+        });
+        Ok(())
+    }
+
+    fn reregister(&self, selector: &mut Selector, token: Token, events: EventSet,
+                  opts: PollOpt) -> io::Result<()> {
+        self.register(selector, token, events, opts)
+    }
+
+    fn deregister(&self, _selector: &mut Selector) -> io::Result<()> {
+        *self.iocp.lock().unwrap() = None;
+        Ok(())
+    }
+}

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1,0 +1,160 @@
+//! Implementation of mio for Windows using IOCP
+//!
+//! This module uses I/O Completion Ports (IOCP) on Windows to implement mio's
+//! Unix epoll-like interface. Unfortunately these two I/O models are
+//! fundamentally incompatible:
+//!
+//! * IOCP is a completion-based model where work is submitted to the kernel and
+//!   a program is notified later when the work finished.
+//! * epoll is a readiness-based model where the kernel is queried as to what
+//!   work can be done, and afterwards the work is done.
+//!
+//! As a result, this implementation for Windows is much less "low level" than
+//! the Unix implementation of mio. This design decision was intentional,
+//! however.
+//!
+//! ## What is IOCP?
+//!
+//! The [official docs][docs] have a comprehensive explanation of what IOCP is,
+//! but at a high level it requires the following operations to be executed to
+//! perform some I/O:
+//!
+//! 1. A completion port is created
+//! 2. An I/O handle and a token is registered with this completion port
+//! 3. Some I/O is issued on the handle. This generally means that an API was
+//!    invoked with a zeroed `OVERLAPPED` structure. The API will immediately
+//!    return.
+//! 4. After some time, the application queries the I/O port for completed
+//!    events. The port will returned a pointer to the `OVERLAPPED` along with
+//!    the token presented at registration time.
+//!
+//! Many I/O operations can be fired off before waiting on a port, and the port
+//! will block execution of the calling thread until an I/O event has completed
+//! (or a timeout has elapsed).
+//!
+//! Currently all of these low-level operations are housed in a separate `wio`
+//! crate to provide a 0-cost abstraction over IOCP. This crate uses that to
+//! implement all fiddly bits so there's very few actual Windows API calls or
+//! `unsafe` blocks as a result.
+//!
+//! [docs]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365198%28v=vs.85%29.aspx
+//!
+//! ## Safety of IOCP
+//!
+//! Unfortunately for us, IOCP is pretty unsafe in terms of Rust lifetimes and
+//! such. When an I/O operation is submitted to the kernel, it involves handing
+//! the kernel a few pointers like a buffer to read/write, an `OVERLAPPED`
+//! structure pointer, and perhaps some other buffers such as for socket
+//! addresses. These pointers all have to remain valid **for the entire I/O
+//! operation's duration**.
+//!
+//! There's 0-cost way to define a safe lifetime for these pointers/buffers over
+//! the span of an I/O operation, so we're forced to add a layer of abstraction
+//! (not 0-cost) to make these APIs safe. Currently this implementation
+//! basically just boxes everything up on the heap to give it a stable address
+//! and then keys of that most of the time.
+//!
+//! ## From completion to readiness
+//!
+//! Translating a completion-based model to a readiness-based model is also no
+//! easy task, and a significant portion of this implementation is managing this
+//! translation. The basic idea behind this implementation is to issue I/O
+//! operations preemptively and then translate their completions to a "I'm
+//! ready" event.
+//!
+//! For example, in the case of reading a `TcpSocket`, as soon as a socket is
+//! connected (or registered after an accept) a read operation is executed.
+//! While the read is in progress calls to `read` will return `WouldBlock`, and
+//! once the read is completed we translate the completion notification into a
+//! `readable` event. Once the internal buffer is drained (e.g. all data from it
+//! has been read) a read operation is re-issued.
+//!
+//! Write operations are a little different from reads, and the current
+//! implementation is to just schedule a write as soon as `write` is first
+//! called. While that write operation is in progress all future calls to
+//! `write` will return `WouldBlock`. Completion of the write then translates to
+//! a `writable` event. Note that this will probably want to add some layer of
+//! internal buffering in the future.
+//!
+//! ## Buffer Management
+//!
+//! As there's lots of I/O operations in flight at any one point in time,
+//! there's lots of live buffers that need to be juggled around (e.g. this
+//! implementaiton's own internal buffers).
+//!
+//! Currently all buffers are created for the I/O operation at hand and are then
+//! discarded when it completes (this is listed as future work below).
+//!
+//! ## Callback Management
+//!
+//! When the main event loop receives a notification that an I/O operation has
+//! completed, some work needs to be done to translate that to a set of events
+//! or perhaps some more I/O needs to be scheduled. For example after a
+//! `TcpStream` is connected it generates a writable event and also schedules a
+//! read.
+//!
+//! To manage all this the `Selector` maintains an internal hash map of I/O
+//! operations to callbacks, and the callbacks are invoked whenever the
+//! operation completes.
+//!
+//! ## Thread Safety
+//!
+//! Currently all of the I/O primitives make liberal use of `Arc` and `Mutex`
+//! as an implementation detail. The main reason for this is to ensure that the
+//! types are `Send` and `Sync`, but the implementations have not been stressed
+//! in multithreaded situations yet. As a result, there are bound to be
+//! functional surprises in using these concurrently.
+//!
+//! ## Future Work
+//!
+//! First up, let's take a look at unimplemented portions of this module:
+//!
+//! * The `PollOpt::level()` option is currently entirely unimplemented.
+//! * Each `EventLoop` currently owns its completion port, but this prevents an
+//!   I/O handle from being added to multiple event loops (something that can be
+//!   done on Unix). Additionally, it hinders event loops moving across threads.
+//!   This should be solved by likely having a global `Selector` which all
+//!   others then communicate with.
+//! * Although Unix sockets don't exist on Windows, there are named pipes and
+//!   those should likely be bound here in a similar fashion to `TcpStream`.
+//!
+//! Next up, there are a few performance improvements and optimizations that can
+//! still be implemented
+//!
+//! * Buffer management right now is pretty bad, they're all just allocated
+//!   right before an I/O operation and discarded right after. There should at
+//!   least be some form of buffering buffers.
+//! * No calls to `write` are internally buffered before being scheduled, which
+//!   means that writing performance is abysmal compared to Unix. There should
+//!   be some level of buffering of writes probably.
+//! * All callbacks are stored as `Box<FnOnce(...)>`, but these should ideally
+//!   be `Arc<Fn(...)>` to avoid these extraneous `Box` allocations.
+
+use std::io;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+mod awakener;
+mod selector;
+mod tcp;
+mod udp;
+
+pub use self::awakener::Awakener;
+pub use self::selector::{Events, Selector};
+pub use self::tcp::TcpSocket;
+pub use self::udp::UdpSocket;
+
+#[derive(Copy, Clone)]
+enum Family {
+    V4, V6,
+}
+
+fn bad_state() -> io::Error {
+    io::Error::new(io::ErrorKind::Other, "bad state to make this function call")
+}
+
+fn wouldblock() -> io::Error {
+    io::Error::new(io::ErrorKind::WouldBlock, "operation would block")
+}
+
+fn ipv4_any() -> Ipv4Addr { Ipv4Addr::new(0, 0, 0, 0) }
+fn ipv6_any() -> Ipv6Addr { Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0) }

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -1,0 +1,355 @@
+use std::collections::hash_map::{HashMap, Entry};
+use std::io;
+use std::mem;
+use std::os::windows::prelude::*;
+use std::sync::{Arc, Mutex};
+
+use slab::Index;
+use winapi::*;
+use wio::Overlapped;
+use wio::iocp::{CompletionPort, CompletionStatus};
+
+use {Token, PollOpt};
+use event::{IoEvent, EventSet};
+
+/// The guts of the Windows event loop, this is the struct which actually owns
+/// a completion port.
+///
+/// Internally this is just an `Arc`, and this allows handing out references to
+/// the internals to I/O handles registered on this selector. This is
+/// required to schedule I/O operations independently of being inside the event
+/// loop (e.g. when a call to `write` is seen we're not "in the event loop").
+pub struct Selector {
+    inner: Arc<SelectorInner>,
+}
+
+pub struct SelectorInner {
+    /// The actual completion port that's used to manage all I/O
+    port: CompletionPort,
+
+    /// A list of all registered handles with this selector.
+    ///
+    /// The key of this map is either a `SOCKET` or a `HANDLE`, and the value is
+    /// `None` if the handle was registered with `oneshot` and it expired, or
+    /// `Some` if the handle is registered and receiving events.
+    handles: Mutex<HashMap<usize, Option<Registration>>>,
+
+    /// A list of all active I/O operations currently on this selector.
+    ///
+    /// The key of this map is the address of the `OVERLAPPED` operation and the
+    /// value is a completion callback to be invoked when it's done. Using raw
+    /// pointers as keys here should be ok for two reasons:
+    ///
+    /// 1. The kernel already requires that the pointer to the `OVERLAPPED` is
+    ///    stable and valid for the entire duration of the I/O operation.
+    /// 2. It is required that an `OVERLAPPED` instance is associated with at
+    ///    most one concurrent I/O operation.
+    ///
+    /// Consequently, an `OVERLAPPED` pointer should uniquely identify a pending
+    /// I/O request and be valid while it's running.
+    io: Mutex<HashMap<usize, Box<Callback>>>,
+
+    /// A list of deferred events to be generated on the next call to `select`.
+    ///
+    /// Events can sometimes be generated without an associated I/O operation
+    /// having completed, and this list is emptied out and returned on each turn
+    /// of the event loop.
+    defers: Mutex<Vec<(usize, EventSet, Token)>>,
+}
+
+#[derive(Copy, Clone)]
+struct Registration {
+    token: Token,
+    opts: PollOpt,
+    interest: EventSet,
+}
+
+impl Selector {
+    pub fn new() -> io::Result<Selector> {
+        CompletionPort::new(1).map(|cp| {
+            Selector {
+                inner: Arc::new(SelectorInner {
+                    port: cp,
+                    handles: Mutex::new(HashMap::new()),
+                    io: Mutex::new(HashMap::new()),
+                    defers: Mutex::new(Vec::new()),
+                }),
+            }
+        })
+    }
+
+    pub fn select(&mut self,
+                  events: &mut Events,
+                  timeout_ms: usize) -> io::Result<()> {
+        // If we have some deferred events then we only want to poll for I/O
+        // events, so clamp the timeout to 0 in that case.
+        let timeout = if self.inner.defers.lock().unwrap().len() > 0 {
+            0
+        } else {
+            timeout_ms as u32
+        };
+
+        // Clear out the previous list of I/O events and get some more!
+        events.events.truncate(0);
+        let inner = self.inner.clone();
+        let n = match inner.port.get_many(&mut events.statuses, Some(timeout)) {
+            Ok(statuses) => statuses.len(),
+            Err(ref e) if e.raw_os_error() == Some(WAIT_TIMEOUT as i32) => 0,
+            Err(e) => return Err(e),
+        };
+
+        // First up, process all completed I/O events. Lookup the callback
+        // associated with the I/O and invoke it. Also, carefully don't hold any
+        // locks while we invoke a callback in case more I/O is scheduled to
+        // prevent deadlock.
+        //
+        // Note that if we see an I/O completion with a null OVERLAPPED pointer
+        // then it means it was our awakener, so just generate a readable
+        // notification for it and carry on.
+        let dst = &mut events.events;
+        for status in events.statuses[..n].iter_mut() {
+            if status.overlapped() as usize == 0 {
+                dst.push(IoEvent::new(EventSet::readable(),
+                                      Token(status.token())));
+                continue
+            }
+
+            let callback = inner.io.lock().unwrap()
+                                .remove(&(status.overlapped() as usize))
+                                .expect("I/O finished with no handler");
+            callback.call(status, &mut |handle, set| {
+                inner.push_event(dst, handle, set, Token(status.token()));
+            }, self);
+        }
+
+        // Finally, clear out the list of deferred events and process them all
+        // here.
+        let defers = mem::replace(&mut *inner.defers.lock().unwrap(), Vec::new());
+        for (handle, set, token) in defers {
+            inner.push_event(dst, handle as HANDLE, set, token);
+        }
+        Ok(())
+    }
+
+    pub fn inner(&self) -> &Arc<SelectorInner> { &self.inner }
+}
+
+impl SelectorInner {
+    pub fn port(&self) -> &CompletionPort { &self.port }
+
+    /// Given a handle, token, and an event set describing how its ready,
+    /// translate that to an `IoEvent` and process accordingly.
+    ///
+    /// This function will mask out all ignored events (e.g. ignore `writable`
+    /// events if they weren't requested) and also handle properties such as
+    /// `oneshot`.
+    ///
+    /// Eventually this function will probably also be modified to handle the
+    /// `level()` polling option.
+    fn push_event(&self, events: &mut Vec<IoEvent>, handle: HANDLE,
+                  set: EventSet, token: Token) {
+        // A vacant handle means it's been deregistered, so just skip this
+        // event.
+        let mut handles = self.handles.lock().unwrap();
+        let mut e = match handles.entry(handle as usize) {
+            Entry::Vacant(..) => return,
+            Entry::Occupied(e) => e,
+        };
+
+        // A handle in the map without a registration is one that's become idle
+        // as a result of a `oneshot`, so just use a registration that will turn
+        // this function into a noop.
+        let reg = e.get().unwrap_or(Registration {
+            token: Token(0),
+            interest: EventSet::none(),
+            opts: PollOpt::oneshot(),
+        });
+
+        // If we're not actually interested in any of these events,
+        // discard the event, and then if we're actually delivering an event we
+        // stop listening if it's also a oneshot.
+        let set = reg.interest & set;
+        if set != EventSet::none() {
+            events.push(IoEvent::new(set, token));
+
+            if reg.opts.is_oneshot() {
+                trace!("deregistering because of oneshot");
+                e.insert(None);
+            }
+        }
+    }
+
+    pub fn register_socket(&self, socket: &AsRawSocket, token: Token,
+                           interest: EventSet, opts: PollOpt)
+                           -> io::Result<()> {
+        if opts.contains(PollOpt::level()) {
+            return Err(io::Error::new(io::ErrorKind::Other,
+                                      "level opt not implemented on windows"))
+        } else if !opts.contains(PollOpt::edge()) {
+            return Err(other("must have edge opt"))
+        }
+
+        let mut handles = self.handles.lock().unwrap();
+        match handles.entry(socket.as_raw_socket() as usize) {
+            Entry::Occupied(..) => return Err(other("socket already registered")),
+            Entry::Vacant(v) => {
+                try!(self.port.add_socket(token.as_usize(), socket));
+                v.insert(Some(Registration {
+                    token: token,
+                    interest: set2mask(interest),
+                    opts: opts,
+                }));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn reregister_socket(&self, socket: &AsRawSocket, token: Token,
+                             interest: EventSet, opts: PollOpt)
+                             -> io::Result<()> {
+        if opts.contains(PollOpt::level()) {
+            return Err(io::Error::new(io::ErrorKind::Other,
+                                      "level opt not implemented on windows"))
+        } else if !opts.contains(PollOpt::edge()) {
+            return Err(other("must have edge opt"))
+        }
+
+        let mut handles = self.handles.lock().unwrap();
+        match handles.entry(socket.as_raw_socket() as usize) {
+            Entry::Vacant(..) => return Err(other("socket not registered")),
+            Entry::Occupied(mut v) => {
+                match v.get().as_ref().map(|t| t.token) {
+                    Some(t) if t == token => {}
+                    Some(..) => return Err(other("cannot change tokens")),
+                    None => {}
+                }
+                v.insert(Some(Registration {
+                    token: token,
+                    interest: set2mask(interest),
+                    opts: opts,
+                }));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn deregister_socket(&self, socket: &AsRawSocket) -> io::Result<()> {
+        // Note that we can't actually deregister the socket from the completion
+        // port here, so we just remove our own internal metadata about it.
+        let mut handles = self.handles.lock().unwrap();
+        match handles.entry(socket.as_raw_socket() as usize) {
+            Entry::Vacant(..) => return Err(other("socket not registered")),
+            Entry::Occupied(v) => { v.remove(); }
+        }
+        Ok(())
+    }
+
+    /// Schedules some events for a handle to be delivered on the next turn of
+    /// the event loop (without an associated I/O event).
+    ///
+    /// This function will discard this if:
+    ///
+    /// * The handle has been de-registered
+    /// * The handle doesn't have an active registration (e.g. its oneshot
+    ///   expired)
+    pub fn defer(&self, handle: HANDLE, set: EventSet) {
+        debug!("defer {:?} {:?}", handle, set);
+        let handles = self.handles.lock().unwrap();
+        let reg = handles.get(&(handle as usize)).and_then(|t| t.as_ref())
+                         .map(|t| t.token);
+        let token = match reg {
+            Some(token) => token,
+            None => return,
+        };
+        self.defers.lock().unwrap().push((handle as usize, set, token));
+    }
+
+    /// Register a callback to be executed after some I/O has been issued.
+    ///
+    /// Callbacks are keyed off the `OVERLAPPED` pointer (or in this case
+    /// `wio::Overlapped`). The arguments to the callback are:
+    ///
+    /// * The status of the I/O operation (e.g. number of bytes transferred)
+    /// * A thunk to invoke to generate `IoEvent` structures
+    /// * The outer selector at the time of the I/O completion
+    pub fn register<F>(&self, overlapped: *mut Overlapped, handler: F)
+        where F: FnOnce(&CompletionStatus, &mut FnMut(HANDLE, EventSet),
+                        &mut Selector) +
+                 Send + Sync + 'static
+    {
+        let prev = self.io.lock().unwrap()
+                       .insert(overlapped as usize, Box::new(handler));
+        debug_assert!(prev.is_none());
+    }
+}
+
+/// From a given interest set return the event set mask used to generate events.
+///
+/// The only currently interesting thing this function does is ensure that hup
+/// events are generated for interests that only include the readable event.
+fn set2mask(e: EventSet) -> EventSet {
+    if e.is_readable() {
+        e | EventSet::hup()
+    } else {
+        e
+    }
+}
+
+fn other(s: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, s)
+}
+
+#[derive(Debug)]
+pub struct Events {
+    /// Raw I/O event completions are filled in here by the call to `get_many`
+    /// on the completion port above. These are then postprocessed into the
+    /// vector below.
+    statuses: Box<[CompletionStatus]>,
+
+    /// Literal events returned by `get` to the upwards `EventLoop`
+    events: Vec<IoEvent>,
+}
+
+impl Events {
+    pub fn new() -> Events {
+        // Use a nice large space for receiving I/O events (currently the same
+        // as unix's 1024) and then also prepare the output vector to have the
+        // same space.
+        //
+        // Note that it's possible for the output `events` to grow beyond 1024
+        // capacity as it can also include deferred events, but that's certainly
+        // not the end of the world!
+        Events {
+            statuses: vec![CompletionStatus::zero(); 1024].into_boxed_slice(),
+            events: Vec::with_capacity(1024),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    pub fn get(&self, idx: usize) -> IoEvent {
+        self.events[idx]
+    }
+}
+
+trait Callback: Send + Sync + 'static {
+    fn call(self: Box<Self>, status: &CompletionStatus,
+            push: &mut FnMut(HANDLE, EventSet),
+            selector: &mut Selector);
+}
+
+impl<F> Callback for F
+    where F: FnOnce(&CompletionStatus, &mut FnMut(HANDLE, EventSet),
+                    &mut Selector) +
+             Send + Sync + 'static
+{
+    fn call(self: Box<Self>, status: &CompletionStatus,
+            push: &mut FnMut(HANDLE, EventSet),
+            selector: &mut Selector) {
+        (*self)(status, push, selector)
+    }
+}

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -1,0 +1,590 @@
+use std::fmt;
+use std::io::{self, Read, Write, Cursor};
+use std::mem;
+use std::net::{SocketAddrV4, SocketAddrV6};
+use std::net::{self, SocketAddr, TcpStream, TcpListener};
+use std::os::windows::prelude::*;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use net2::{self, TcpBuilder};
+use net::tcp::Shutdown;
+use wio::net::*;
+use wio::Overlapped;
+use winapi::*;
+
+use {Evented, EventSet, PollOpt, Selector, Token};
+use sys::windows::selector::SelectorInner;
+use sys::windows::{bad_state, wouldblock, Family};
+
+pub struct TcpSocket {
+    /// Separately stored implementation to ensure that the `Drop`
+    /// implementation on this type is only executed when it's actually dropped
+    /// (many clones of this `imp` are made).
+    imp: Imp,
+}
+
+#[derive(Clone)]
+struct Imp {
+    /// A stable address and synchronized access for all internals. This serves
+    /// to ensure that all `Overlapped` pointers are valid for a long period of
+    /// time as well as allowing completion callbacks to have access to the
+    /// internals without having ownership.
+    inner: Arc<Mutex<Inner>>,
+    family: Family,
+}
+
+struct Inner {
+    socket: Socket,
+    iocp: Option<Arc<SelectorInner>>,
+    deferred_connect: Option<SocketAddr>,
+    bound: bool,
+    read: State<Cursor<Vec<u8>>>,
+    write: State<(Vec<u8>, usize)>,
+    accept: State<TcpStream>,
+    io: Io,
+}
+
+struct Io {
+    read: Overlapped, // also used for connect/accept
+    write: Overlapped,
+    accept_buf: AcceptAddrsBuf,
+}
+
+/// Internal state transitions for this socket.
+///
+/// This enum keeps track of which `std::net` primitive we currently are.
+/// Reusing `std::net` allows us to use the extension traits in `net2` and `wio`
+/// along with not having to manage the literal socket creation ourselves.
+enum Socket {
+    Empty,                  // socket has been closed
+    Building(TcpBuilder),   // not-connected nor not-listened socket
+    Stream(TcpStream),      // accepted or connected socket
+    Listener(TcpListener),  // listened socket
+}
+
+enum State<T> {
+    Empty,              // no I/O operation in progress
+    Pending,            // an I/O operation is in progress
+    Ready(T),           // I/O has finished with this value
+    Error(io::Error),   // there was an I/O error
+}
+
+impl TcpSocket {
+    pub fn v4() -> io::Result<TcpSocket> {
+        TcpBuilder::new_v4().map(|s| {
+            TcpSocket::new(Socket::Building(s), Family::V4)
+        })
+    }
+
+    pub fn v6() -> io::Result<TcpSocket> {
+        TcpBuilder::new_v6().map(|s| {
+            TcpSocket::new(Socket::Building(s), Family::V6)
+        })
+    }
+
+    fn new(socket: Socket, fam: Family) -> TcpSocket {
+        TcpSocket {
+            imp: Imp {
+                inner: Arc::new(Mutex::new(Inner {
+                    socket: socket,
+                    iocp: None,
+                    deferred_connect: None,
+                    bound: false,
+                    accept: State::Empty,
+                    read: State::Empty,
+                    write: State::Empty,
+                    io: Io {
+                        read: Overlapped::zero(),
+                        write: Overlapped::zero(),
+                        accept_buf: AcceptAddrsBuf::new(),
+                    },
+                })),
+                family: fam,
+            },
+        }
+    }
+
+    pub fn connect(&self, addr: &SocketAddr) -> io::Result<bool> {
+        let mut me = self.inner();
+        let me = &mut *me;
+        if me.deferred_connect.is_some() {
+            return Err(bad_state())
+        }
+        // If we haven't been registered defer the actual connect until we're
+        // registered
+        let iocp = match me.iocp {
+            Some(ref s) => s,
+            None => {
+                me.deferred_connect = Some(*addr);
+                return Ok(false)
+            }
+        };
+        let (socket, connected) = match me.socket {
+            Socket::Building(ref b) => {
+                // connect_overlapped only works on bound sockets, so if we're
+                // not bound yet go ahead and bind us
+                if !me.bound {
+                    try!(b.bind(&addr_any(self.imp.family)));
+                    me.bound = true;
+                }
+                let res = unsafe {
+                    trace!("scheduling a connect");
+                    try!(b.connect_overlapped(addr, &mut me.io.read))
+                };
+                let me2 = self.imp.clone();
+                iocp.register(&mut me.io.read, move |_, push, _| {
+                    trace!("finished a connect");
+                    me2.schedule_read();
+                    push(me2.inner().socket.handle(), EventSet::writable());
+                });
+                res
+            }
+            _ => return Err(bad_state()),
+        };
+        me.socket = Socket::Stream(socket);
+        Ok(connected)
+    }
+
+    pub fn bind(&self, addr: &SocketAddr) -> io::Result<()> {
+        let mut me = self.inner();
+        try!(try!(me.socket.builder()).bind(addr));
+        me.bound = true;
+        Ok(())
+    }
+
+    pub fn listen(&self, backlog: usize) -> io::Result<()> {
+        let mut me = self.inner();
+        let listener = try!(try!(me.socket.builder()).listen(backlog as i32));
+        me.socket = Socket::Listener(listener);
+        Ok(())
+    }
+
+    pub fn accept(&self) -> io::Result<Option<TcpSocket>> {
+        let mut me = self.inner();
+        try!(me.socket.listener());
+        let ret = match mem::replace(&mut me.accept, State::Empty) {
+            State::Empty => return Ok(None),
+            State::Pending => {
+                me.accept = State::Pending;
+                return Ok(None)
+            }
+            State::Ready(s) => {
+                Ok(Some(TcpSocket::new(Socket::Stream(s), self.imp.family)))
+            }
+            State::Error(e) => Err(e),
+        };
+        drop(me);
+        self.imp.schedule_read();
+        return ret
+    }
+
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        try!(self.inner().socket.stream()).peer_addr()
+    }
+
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        match self.inner().socket {
+            Socket::Stream(ref s) => s.local_addr(),
+            Socket::Listener(ref s) => s.local_addr(),
+            Socket::Empty |
+            Socket::Building(..) => Err(bad_state()),
+        }
+    }
+
+    pub fn try_clone(&self) -> io::Result<TcpSocket> {
+        match self.inner().socket {
+            Socket::Stream(ref s) => s.try_clone().map(|s| {
+                TcpSocket::new(Socket::Stream(s), self.imp.family)
+            }),
+            Socket::Listener(ref s) => s.try_clone().map(|s| {
+                TcpSocket::new(Socket::Listener(s), self.imp.family)
+            }),
+            Socket::Empty |
+            Socket::Building(..) => Err(bad_state()),
+        }
+    }
+
+    pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
+        try!(self.inner().socket.stream()).shutdown(match how {
+            Shutdown::Read => net::Shutdown::Read,
+            Shutdown::Write => net::Shutdown::Write,
+            Shutdown::Both => net::Shutdown::Both,
+        })
+    }
+
+    /*
+     *
+     * ===== Socket Options =====
+     *
+     */
+
+    pub fn set_reuseaddr(&self, val: bool) -> io::Result<()> {
+        try!(self.inner().socket.builder()).reuse_address(val).map(|_| ())
+    }
+
+    pub fn take_socket_error(&self) -> io::Result<()> {
+        unimplemented!();
+    }
+
+    pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
+        net2::TcpStreamExt::set_nodelay(try!(self.inner().socket.stream()),
+                                        nodelay)
+    }
+
+    pub fn set_keepalive(&self, seconds: Option<u32>) -> io::Result<()> {
+        let dur = seconds.map(|s| s * 1000);
+        net2::TcpStreamExt::set_keepalive_ms(try!(self.inner().socket.stream()),
+                                             dur)
+    }
+
+    fn inner(&self) -> MutexGuard<Inner> {
+        self.imp.inner()
+    }
+
+    fn post_register(&self, interest: EventSet, selector: &SelectorInner) {
+        if interest.is_readable() {
+            self.imp.schedule_read();
+        }
+
+        // At least with epoll, if a socket is registered with an interest in
+        // writing and it's immediately writable then a writable event is
+        // generated immediately, so do so here.
+        if interest.is_writable() {
+            let me = self.inner();
+            if let State::Empty = me.write {
+                if let Socket::Stream(..) = me.socket {
+                    selector.defer(me.socket.handle(), EventSet::writable());
+                }
+            }
+        }
+    }
+}
+
+impl Imp {
+    fn inner(&self) -> MutexGuard<Inner> {
+        self.inner.lock().unwrap()
+    }
+
+    /// Issues a "read" operation for this socket, if applicable.
+    ///
+    /// This is intended to be invoked from either a completion callback or a
+    /// normal context. The function is infallible because errors are stored
+    /// internally to be returned later.
+    ///
+    /// It is required that this function is only called after the handle has
+    /// been registered with an event loop.
+    fn schedule_read(&self) {
+        let mut me = self.inner();
+        let me = &mut *me;
+        let iocp = me.iocp.as_ref().unwrap();
+        let io = &mut me.io;
+        match me.socket {
+            Socket::Empty |
+            Socket::Building(..) => {}
+
+            Socket::Listener(ref l) => {
+                match me.accept {
+                    State::Empty => {}
+                    _ => return
+                }
+                let res = match self.family {
+                    Family::V4 => TcpBuilder::new_v4(),
+                    Family::V6 => TcpBuilder::new_v6(),
+                }.and_then(|builder| unsafe {
+                    trace!("scheduling an accept");
+                    l.accept_overlapped(&builder, &mut io.accept_buf,
+                                        &mut io.read)
+                });
+                match res {
+                    Ok((socket, _)) => {
+                        me.accept = State::Pending;
+                        let me2 = self.clone();
+                        iocp.register(&mut io.read, move |_, push, _| {
+                            trace!("finished an accept");
+                            let mut me = me2.inner();
+                            me.accept = State::Ready(socket);
+                            push(me.socket.handle(), EventSet::readable());
+                        });
+                    }
+                    Err(e) => {
+                        me.accept = State::Error(e);
+                        iocp.defer(me.socket.handle(), EventSet::readable());
+                    }
+                }
+            }
+
+            Socket::Stream(ref s) => {
+                match me.read {
+                    State::Empty => {}
+                    _ => return,
+                }
+                let mut buf = Vec::with_capacity(64 * 1024);
+                let res = unsafe {
+                    trace!("scheduling a read");
+                    let cap = buf.capacity();
+                    buf.set_len(cap);
+                    s.read_overlapped(&mut buf, &mut io.read)
+                };
+                match res {
+                    Ok(_) => {
+                        me.read = State::Pending;
+                        let me2 = self.clone();
+                        iocp.register(&mut io.read, move |s, push, _| {
+                            let mut me = me2.inner();
+                            unsafe {
+                                buf.set_len(s.bytes_transferred() as usize);
+                            }
+                            trace!("finished a read {}", buf.len());
+                            me.read = State::Ready(Cursor::new(buf));
+
+                            // If we transferred 0 bytes then be sure to
+                            // indicate that hup has happened.
+                            let mut e = EventSet::readable();
+                            if s.bytes_transferred() == 0 {
+                                e = e | EventSet::hup();
+                            }
+                            push(me.socket.handle(), e);
+                        });
+                    }
+                    Err(e) => {
+                        // Like above, be sure to indicate that hup has happened
+                        // whenever we get `ECONNRESET`
+                        let mut set = EventSet::readable();
+                        if e.raw_os_error() == Some(WSAECONNRESET as i32) {
+                            set = set | EventSet::hup();
+                        }
+                        me.read = State::Error(e);
+                        iocp.defer(me.socket.handle(), set);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Similar to `schedule_read`, except that this issues, well, writes.
+    ///
+    /// This function will continually attempt to write the entire contents of
+    /// the buffer `buf` until they have all been written. The `pos` argument is
+    /// the current offset within the buffer up to which the contents have
+    /// already been written.
+    ///
+    /// A new writable event (e.g. allowing another write) will only happen once
+    /// the buffer has been written completely (or hit an error).
+    fn schedule_write(&self, buf: Vec<u8>, pos: usize) {
+        let mut me = self.inner();
+        let me = &mut *me;
+        let s = me.socket.stream().unwrap();
+        let iocp = me.iocp.as_ref().unwrap();
+        let err = unsafe {
+            trace!("scheduling a write");
+            s.write_overlapped(&buf[pos..], &mut me.io.write)
+        };
+        match err {
+            Ok(_) => {
+                me.write = State::Pending;
+                let me2 = self.clone();
+                iocp.register(&mut me.io.write, move |s, push, _| {
+                    trace!("finished a write {}", s.bytes_transferred());
+                    let mut me = me2.inner();
+                    let new_pos = pos + (s.bytes_transferred() as usize);
+                    if new_pos == buf.len() {
+                        me.write = State::Empty;
+                        push(me.socket.handle(), EventSet::writable());
+                    } else {
+                        drop(me);
+                        me2.schedule_write(buf, new_pos);
+                    }
+                });
+            }
+            Err(e) => {
+                me.write = State::Error(e);
+                iocp.defer(me.socket.handle(), EventSet::writable());
+            }
+        }
+    }
+}
+
+impl Socket {
+    fn builder(&self) -> io::Result<&TcpBuilder> {
+        match *self {
+            Socket::Building(ref s) => Ok(s),
+            _ => Err(bad_state()),
+        }
+    }
+
+    fn listener(&self) -> io::Result<&TcpListener> {
+        match *self {
+            Socket::Listener(ref s) => Ok(s),
+            _ => Err(bad_state()),
+        }
+    }
+
+    fn stream(&self) -> io::Result<&TcpStream> {
+        match *self {
+            Socket::Stream(ref s) => Ok(s),
+            _ => Err(bad_state()),
+        }
+    }
+
+    fn handle(&self) -> HANDLE {
+        match *self {
+            Socket::Stream(ref s) => s.as_raw_socket() as HANDLE,
+            Socket::Listener(ref l) => l.as_raw_socket() as HANDLE,
+            Socket::Building(ref b) => b.as_raw_socket() as HANDLE,
+            Socket::Empty => INVALID_HANDLE_VALUE,
+        }
+    }
+}
+
+fn addr_any(family: Family) -> SocketAddr {
+    match family {
+        Family::V4 => {
+            let addr = SocketAddrV4::new(super::ipv4_any(), 0);
+            SocketAddr::V4(addr)
+        }
+        Family::V6 => {
+            let addr = SocketAddrV6::new(super::ipv6_any(), 0, 0, 0);
+            SocketAddr::V6(addr)
+        }
+    }
+}
+
+impl Read for TcpSocket {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut me = self.inner();
+        match mem::replace(&mut me.read, State::Empty) {
+            State::Empty => Err(wouldblock()),
+            State::Pending => { me.read = State::Pending; Err(wouldblock()) }
+            State::Ready(mut cursor) => {
+                let amt = try!(cursor.read(buf));
+                // Once the entire buffer is written we need to schedule the
+                // next read operation.
+                if cursor.position() as usize == cursor.get_ref().len() {
+                    drop(me);
+                    self.imp.schedule_read();
+                } else {
+                    me.read = State::Ready(cursor);
+                }
+                Ok(amt)
+            }
+            State::Error(e) => {
+                drop(me);
+                self.imp.schedule_read();
+                Err(e)
+            }
+        }
+    }
+}
+
+impl Write for TcpSocket {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        {
+            let mut me = self.inner();
+            let me = &mut *me;
+            match me.write {
+                State::Empty => {}
+                _ => return Err(wouldblock())
+            }
+            try!(me.socket.stream());
+            if me.iocp.is_none() {
+                return Err(wouldblock())
+            }
+        }
+        self.imp.schedule_write(buf.to_vec(), 0);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Evented for TcpSocket {
+    fn register(&self, selector: &mut Selector, token: Token,
+                interest: EventSet, opts: PollOpt) -> io::Result<()> {
+        let mut me = self.inner();
+        let selector = selector.inner();
+        match me.socket {
+            Socket::Stream(ref s) => {
+                try!(selector.register_socket(s, token, interest, opts));
+            }
+            Socket::Listener(ref l) => {
+                try!(selector.register_socket(l, token, interest, opts));
+            }
+            Socket::Building(ref b) => {
+                try!(selector.register_socket(b, token, interest, opts));
+            }
+            Socket::Empty => return Err(bad_state()),
+        }
+        me.iocp = Some(selector.clone());
+
+        // If we were connected before being registered process that request
+        // here and go along our merry ways. Note that the callback for a
+        // successful connect will worry about generating writable/readable
+        // events and scheduling a new read.
+        let addr = me.deferred_connect.take();
+        drop(me);
+        if let Some(addr) = addr {
+            return self.connect(&addr).map(|_| ())
+        }
+        self.post_register(interest, selector);
+        Ok(())
+    }
+
+    fn reregister(&self, selector: &mut Selector, token: Token,
+                  interest: EventSet, opts: PollOpt) -> io::Result<()> {
+        let me = self.inner();
+        let selector = selector.inner();
+        // TODO: assert that me.iocp == selector?
+        if me.iocp.is_none() {
+            return Err(bad_state())
+        }
+        assert!(me.deferred_connect.is_none());
+        match me.socket {
+            Socket::Stream(ref s) => {
+                try!(selector.reregister_socket(s, token, interest, opts));
+            }
+            Socket::Listener(ref l) => {
+                try!(selector.reregister_socket(l, token, interest, opts));
+            }
+            Socket::Building(ref b) => {
+                try!(selector.reregister_socket(b, token, interest, opts));
+            }
+            Socket::Empty => return Err(bad_state()),
+        }
+        drop(me);
+        self.post_register(interest, selector);
+        Ok(())
+    }
+
+    fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
+        let me = self.inner();
+        let selector = selector.inner();
+        // TODO: assert that me.iocp == selector?
+        if me.iocp.is_none() {
+            return Err(bad_state())
+        }
+        match me.socket {
+            Socket::Stream(ref s) => selector.deregister_socket(s),
+            Socket::Listener(ref l) => selector.deregister_socket(l),
+            Socket::Building(ref b) => selector.deregister_socket(b),
+            Socket::Empty => Err(bad_state()),
+        }
+    }
+}
+
+impl fmt::Debug for TcpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        "TcpSocket { ... }".fmt(f)
+    }
+}
+
+impl Drop for TcpSocket {
+    fn drop(&mut self) {
+        // When the `TcpSocket` itself is dropped then we close the internal
+        // handle (e.g. call `closesocket`). This will cause all pending I/O
+        // operations to forcibly finish and we'll get notifications for all of
+        // them and clean up the rest of our internal state (yay!)
+        self.inner().socket = Socket::Empty;
+    }
+}

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -1,0 +1,390 @@
+//! UDP for IOCP
+//!
+//! Note that most of this module is quite similar to the TCP module, so if
+//! something seems odd you may also want to try the docs over there.
+
+use std::fmt;
+use std::io::prelude::*;
+use std::io;
+use std::mem;
+use std::net::{self, SocketAddr};
+use std::os::windows::prelude::*;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use net2::{UdpBuilder, UdpSocketExt};
+use winapi::*;
+use wio::Overlapped;
+use wio::net::SocketAddrBuf;
+use wio::net::UdpSocketExt as WioUdpSocketExt;
+
+use {Evented, EventSet, IpAddr, PollOpt, Selector, Token};
+use bytes::{Buf, MutBuf};
+use sys::windows::selector::SelectorInner;
+use sys::windows::{bad_state, wouldblock, Family};
+
+pub struct UdpSocket {
+    imp: Imp,
+}
+
+#[derive(Clone)]
+struct Imp {
+    inner: Arc<Mutex<Inner>>,
+    family: Family,
+}
+
+struct Inner {
+    socket: Socket,
+    iocp: Option<Arc<SelectorInner>>,
+    read: State<Vec<u8>>,
+    write: State<(Vec<u8>, usize)>,
+    io: Io,
+}
+
+struct Io {
+    read: Overlapped,
+    read_buf: SocketAddrBuf,
+    write: Overlapped,
+}
+
+enum Socket {
+    Empty,
+    Building(UdpBuilder),
+    Bound(net::UdpSocket),
+}
+
+enum State<T> {
+    Empty,
+    Pending,
+    Ready(T),
+    Error(io::Error),
+}
+
+impl UdpSocket {
+    pub fn v4() -> io::Result<UdpSocket> {
+        UdpBuilder::new_v4().map(|u| {
+            UdpSocket::new(Socket::Building(u), Family::V4)
+        })
+    }
+
+    /// Returns a new, unbound, non-blocking, IPv6 UDP socket
+    pub fn v6() -> io::Result<UdpSocket> {
+        UdpBuilder::new_v6().map(|u| {
+            UdpSocket::new(Socket::Building(u), Family::V6)
+        })
+    }
+
+    fn new(socket: Socket, fam: Family) -> UdpSocket {
+        UdpSocket {
+            imp: Imp {
+                inner: Arc::new(Mutex::new(Inner {
+                    socket: socket,
+                    iocp: None,
+                    read: State::Empty,
+                    write: State::Empty,
+                    io: Io {
+                        read: Overlapped::zero(),
+                        read_buf: SocketAddrBuf::new(),
+                        write: Overlapped::zero(),
+                    },
+                })),
+                family: fam,
+            },
+        }
+    }
+
+    pub fn bind(&self, addr: &SocketAddr) -> io::Result<()> {
+        let mut me = self.inner();
+        let socket = try!(try!(me.socket.builder()).bind(addr));
+        me.socket = Socket::Bound(socket);
+        Ok(())
+    }
+
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        try!(self.inner().socket.socket()).local_addr()
+    }
+
+    pub fn try_clone(&self) -> io::Result<UdpSocket> {
+        try!(self.inner().socket.socket()).try_clone().map(|s| {
+            UdpSocket::new(Socket::Bound(s), self.imp.family)
+        })
+    }
+
+    pub fn send_to<B: Buf>(&self, buf: &mut B, target: &SocketAddr)
+                           -> io::Result<Option<()>> {
+        match self._send_to(buf.bytes(), target) {
+            Ok(n) => { buf.advance(n); Ok(Some(())) }
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Note that unlike `TcpStream::write` this function will not attempt to
+    /// continue writing `buf` until its entirely written.
+    ///
+    /// TODO: This... may be wrong in the long run. We're reporting that we
+    ///       successfully wrote all of the bytes in `buf` but it's possible
+    ///       that we don't actually end up writing all of them!
+    fn _send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
+        let mut me = self.inner();
+        let me = &mut *me;
+        match me.write {
+            State::Empty => {}
+            _ => return Err(wouldblock())
+        }
+        let s = try!(me.socket.socket());
+        let iocp = match me.iocp {
+            Some(ref s) => s,
+            None => return Err(wouldblock()),
+        };
+        let owned_buf = buf.to_vec();
+        try!(unsafe {
+            trace!("scheduling a send");
+            s.send_to_overlapped(&owned_buf, target, &mut me.io.write)
+        });
+        me.write = State::Pending;
+        let me2 = self.imp.clone();
+        iocp.register(&mut me.io.write, move |s, push, _| {
+            trace!("finished a send {}", s.bytes_transferred());
+            let mut me = me2.inner();
+            me.write = State::Empty;
+            push(me.socket.handle(), EventSet::writable());
+            drop(owned_buf); // keep the buf alive until I/O is done
+        });
+        Ok(buf.len())
+    }
+
+    pub fn recv_from<B: MutBuf>(&self, buf: &mut B)
+                                -> io::Result<Option<SocketAddr>> {
+        let mut me = self.inner();
+        match mem::replace(&mut me.read, State::Empty) {
+            State::Empty => Ok(None),
+            State::Pending => { me.read = State::Pending; Ok(None) }
+            State::Ready(data) => {
+                // If we weren't provided enough space to receive the message
+                // then don't actually read any data, just return an error.
+                if buf.remaining() < data.len() {
+                    me.read = State::Ready(data);
+                    Err(io::Error::from_raw_os_error(WSAEMSGSIZE as i32))
+                } else {
+                    let r = if let Some(addr) = me.io.read_buf.to_socket_addr() {
+                        buf.write_slice(&data);
+                        Ok(Some(addr))
+                    } else {
+                        Err(io::Error::new(io::ErrorKind::Other,
+                                           "failed to parse socket address"))
+                    };
+                    drop(me);
+                    self.imp.schedule_read();
+                    r
+                }
+            }
+            State::Error(e) => {
+                drop(me);
+                self.imp.schedule_read();
+                Err(e)
+            }
+        }
+    }
+
+    pub fn set_broadcast(&self, on: bool) -> io::Result<()> {
+        try!(self.inner().socket.socket()).set_broadcast(on)
+    }
+
+    pub fn set_multicast_loop(&self, on: bool) -> io::Result<()> {
+        let me = self.inner();
+        let socket = try!(me.socket.socket());
+        match self.imp.family {
+            Family::V4 => socket.set_multicast_loop_v4(on),
+            Family::V6 => socket.set_multicast_loop_v6(on),
+        }
+    }
+
+    pub fn join_multicast(&self, multi: &IpAddr) -> io::Result<()> {
+        let me = self.inner();
+        let socket = try!(me.socket.socket());
+        match *multi {
+            IpAddr::V4(ref v4) => {
+                socket.join_multicast_v4(v4, &super::ipv4_any())
+            }
+            IpAddr::V6(ref v6) => {
+                socket.join_multicast_v6(v6, 0)
+            }
+        }
+    }
+
+    pub fn leave_multicast(&self, multi: &IpAddr) -> io::Result<()> {
+        let me = self.inner();
+        let socket = try!(me.socket.socket());
+        match *multi {
+            IpAddr::V4(ref v4) => {
+                socket.leave_multicast_v4(v4, &super::ipv4_any())
+            }
+            IpAddr::V6(ref v6) => socket.leave_multicast_v6(v6, 0),
+        }
+    }
+
+    pub fn set_multicast_time_to_live(&self, ttl: i32) -> io::Result<()> {
+        try!(self.inner().socket.socket()).set_multicast_ttl_v4(ttl as u32)
+    }
+
+    fn inner(&self) -> MutexGuard<Inner> {
+        self.imp.inner()
+    }
+
+    fn post_register(&self, interest: EventSet, selector: &SelectorInner) {
+        if interest.is_readable() {
+            self.imp.schedule_read();
+        }
+        // See comments in TcpSocket::post_register for what's going on here
+        if interest.is_writable() {
+            let me = self.inner();
+            if let State::Empty = me.write {
+                if let Socket::Bound(..) = me.socket {
+                    selector.defer(me.socket.handle(), EventSet::writable());
+                }
+            }
+        }
+    }
+}
+
+impl Imp {
+    fn inner(&self) -> MutexGuard<Inner> {
+        self.inner.lock().unwrap()
+    }
+
+    fn schedule_read(&self) {
+        let mut me = self.inner();
+        let me = &mut *me;
+        match me.read {
+            State::Empty => {}
+            _ => return,
+        }
+        let iocp = me.iocp.as_ref().unwrap();
+        let io = &mut me.io;
+        let socket = match me.socket {
+            Socket::Empty |
+            Socket::Building(..) => return,
+            Socket::Bound(ref s) => s,
+        };
+        let mut buf = Vec::with_capacity(64 * 1024);
+        let res = unsafe {
+            trace!("scheduling a read");
+            let cap = buf.capacity();
+            buf.set_len(cap);
+            socket.recv_from_overlapped(&mut buf, &mut io.read_buf,
+                                        &mut io.read)
+        };
+        match res {
+            Ok(_) => {
+                me.read = State::Pending;
+                let me2 = self.clone();
+                iocp.register(&mut io.read, move |s, push, _| {
+                    let mut me = me2.inner();
+                    unsafe {
+                        buf.set_len(s.bytes_transferred() as usize);
+                    }
+                    trace!("finished a read {}", buf.len());
+                    me.read = State::Ready(buf);
+                    push(me.socket.handle(), EventSet::readable());
+                });
+            }
+            Err(e) => {
+                me.read = State::Error(e);
+                iocp.defer(me.socket.handle(), EventSet::readable());
+            }
+        }
+    }
+}
+
+impl Evented for UdpSocket {
+    fn register(&self, selector: &mut Selector, token: Token,
+                interest: EventSet, opts: PollOpt) -> io::Result<()> {
+        let mut me = self.inner();
+        let selector = selector.inner();
+        match me.socket {
+            Socket::Bound(ref s) => {
+                try!(selector.register_socket(s, token, interest, opts));
+            }
+            Socket::Building(ref b) => {
+                try!(selector.register_socket(b, token, interest, opts));
+            }
+            Socket::Empty => return Err(bad_state()),
+        }
+        me.iocp = Some(selector.clone());
+        drop(me);
+        self.post_register(interest, selector);
+        Ok(())
+    }
+
+    fn reregister(&self, selector: &mut Selector, token: Token,
+                  interest: EventSet, opts: PollOpt) -> io::Result<()> {
+        let me = self.inner();
+        let selector = selector.inner();
+        // TODO: assert that me.iocp == selector?
+        if me.iocp.is_none() {
+            return Err(bad_state())
+        }
+        match me.socket {
+            Socket::Bound(ref s) => {
+                try!(selector.reregister_socket(s, token, interest, opts));
+            }
+            Socket::Building(ref b) => {
+                try!(selector.reregister_socket(b, token, interest, opts));
+            }
+            Socket::Empty => return Err(bad_state()),
+        }
+        drop(me);
+        self.post_register(interest, selector);
+        Ok(())
+    }
+
+    fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
+        let me = self.inner();
+        let selector = selector.inner();
+        // TODO: assert that me.iocp == selector?
+        if me.iocp.is_none() {
+            return Err(bad_state())
+        }
+        match me.socket {
+            Socket::Bound(ref s) => selector.deregister_socket(s),
+            Socket::Building(ref b) => selector.deregister_socket(b),
+            Socket::Empty => Err(bad_state()),
+        }
+    }
+}
+
+impl fmt::Debug for UdpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        "UdpSocket { ... }".fmt(f)
+    }
+}
+
+impl Drop for UdpSocket {
+    fn drop(&mut self) {
+        self.inner().socket = Socket::Empty;
+    }
+}
+
+impl Socket {
+    fn builder(&self) -> io::Result<&UdpBuilder> {
+        match *self {
+            Socket::Building(ref s) => Ok(s),
+            _ => Err(bad_state()),
+        }
+    }
+
+    fn socket(&self) -> io::Result<&net::UdpSocket> {
+        match *self {
+            Socket::Bound(ref s) => Ok(s),
+            _ => Err(bad_state()),
+        }
+    }
+
+    fn handle(&self) -> HANDLE {
+        match *self {
+            Socket::Bound(ref s) => s.as_raw_socket() as HANDLE,
+            Socket::Building(ref b) => b.as_raw_socket() as HANDLE,
+            Socket::Empty => INVALID_HANDLE_VALUE,
+        }
+    }
+}

--- a/test/smoke.rs
+++ b/test/smoke.rs
@@ -1,0 +1,39 @@
+extern crate mio;
+
+use mio::{EventLoop, Handler, Token, EventSet, PollOpt};
+use mio::tcp::TcpListener;
+
+struct E;
+
+impl Handler for E {
+    type Timeout = ();
+    type Message = ();
+}
+
+#[test]
+fn reregister_before_register() {
+    let mut e = EventLoop::<E>::new().unwrap();
+
+    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let res = e.reregister(&l, Token(1), EventSet::all(), PollOpt::edge());
+    if cfg!(target_os = "macos") {
+        assert!(res.is_ok());
+    } else {
+        assert!(res.is_err());
+    }
+}
+
+#[test]
+fn run_once_with_nothing() {
+    let mut e = EventLoop::<E>::new().unwrap();
+    e.run_once(&mut E).unwrap();
+}
+
+#[test]
+fn add_then_drop() {
+    let mut e = EventLoop::<E>::new().unwrap();
+    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    e.register_opt(&l, Token(1), EventSet::all(), PollOpt::edge()).unwrap();
+    drop(l);
+    e.run_once(&mut E).unwrap();
+}

--- a/test/tcp.rs
+++ b/test/tcp.rs
@@ -1,0 +1,224 @@
+extern crate mio;
+extern crate env_logger;
+
+use std::io::prelude::*;
+use std::net;
+use std::sync::mpsc::channel;
+use std::thread;
+
+use mio::{EventLoop, Handler, Token, EventSet, PollOpt, TryRead, TryWrite};
+use mio::tcp::{TcpListener, TcpStream};
+
+#[test]
+fn accept() {
+    struct H { hit: bool, listener: TcpListener }
+
+    impl Handler for H {
+        type Timeout = ();
+        type Message = ();
+
+        fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token,
+                 events: EventSet) {
+            self.hit = true;
+            assert_eq!(token, Token(1));
+            assert!(events.is_readable());
+            assert!(self.listener.accept().unwrap().is_some());
+            event_loop.shutdown();
+        }
+    }
+
+    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = l.local_addr().unwrap();
+
+    let t = thread::spawn(move || {
+        net::TcpStream::connect(&addr).unwrap();
+    });
+
+    let mut e = EventLoop::new().unwrap();
+
+    e.register_opt(&l, Token(1), EventSet::readable(), PollOpt::edge()).unwrap();
+
+    let mut h = H { hit: false, listener: l };
+    e.run(&mut h).unwrap();
+    assert!(h.hit);
+    assert!(h.listener.accept().unwrap().is_none());
+    t.join().unwrap();
+}
+
+#[test]
+fn connect() {
+    struct H { hit: u32 }
+
+    impl Handler for H {
+        type Timeout = ();
+        type Message = ();
+
+        fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token,
+                 events: EventSet) {
+            assert_eq!(token, Token(1));
+            match self.hit {
+                0 => assert!(events.is_writable()),
+                1 => assert!(events.is_hup()),
+                _ => panic!(),
+            }
+            self.hit += 1;
+            event_loop.shutdown();
+        }
+    }
+
+    let l = net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = l.local_addr().unwrap();
+
+    let (tx, rx) = channel();
+    let (tx2, rx2) = channel();
+    let t = thread::spawn(move || {
+        let s = l.accept().unwrap();
+        rx.recv().unwrap();
+        drop(s);
+        tx2.send(()).unwrap();
+    });
+
+    let mut e = EventLoop::new().unwrap();
+    let s = TcpStream::connect(&addr).unwrap();
+
+    e.register_opt(&s, Token(1), EventSet::all(), PollOpt::edge()).unwrap();
+
+    let mut h = H { hit: 0 };
+    e.run(&mut h).unwrap();
+    assert_eq!(h.hit, 1);
+    tx.send(()).unwrap();
+    rx2.recv().unwrap();
+    e.run(&mut h).unwrap();
+    assert_eq!(h.hit, 2);
+    t.join().unwrap();
+}
+
+#[test]
+fn read() {
+    const N: usize = 16 * 1024 * 1024;
+    struct H { amt: usize, socket: TcpStream }
+
+    impl Handler for H {
+        type Timeout = ();
+        type Message = ();
+
+        fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token,
+                 _events: EventSet) {
+            assert_eq!(token, Token(1));
+            let mut b = [0; 1024];
+            loop {
+                if let Some(amt) = self.socket.try_read(&mut b).unwrap() {
+                    self.amt += amt;
+                } else {
+                    break
+                }
+                if self.amt >= N {
+                    event_loop.shutdown();
+                    break
+                }
+            }
+        }
+    }
+
+    let l = net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = l.local_addr().unwrap();
+
+    let t = thread::spawn(move || {
+        let mut s = l.accept().unwrap().0;
+        let b = [0; 1024];
+        let mut amt = 0;
+        while amt < N {
+            amt += s.write(&b).unwrap();
+        }
+    });
+
+    let mut e = EventLoop::new().unwrap();
+    let s = TcpStream::connect(&addr).unwrap();
+
+    e.register_opt(&s, Token(1), EventSet::readable(), PollOpt::edge()).unwrap();
+
+    let mut h = H { amt: 0, socket: s };
+    e.run(&mut h).unwrap();
+    t.join().unwrap();
+}
+
+#[test]
+fn write() {
+    const N: usize = 16 * 1024 * 1024;
+    struct H { amt: usize, socket: TcpStream }
+
+    impl Handler for H {
+        type Timeout = ();
+        type Message = ();
+
+        fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token,
+                 _events: EventSet) {
+            assert_eq!(token, Token(1));
+            let b = [0; 1024];
+            loop {
+                if let Some(amt) = self.socket.try_write(&b).unwrap() {
+                    self.amt += amt;
+                } else {
+                    break
+                }
+                if self.amt >= N {
+                    event_loop.shutdown();
+                    break
+                }
+            }
+        }
+    }
+
+    let l = net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = l.local_addr().unwrap();
+
+    let t = thread::spawn(move || {
+        let mut s = l.accept().unwrap().0;
+        let mut b = [0; 1024];
+        let mut amt = 0;
+        while amt < N {
+            amt += s.read(&mut b).unwrap();
+        }
+    });
+
+    let mut e = EventLoop::new().unwrap();
+    let s = TcpStream::connect(&addr).unwrap();
+
+    e.register_opt(&s, Token(1), EventSet::writable(), PollOpt::edge()).unwrap();
+
+    let mut h = H { amt: 0, socket: s };
+    e.run(&mut h).unwrap();
+    t.join().unwrap();
+}
+
+#[test]
+fn connect_then_close() {
+    struct H { listener: TcpListener }
+
+    impl Handler for H {
+        type Timeout = ();
+        type Message = ();
+
+        fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token,
+                 _events: EventSet) {
+            if token == Token(1) {
+                let s = self.listener.accept().unwrap().unwrap();
+                event_loop.register_opt(&s, Token(3), EventSet::all(),
+                                        PollOpt::edge()).unwrap();
+                drop(s);
+            } else if token == Token(2) {
+                event_loop.shutdown();
+            }
+        }
+    }
+
+    let mut e = EventLoop::new().unwrap();
+    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let s = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
+
+    e.register_opt(&l, Token(1), EventSet::readable(), PollOpt::edge()).unwrap();
+    e.register_opt(&s, Token(2), EventSet::readable(), PollOpt::edge()).unwrap();
+
+    let mut h = H { listener: l };
+    e.run(&mut h).unwrap();
+}

--- a/test/test.rs
+++ b/test/test.rs
@@ -14,9 +14,11 @@ mod test_echo_server;
 mod test_multicast;
 mod test_notify;
 mod test_register_deregister;
+#[cfg(unix)]
 mod test_tick;
 mod test_timer;
 mod test_udp_socket;
+#[cfg(unix)]
 mod test_unix_echo_server;
 
 mod ports {

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -102,8 +102,6 @@ impl Handler for TestHandler {
 
 #[test]
 pub fn test_close_on_drop() {
-    ::env_logger::init().unwrap();
-
     debug!("Starting TEST_CLOSE_ON_DROP");
     let mut event_loop = EventLoop::new().unwrap();
 

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -48,7 +48,8 @@ impl EchoConn {
             Err(e) => debug!("not implemented; client err={:?}", e),
         }
 
-        event_loop.reregister(&self.sock, self.token.unwrap(), self.interest, PollOpt::edge() | PollOpt::oneshot())
+        event_loop.reregister(&self.sock, self.token.unwrap(), self.interest,
+                              PollOpt::edge() | PollOpt::oneshot())
     }
 
     fn readable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
@@ -72,7 +73,8 @@ impl EchoConn {
 
         // prepare to provide this to writable
         self.buf = Some(buf.flip());
-        event_loop.reregister(&self.sock, self.token.unwrap(), self.interest, PollOpt::edge())
+        event_loop.reregister(&self.sock, self.token.unwrap(), self.interest,
+                              PollOpt::edge())
     }
 }
 
@@ -92,18 +94,21 @@ impl EchoServer {
 
         // Register the connection
         self.conns[tok].token = Some(tok);
-        event_loop.register_opt(&self.conns[tok].sock, tok, EventSet::readable(), PollOpt::edge() | PollOpt::oneshot())
+        event_loop.register_opt(&self.conns[tok].sock, tok, EventSet::readable(),
+                                PollOpt::edge() | PollOpt::oneshot())
             .ok().expect("could not register socket with event loop");
 
         Ok(())
     }
 
-    fn conn_readable(&mut self, event_loop: &mut EventLoop<Echo>, tok: Token) -> io::Result<()> {
+    fn conn_readable(&mut self, event_loop: &mut EventLoop<Echo>,
+                     tok: Token) -> io::Result<()> {
         debug!("server conn readable; tok={:?}", tok);
         self.conn(tok).readable(event_loop)
     }
 
-    fn conn_writable(&mut self, event_loop: &mut EventLoop<Echo>, tok: Token) -> io::Result<()> {
+    fn conn_writable(&mut self, event_loop: &mut EventLoop<Echo>,
+                     tok: Token) -> io::Result<()> {
         debug!("server conn writable; tok={:?}", tok);
         self.conn(tok).writable(event_loop)
     }
@@ -175,7 +180,8 @@ impl EchoClient {
             self.next_msg(event_loop).unwrap();
         }
 
-        event_loop.reregister(&self.sock, self.token, self.interest, PollOpt::edge() | PollOpt::oneshot())
+        event_loop.reregister(&self.sock, self.token, self.interest,
+                              PollOpt::edge() | PollOpt::oneshot())
     }
 
     fn writable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
@@ -194,7 +200,8 @@ impl EchoClient {
             Err(e) => debug!("not implemented; client err={:?}", e)
         }
 
-        event_loop.reregister(&self.sock, self.token, self.interest, PollOpt::edge() | PollOpt::oneshot())
+        event_loop.reregister(&self.sock, self.token, self.interest,
+                              PollOpt::edge() | PollOpt::oneshot())
     }
 
     fn next_msg(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
@@ -210,7 +217,8 @@ impl EchoClient {
         self.rx = SliceBuf::wrap(curr.as_bytes());
 
         self.interest.insert(EventSet::writable());
-        event_loop.reregister(&self.sock, self.token, self.interest, PollOpt::edge() | PollOpt::oneshot())
+        event_loop.reregister(&self.sock, self.token, self.interest,
+                              PollOpt::edge() | PollOpt::oneshot())
     }
 }
 
@@ -235,7 +243,9 @@ impl Handler for Echo {
     type Timeout = usize;
     type Message = ();
 
-    fn ready(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, events: EventSet) {
+    fn ready(&mut self, event_loop: &mut EventLoop<Echo>, token: Token,
+             events: EventSet) {
+        debug!("ready {:?} {:?}", token, events);
         if events.is_readable() {
             match token {
                 SERVER => self.server.accept(event_loop).unwrap(),
@@ -263,13 +273,15 @@ pub fn test_echo_server() {
     let srv = TcpListener::bind(&addr).unwrap();
 
     info!("listen for connections");
-    event_loop.register_opt(&srv, SERVER, EventSet::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    event_loop.register_opt(&srv, SERVER, EventSet::readable(),
+                            PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
     let (sock, _) = TcpSocket::v4().unwrap()
         .connect(&addr).unwrap();
 
     // Connect to the server
-    event_loop.register_opt(&sock, CLIENT, EventSet::writable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    event_loop.register_opt(&sock, CLIENT, EventSet::writable(),
+                            PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
     // Start the event loop
     event_loop.run(&mut Echo::new(srv, sock, vec!["foo", "bar"])).unwrap();

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -66,6 +66,7 @@ impl Handler for TestHandler {
 }
 
 #[test]
+#[cfg(unix)] // level() not implemented on windows yet
 pub fn test_register_deregister() {
     debug!("Starting TEST_REGISTER_DEREGISTER");
     let mut event_loop = EventLoop::new().unwrap();


### PR DESCRIPTION
These commits add preliminary support for the TCP/UDP API of mio, built on top of [IOCP](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365198%28v=vs.85%29.aspx) using some [raw Rust bindings](https://github.com/alexcrichton/wio) plus some [networking extensions](https://github.com/alexcrichton/net2-rs) as the foundational support. This support is definitely **still experimental** as there are likely to be a number of bugs and kinks to work out.

I haven't yet done much benchmarking as there are still a number of places I would like to improve the implementation in terms of performance. I've also been focusing on getting "hello world" and the in-tree tests working ASAP to start getting some broader usage and feedback. High level docs are available in the `src/sys/windows/mod.rs` file and the TCP/UDP implementations are quite similar in terms of how they're implemented.

Not many new tests were added, but all tests (other than those using unix sockets) are passing on Windows and an `appveyor.yml` file was also added to enable AppVeyor CI support to ensure this doesn't regress.

cc #155