### PR TITLE
windows: Pool buffers on the selector

### DIFF
--- a/src/sys/windows/buffer_pool.rs
+++ b/src/sys/windows/buffer_pool.rs
@@ -1,0 +1,20 @@
+pub struct BufferPool {
+    pool: Vec<Vec<u8>>,
+}
+
+impl BufferPool {
+    pub fn new(cap: usize) -> BufferPool {
+        BufferPool { pool: Vec::with_capacity(cap) }
+    }
+
+    pub fn get(&mut self, default_cap: usize) -> Vec<u8> {
+        self.pool.pop().unwrap_or_else(|| Vec::with_capacity(default_cap))
+    }
+
+    pub fn put(&mut self, mut buf: Vec<u8>) {
+        if self.pool.len() < self.pool.capacity(){
+            unsafe { buf.set_len(0); }
+            self.pool.push(buf);
+        }
+    }
+}

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -137,6 +137,7 @@ mod awakener;
 mod selector;
 mod tcp;
 mod udp;
+mod buffer_pool;
 
 pub use self::awakener::Awakener;
 pub use self::selector::{Events, Selector};


### PR DESCRIPTION
This adds a cache of buffers to be stored locally on the selector for new
requests to use for both reads and writes. The cache has a maximum size of the
number of buffers it can store and new buffers are allocated if the cache is
empty at the time.

Closes #245