### PR TITLE
Move EventLoopConfig to the builder pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Don't re-export bytes types
 * Preliminary Windows support
 * Renamed `EventLoop::register_opt` to `EventLoop::register`
+* `EventLoopConfig` is now a builder instead of having public struct fields. It
+  is also no longer `Copy`.
 
 # 0.4.1 (July 21)
 

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -221,15 +221,13 @@ impl Handler for Echo {
 #[test]
 pub fn test_echo_server() {
     debug!("Starting TEST_ECHO_SERVER");
-    let config =
-        EventLoopConfig {
-            io_poll_timeout_ms: 1_000,
-            notify_capacity: 1_048_576,
-            messages_per_tick: 64,
-            timer_tick_ms: 100,
-            timer_wheel_size: 1_024,
-            timer_capacity: 65_536,
-        };
+    let mut config = EventLoopConfig::new();
+    config.io_poll_timeout_ms(1_000)
+          .notify_capacity(1_048_576)
+          .messages_per_tick(64)
+          .timer_tick_ms(100)
+          .timer_wheel_size(1_024)
+          .timer_capacity(65_536);
     let mut event_loop = EventLoop::configured(config).unwrap();
 
     let addr = localhost();

--- a/test/test_notify.rs
+++ b/test/test_notify.rs
@@ -73,7 +73,6 @@ pub fn test_notify() {
 
 #[test]
 pub fn test_notify_capacity() {
-    use std::default::Default;
     use std::sync::mpsc::*;
     use std::thread;
 
@@ -92,10 +91,8 @@ pub fn test_notify_capacity() {
         }
     }
 
-    let config = EventLoopConfig {
-        notify_capacity: 1,
-        .. EventLoopConfig::default()
-    };
+    let mut config = EventLoopConfig::new();
+    config.notify_capacity(1);
 
     let (tx, rx) = channel::<i32>();
     let mut event_loop = EventLoop::configured(config).unwrap();


### PR DESCRIPTION
This allows it to be extensible in the future without breaking backwards
compatibility, as well being idiomatic in terms of configuration with a builder.
The `Copy` trait has also been removed as it one day may not contain `Copy`
configuration values (e.g. strings/vectors).

Closes #247