### PR TITLE
Don't take Buf/MutBuf for UDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   is also no longer `Copy`. (#259)
 * `TcpSocket` is no longer exported in the public API (#262)
 * `TcpListener` now returns the remote peer address from `accept` as well (#275)
+* The `UdpSocket::{send_to, recv_from}` methods are no longer generic over `Buf`
+  or `MutBuf` but instead take slices directly. The return types have also been
+  updated to return the number of bytes transferred. (#260)
 
 # 0.4.1 (July 21)
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,5 +1,4 @@
 use {io, sys, Evented, EventSet, IpAddr, PollOpt, Selector, Token};
-use bytes::{Buf, MutBuf};
 use std::net::SocketAddr;
 
 #[derive(Debug)]
@@ -46,11 +45,13 @@ impl UdpSocket {
             .map(From::from)
     }
 
-    pub fn send_to<B: Buf>(&self, buf: &mut B, target: &SocketAddr) -> io::Result<Option<()>> {
+    pub fn send_to(&self, buf: &[u8], target: &SocketAddr)
+                   -> io::Result<Option<usize>> {
         self.sys.send_to(buf, target)
     }
 
-    pub fn recv_from<B: MutBuf>(&self, buf: &mut B) -> io::Result<Option<SocketAddr>> {
+    pub fn recv_from(&self, buf: &mut [u8])
+                     -> io::Result<Option<(usize, SocketAddr)>> {
         self.sys.recv_from(buf)
     }
 

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -1,6 +1,6 @@
 use mio::*;
 use mio::udp::*;
-use bytes::{Buf, RingBuf, SliceBuf};
+use bytes::{Buf, MutBuf, RingBuf, SliceBuf};
 use std::str;
 use std::net::{SocketAddr};
 use super::localhost;
@@ -31,8 +31,9 @@ impl UdpHandler {
         match token {
             LISTENER => {
                 debug!("We are receiving a datagram now...");
-                match self.rx.recv_from(&mut self.rx_buf) {
-                    Ok(Some(SocketAddr::V4(addr))) => {
+                match unsafe { self.rx.recv_from(self.rx_buf.mut_bytes()) } {
+                    Ok(Some((cnt, SocketAddr::V4(addr)))) => {
+                        MutBuf::advance(&mut self.rx_buf, cnt);
                         assert_eq!(*addr.ip(), Ipv4Addr::new(127, 0, 0, 1));
                     }
                     _ => panic!("unexpected result"),
@@ -47,7 +48,10 @@ impl UdpHandler {
     fn handle_write(&mut self, _: &mut EventLoop<UdpHandler>, token: Token, _: EventSet) {
         match token {
             SENDER => {
-                self.tx.send_to(&mut self.buf, &self.rx.local_addr().unwrap()).unwrap();
+                let addr = self.rx.local_addr().unwrap();
+                let cnt = self.tx.send_to(self.buf.bytes(), &addr)
+                                 .unwrap().unwrap();
+                self.buf.advance(cnt);
             },
             _ => ()
         }

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -1,6 +1,6 @@
 use mio::*;
 use mio::udp::*;
-use bytes::{Buf, RingBuf, SliceBuf, MutSliceBuf};
+use bytes::{Buf, RingBuf, SliceBuf, MutBuf};
 use super::localhost;
 use std::str;
 
@@ -37,7 +37,11 @@ impl Handler for UdpHandler {
             match token {
                 LISTENER => {
                     debug!("We are receiving a datagram now...");
-                    self.rx.recv_from(&mut self.rx_buf).unwrap();
+                    let (cnt, _) = unsafe {
+                        self.rx.recv_from(self.rx_buf.mut_bytes()).unwrap()
+                                                                  .unwrap()
+                    };
+                    MutBuf::advance(&mut self.rx_buf, cnt);
                     assert!(str::from_utf8(self.rx_buf.bytes()).unwrap() == self.msg);
                     event_loop.shutdown();
                 },
@@ -48,7 +52,10 @@ impl Handler for UdpHandler {
         if events.is_writable() {
             match token {
                 SENDER => {
-                    self.tx.send_to(&mut self.buf, &self.rx.local_addr().unwrap()).unwrap();
+                    let addr = self.rx.local_addr().unwrap();
+                    let cnt = self.tx.send_to(self.buf.bytes(), &addr).unwrap()
+                                                                      .unwrap();
+                    self.buf.advance(cnt);
                 },
                 _ => {}
             }
@@ -69,7 +76,7 @@ pub fn test_udp_socket() {
 
     // ensure that the sockets are non-blocking
     let mut buf = [0; 128];
-    assert!(rx.recv_from(&mut MutSliceBuf::wrap(&mut buf)).unwrap().is_none());
+    assert!(rx.recv_from(&mut buf).unwrap().is_none());
 
     info!("Registering SENDER");
     event_loop.register(&tx, SENDER, EventSet::writable(), PollOpt::edge()).unwrap();


### PR DESCRIPTION
Bring these methods in line with the `std::net` equivalents by having the same
signatures, but returning `Option<T>` instead of `T` to represent the "would
block" case via `None`.

Closes #255