### PR TITLE
windows: Remove the last HashMap in Selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.5.0 (unreleased)
 
 * Don't re-export bytes types
+* Preliminary Windows support
 
 # 0.4.1 (July 21)
 


### PR DESCRIPTION
This commit removes the last `HashMap` storage in the `Selector` on Windows,
meaning that I/O scheduling and completion no longer has a `HashMap` lookup on
either side. This was starting to show up in the profiles I was making and this
basically erases that overhead.