### PR TITLE
Remove TcpSocket from the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # 0.5.0 (unreleased)
 
 * Don't re-export bytes types
-* Preliminary Windows support
-* Renamed `EventLoop::register_opt` to `EventLoop::register`
+* Preliminary Windows support (#239)
+* Renamed `EventLoop::register_opt` to `EventLoop::register` (#257)
 * `EventLoopConfig` is now a builder instead of having public struct fields. It
-  is also no longer `Copy`.
+  is also no longer `Copy`. (#259)
+* `TcpSocket` is no longer exported in the public API (#262)
 
 # 0.4.1 (July 21)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ clock_ticks = "0.0.5"
 bytes = { git = "https://github.com/carllerche/bytes", rev = "7edb577d0a" }
 winapi = "0.2.1"
 wio = { git = "https://github.com/alexcrichton/wio" }
-net2 = "0.2.7"
+net2 = "0.2.9"
 
 [dev-dependencies]
 env_logger = "0.3.0"

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -1,98 +1,9 @@
-use {io, sys, Evented, EventSet, PollOpt, Selector, Token, TryAccept};
 use std::io::{Read, Write};
-use std::net::SocketAddr;
+use std::net::{self, SocketAddr, SocketAddrV4, SocketAddrV6, Ipv4Addr, Ipv6Addr};
 
-/*
- *
- * ===== TcpSocket =====
- *
- */
+use net2::TcpBuilder;
 
-#[derive(Debug)]
-pub struct TcpSocket {
-    sys: sys::TcpSocket,
-}
-
-impl TcpSocket {
-    /// Returns a new, unbound, non-blocking, IPv4 socket
-    pub fn v4() -> io::Result<TcpSocket> {
-        sys::TcpSocket::v4().map(From::from)
-    }
-
-    /// Returns a new, unbound, non-blocking, IPv6 socket
-    pub fn v6() -> io::Result<TcpSocket> {
-        sys::TcpSocket::v6().map(From::from)
-    }
-
-    pub fn connect(self, addr: &SocketAddr) -> io::Result<(TcpStream, bool)> {
-        let complete = try!(self.sys.connect(addr));
-        Ok((From::from(self.sys), complete))
-    }
-
-    pub fn bind(&self, addr: &SocketAddr) -> io::Result<()> {
-        self.sys.bind(addr)
-    }
-
-    pub fn listen(self, backlog: usize) -> io::Result<TcpListener> {
-        try!(self.sys.listen(backlog));
-        Ok(From::from(self.sys))
-    }
-
-    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
-        self.sys.peer_addr()
-    }
-
-    pub fn local_addr(&self) -> io::Result<SocketAddr> {
-        self.sys.local_addr()
-    }
-
-    pub fn try_clone(&self) -> io::Result<TcpSocket> {
-        self.sys.try_clone()
-            .map(From::from)
-    }
-
-    /*
-     *
-     * ===== Socket Options =====
-     *
-     */
-
-    pub fn set_reuseaddr(&self, val: bool) -> io::Result<()> {
-        self.sys.set_reuseaddr(val)
-    }
-
-    pub fn take_socket_error(&self) -> io::Result<()> {
-        self.sys.take_socket_error()
-    }
-
-    pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
-        self.sys.set_nodelay(nodelay)
-    }
-
-    pub fn set_keepalive(&self, seconds: Option<u32>) -> io::Result<()> {
-        self.sys.set_keepalive(seconds)
-    }
-}
-
-impl Evented for TcpSocket {
-    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
-        self.sys.register(selector, token, interest, opts)
-    }
-
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
-        self.sys.reregister(selector, token, interest, opts)
-    }
-
-    fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
-        self.sys.deregister(selector)
-    }
-}
-
-impl From<sys::TcpSocket> for TcpSocket {
-    fn from(sys: sys::TcpSocket) -> TcpSocket {
-        TcpSocket { sys: sys }
-    }
-}
+use {io, sys, Evented, EventSet, PollOpt, Selector, Token, TryAccept};
 
 /*
  *
@@ -102,28 +13,57 @@ impl From<sys::TcpSocket> for TcpSocket {
 
 #[derive(Debug)]
 pub struct TcpStream {
-    sys: sys::TcpSocket,
+    sys: sys::TcpStream,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum Shutdown {
-    /// Further receptions will be disallowed.
-    Read,
-    /// Further  transmissions will be disallowed.
-    Write,
-    /// Further receptions and transmissions will be disallowed.
-    Both,
-}
+pub use std::net::Shutdown;
 
 impl TcpStream {
+    /// Create a new TCP stream an issue a non-blocking connect to the specified
+    /// address.
+    ///
+    /// This convenience method is available and uses the system's default
+    /// options when creating a socket which is then conntected. If fine-grained
+    /// control over the creation of the socket is desired, you can use
+    /// `net2::TcpBuilder` to configure a socket and then pass its socket to
+    /// `TcpStream::connect_stream` to transfer ownership into mio and schedule
+    /// the connect operation.
     pub fn connect(addr: &SocketAddr) -> io::Result<TcpStream> {
         let sock = try!(match *addr {
-            SocketAddr::V4(..) => TcpSocket::v4(),
-            SocketAddr::V6(..) => TcpSocket::v6(),
+            SocketAddr::V4(..) => TcpBuilder::new_v4(),
+            SocketAddr::V6(..) => TcpBuilder::new_v6(),
         });
+        // Required on Windows for a future `connect_overlapped` operation to be
+        // executed successfully.
+        if cfg!(windows) {
+            try!(sock.bind(&inaddr_any(addr)));
+        }
+        TcpStream::connect_stream(try!(sock.to_tcp_stream()), addr)
+    }
 
-        sock.connect(addr)
-            .map(|(stream, _)| stream)
+    /// Creates a new `TcpStream` from the pending socket inside the given
+    /// `std::net::TcpBuilder`, connecting it to the address specified.
+    ///
+    /// This constructor allows configuring the socket before it's actually
+    /// connected, and this function will transfer ownership to the returned
+    /// `TcpStream` if successful. An unconnected `TcpStream` can be created
+    /// with the `net2::TcpBuilder` type (and also configured via that route).
+    ///
+    /// The platform specific behavior of this function looks like:
+    ///
+    /// * On Unix, the socket is placed into nonblocking mode and then a
+    ///   `connect` call is issued.
+    ///
+    /// * On Windows, the address is stored internally and the connect operation
+    ///   is issued when the returned `TcpStream` is registered with an event
+    ///   loop. Note that on Windows you must `bind` a socket before it can be
+    ///   connected, so if a custom `TcpBuilder` is used it should be bound
+    ///   (perhaps to `INADDR_ANY`) before this method is called.
+    pub fn connect_stream(stream: net::TcpStream,
+                          addr: &SocketAddr) -> io::Result<TcpStream> {
+        Ok(TcpStream {
+            sys: try!(sys::TcpStream::connect(stream, addr)),
+        })
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
@@ -135,8 +75,7 @@ impl TcpStream {
     }
 
     pub fn try_clone(&self) -> io::Result<TcpStream> {
-        self.sys.try_clone()
-            .map(From::from)
+        self.sys.try_clone().map(|s| TcpStream { sys: s })
     }
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
         self.sys.shutdown(how)
@@ -149,9 +88,20 @@ impl TcpStream {
     pub fn set_keepalive(&self, seconds: Option<u32>) -> io::Result<()> {
         self.sys.set_keepalive(seconds)
     }
+}
 
-    pub fn take_socket_error(&self) -> io::Result<()> {
-        self.sys.take_socket_error()
+fn inaddr_any(other: &SocketAddr) -> SocketAddr {
+    match *other {
+        SocketAddr::V4(..) => {
+            let any = Ipv4Addr::new(0, 0, 0, 0);
+            let addr = SocketAddrV4::new(any, 0);
+            SocketAddr::V4(addr)
+        }
+        SocketAddr::V6(..) => {
+            let any = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0);
+            let addr = SocketAddrV6::new(any, 0, 0, 0);
+            SocketAddr::V6(addr)
+        }
     }
 }
 
@@ -172,22 +122,18 @@ impl Write for TcpStream {
 }
 
 impl Evented for TcpStream {
-    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token,
+                interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token,
+                  interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.reregister(selector, token, interest, opts)
     }
 
     fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
         self.sys.deregister(selector)
-    }
-}
-
-impl From<sys::TcpSocket> for TcpStream {
-    fn from(sys: sys::TcpSocket) -> TcpStream {
-        TcpStream { sys: sys }
     }
 }
 
@@ -199,36 +145,64 @@ impl From<sys::TcpSocket> for TcpStream {
 
 #[derive(Debug)]
 pub struct TcpListener {
-    sys: sys::TcpSocket,
+    sys: sys::TcpListener,
 }
 
 impl TcpListener {
+    /// Convenience method to bind a new TCP listener to the specified address
+    /// to receive new connections.
+    ///
+    /// This function will take the following steps:
+    ///
+    /// 1. Create a new TCP socket.
+    /// 2. Set the `SO_REUSEADDR` option on the socket.
+    /// 3. Bind the socket to the specified address.
+    /// 4. Call `listen` on the socket to prepare it to receive new connections.
+    ///
+    /// If fine-grained control over the binding and listening process for a
+    /// socket is desired then the `net2::TcpBuilder` methods can be used in
+    /// combination with the `TcpListener::from_listener` method to transfer
+    /// ownership into mio.
     pub fn bind(addr: &SocketAddr) -> io::Result<TcpListener> {
         // Create the socket
         let sock = try!(match *addr {
-            SocketAddr::V4(..) => TcpSocket::v4(),
-            SocketAddr::V6(..) => TcpSocket::v6(),
+            SocketAddr::V4(..) => TcpBuilder::new_v4(),
+            SocketAddr::V6(..) => TcpBuilder::new_v6(),
         });
 
         // Set SO_REUSEADDR
-        try!(sock.set_reuseaddr(true));
+        try!(sock.reuse_address(true));
 
         // Bind the socket
         try!(sock.bind(addr));
 
         // listen
-        sock.listen(1024)
+        let listener = try!(sock.listen(1024));
+        Ok(TcpListener {
+            sys: try!(sys::TcpListener::new(listener, addr)),
+        })
+    }
+
+    /// Creates a new `TcpListener` from an instance of a
+    /// `std::net::TcpListener` type.
+    ///
+    /// This function will set the `listener` provided into nonblocking mode on
+    /// Unix, and otherwise the stream will just be wrapped up in an mio stream
+    /// ready to accept new connections and become associated with an event
+    /// loop.
+    ///
+    /// The address provided must be the address that the listener is bound to.
+    pub fn from_listener(listener: net::TcpListener, addr: &SocketAddr)
+                         -> io::Result<TcpListener> {
+        sys::TcpListener::new(listener, addr).map(|s| TcpListener { sys: s })
     }
 
     /// Accepts a new `TcpStream`.
     ///
-    /// Returns a `Ok(None)` when the socket `WOULDBLOCK`, this means the stream will be ready at
-    /// a later point.
+    /// Returns a `Ok(None)` when the socket `WOULDBLOCK`, this means the stream
+    /// will be ready at a later point.
     pub fn accept(&self) -> io::Result<Option<TcpStream>> {
-        self.sys.accept()
-            .map(|opt| {
-                opt.map(|sys| TcpStream { sys: sys })
-            })
+        self.sys.accept().map(|o| o.map(|s| TcpStream { sys: s }))
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
@@ -236,23 +210,18 @@ impl TcpListener {
     }
 
     pub fn try_clone(&self) -> io::Result<TcpListener> {
-        self.sys.try_clone()
-            .map(From::from)
-    }
-}
-
-impl From<sys::TcpSocket> for TcpListener {
-    fn from(sys: sys::TcpSocket) -> TcpListener {
-        TcpListener { sys: sys }
+        self.sys.try_clone().map(|s| TcpListener { sys: s })
     }
 }
 
 impl Evented for TcpListener {
-    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
+    fn register(&self, selector: &mut Selector, token: Token,
+                interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
+    fn reregister(&self, selector: &mut Selector, token: Token,
+                  interest: EventSet, opts: PollOpt) -> io::Result<()> {
         self.sys.reregister(selector, token, interest, opts)
     }
 
@@ -277,20 +246,6 @@ impl TryAccept for TcpListener {
 
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
-
-#[cfg(unix)]
-impl AsRawFd for TcpSocket {
-    fn as_raw_fd(&self) -> RawFd {
-        self.sys.as_raw_fd()
-    }
-}
-
-#[cfg(unix)]
-impl FromRawFd for TcpSocket {
-    unsafe fn from_raw_fd(fd: RawFd) -> TcpSocket {
-        TcpSocket { sys: FromRawFd::from_raw_fd(fd) }
-    }
-}
 
 #[cfg(unix)]
 impl AsRawFd for TcpStream {

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -5,7 +5,8 @@ pub use self::unix::{
     Events,
     Io,
     Selector,
-    TcpSocket,
+    TcpStream,
+    TcpListener,
     UdpSocket,
     UnixSocket,
     pipe,
@@ -19,7 +20,8 @@ pub use self::windows::{
     Awakener,
     Events,
     Selector,
-    TcpSocket,
+    TcpStream,
+    TcpListener,
     UdpSocket,
 };
 

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -23,7 +23,7 @@ pub use self::awakener::Awakener;
 pub use self::eventedfd::EventedFd;
 pub use self::io::Io;
 pub use self::socket::Socket;
-pub use self::tcp::TcpSocket;
+pub use self::tcp::{TcpStream, TcpListener};
 pub use self::udp::UdpSocket;
 pub use self::uds::UnixSocket;
 

--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -48,60 +48,6 @@ pub fn accept(io: &Io, nonblock: bool) -> io::Result<RawFd> {
         .map_err(super::from_nix_error)
 }
 
-pub fn shutdown(io: &Io, how: Shutdown) -> io::Result<()> {
-    let how: nix::Shutdown = match how {
-        Shutdown::Read  => nix::Shutdown::Read,
-        Shutdown::Write => nix::Shutdown::Write,
-        Shutdown::Both  => nix::Shutdown::Both,
-    };
-    nix::shutdown(io.as_raw_fd(), how)
-        .map_err(super::from_nix_error)
-}
-
-pub fn take_socket_error(io: &Io) -> io::Result<()> {
-    let code = try!(nix::getsockopt(io.as_raw_fd(), nix::sockopt::SocketError)
-                            .map_err(super::from_nix_error));
-    if code != 0 {
-        Err(io::Error::from_raw_os_error(code))
-    } else {
-        Ok(())
-    }
-}
-
-pub fn set_nodelay(io: &Io, delay: bool) -> io::Result<()> {
-    nix::setsockopt(io.as_raw_fd(), nix::sockopt::TcpNoDelay, &delay)
-        .map_err(super::from_nix_error)
-}
-
-pub fn set_keepalive(io: &Io, keepalive: bool) -> io::Result<()> {
-    nix::setsockopt(io.as_raw_fd(), nix::sockopt::KeepAlive, &keepalive)
-        .map_err(super::from_nix_error)
-}
-
-#[cfg(any(target_os = "macos",
-          target_os = "ios"))]
-pub fn set_tcp_keepalive(io: &Io, seconds: u32) -> io::Result<()> {
-    nix::setsockopt(io.as_raw_fd(), nix::sockopt::TcpKeepAlive, &seconds)
-        .map_err(super::from_nix_error)
-}
-
-#[cfg(any(target_os = "freebsd",
-          target_os = "dragonfly",
-          target_os = "linux"))]
-pub fn set_tcp_keepalive(io: &Io, seconds: u32) -> io::Result<()> {
-    nix::setsockopt(io.as_raw_fd(), nix::sockopt::TcpKeepIdle, &seconds)
-        .map_err(super::from_nix_error)
-}
-
-#[cfg(not(any(target_os = "freebsd",
-              target_os = "dragonfly",
-              target_os = "linux",
-              target_os = "macos",
-              target_os = "ios")))]
-pub fn set_tcp_keepalive(io: &Io, _seconds: u32) -> io::Result<()> {
-    Ok(())
-}
-
 // UDP & UDS
 #[inline]
 pub fn recvfrom(io: &Io, buf: &mut [u8]) -> io::Result<(usize, nix::SockAddr)> {
@@ -113,11 +59,6 @@ pub fn recvfrom(io: &Io, buf: &mut [u8]) -> io::Result<(usize, nix::SockAddr)> {
 #[inline]
 pub fn sendto(io: &Io, buf: &[u8], target: &nix::SockAddr) -> io::Result<usize> {
     nix::sendto(io.as_raw_fd(), buf, target, nix::MSG_DONTWAIT)
-        .map_err(super::from_nix_error)
-}
-
-pub fn getpeername(io: &Io) -> io::Result<nix::SockAddr> {
-    nix::getpeername(io.as_raw_fd())
         .map_err(super::from_nix_error)
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,153 +1,158 @@
-use {io, Evented, EventSet, Io, PollOpt, Selector, Token, TryAccept};
-use sys::unix::{net, nix, Socket};
 use std::io::{Read, Write};
-use std::net::SocketAddr;
+use std::net::{self, SocketAddr};
 use std::os::unix::io::{RawFd, FromRawFd, AsRawFd};
 
+use libc;
+use net2::TcpStreamExt;
+use nix::fcntl::FcntlArg::F_SETFL;
+use nix::fcntl::{fcntl, O_NONBLOCK};
+
+use {io, Evented, EventSet, PollOpt, Selector, Token, TryAccept};
+use sys::unix::eventedfd::EventedFd;
+
 #[derive(Debug)]
-pub struct TcpSocket {
-    io: Io,
+pub struct TcpStream {
+    inner: net::TcpStream,
 }
 
-impl TcpSocket {
-    /// Returns a new, unbound, non-blocking, IPv4 socket
-    pub fn v4() -> io::Result<TcpSocket> {
-        TcpSocket::new(nix::AddressFamily::Inet)
-    }
+#[derive(Debug)]
+pub struct TcpListener {
+    inner: net::TcpListener,
+}
 
-    /// Returns a new, unbound, non-blocking, IPv6 socket
-    pub fn v6() -> io::Result<TcpSocket> {
-        TcpSocket::new(nix::AddressFamily::Inet6)
-    }
+fn set_nonblock(s: &AsRawFd) -> io::Result<()> {
+    fcntl(s.as_raw_fd(), F_SETFL(O_NONBLOCK)).map_err(super::from_nix_error)
+                                             .map(|_| ())
+}
 
-    fn new(family: nix::AddressFamily) -> io::Result<TcpSocket> {
-        net::socket(family, nix::SockType::Stream, true)
-            .map(|fd| From::from(Io::from_raw_fd(fd)))
-    }
-
-    pub fn connect(&self, addr: &SocketAddr) -> io::Result<bool> {
-        net::connect(&self.io, &net::to_nix_addr(addr))
-    }
-
-    pub fn bind(&self, addr: &SocketAddr) -> io::Result<()> {
-        net::bind(&self.io, &net::to_nix_addr(addr))
-    }
-
-    pub fn listen(&self, backlog: usize) -> io::Result<()> {
-        net::listen(&self.io, backlog)
-    }
-
-    pub fn accept(&self) -> io::Result<Option<TcpSocket>> {
-        net::accept(&self.io, true)
-            .map(|fd| Some(From::from(Io::from_raw_fd(fd))))
-            .or_else(io::to_non_block)
+impl TcpStream {
+    pub fn connect(stream: net::TcpStream, addr: &SocketAddr)
+                   -> io::Result<TcpStream> {
+        try!(set_nonblock(&stream));
+        match stream.connect(addr) {
+            Ok(..) => {}
+            Err(ref e) if e.raw_os_error() == Some(libc::EINPROGRESS) => {}
+            Err(e) => return Err(e),
+        }
+        Ok(TcpStream { inner: stream })
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
-        net::getpeername(&self.io)
-            .map(net::to_std_addr)
+        self.inner.peer_addr()
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
-        net::getsockname(&self.io)
-            .map(net::to_std_addr)
+        self.inner.local_addr()
     }
 
-    pub fn try_clone(&self) -> io::Result<TcpSocket> {
-        net::dup(&self.io)
-            .map(From::from)
+    pub fn try_clone(&self) -> io::Result<TcpStream> {
+        self.inner.try_clone().map(|s| TcpStream { inner: s })
     }
 
     pub fn shutdown(&self, how: net::Shutdown) -> io::Result<()> {
-        net::shutdown(&self.io, how)
-    }
-
-    /*
-     *
-     * ===== Socket Options =====
-     *
-     */
-
-    pub fn set_reuseaddr(&self, val: bool) -> io::Result<()> {
-        Socket::set_reuseaddr(self, val)
-    }
-
-    pub fn take_socket_error(&self) -> io::Result<()> {
-        net::take_socket_error(&self.io)
+        self.inner.shutdown(how)
     }
 
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
-        net::set_nodelay(&self.io, nodelay)
+        TcpStreamExt::set_nodelay(&self.inner, nodelay)
     }
 
     pub fn set_keepalive(&self, seconds: Option<u32>) -> io::Result<()> {
-        match seconds {
-            Some(sec) => {
-                try!(net::set_keepalive(&self.io, true));
-                net::set_tcp_keepalive(&self.io, sec)
-            },
-            None => {
-                net::set_keepalive(&self.io, false)
-            }
-        }
+        self.inner.set_keepalive_ms(seconds.map(|s| s * 1000))
     }
 }
 
-impl Read for TcpSocket {
+impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.io.read(buf)
+        self.inner.read(buf)
     }
 }
 
-impl Write for TcpSocket {
+impl Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.io.write(buf)
+        self.inner.write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.io.flush()
+        self.inner.flush()
     }
 }
 
-impl Evented for TcpSocket {
-    fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
-        self.io.register(selector, token, interest, opts)
+impl Evented for TcpStream {
+    fn register(&self, selector: &mut Selector, token: Token,
+                interest: EventSet, opts: PollOpt) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
-        self.io.reregister(selector, token, interest, opts)
+    fn reregister(&self, selector: &mut Selector, token: Token,
+                  interest: EventSet, opts: PollOpt) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).reregister(selector, token, interest, opts)
     }
 
     fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
-        self.io.deregister(selector)
+        EventedFd(&self.as_raw_fd()).deregister(selector)
     }
 }
 
-impl TryAccept for TcpSocket {
-    type Output = TcpSocket;
-
-    fn accept(&self) -> io::Result<Option<TcpSocket>> {
-        TcpSocket::accept(self)
+impl FromRawFd for TcpStream {
+    unsafe fn from_raw_fd(fd: RawFd) -> TcpStream {
+        TcpStream { inner: net::TcpStream::from_raw_fd(fd) }
     }
 }
 
-impl Socket for TcpSocket {
-}
-
-impl From<Io> for TcpSocket {
-    fn from(io: Io) -> TcpSocket {
-        TcpSocket { io: io }
-    }
-}
-
-impl FromRawFd for TcpSocket {
-    unsafe fn from_raw_fd(fd: RawFd) -> TcpSocket {
-        TcpSocket { io: Io::from_raw_fd(fd) }
-    }
-}
-
-impl AsRawFd for TcpSocket {
+impl AsRawFd for TcpStream {
     fn as_raw_fd(&self) -> RawFd {
-        self.io.as_raw_fd()
+        self.inner.as_raw_fd()
+    }
+}
+
+impl TcpListener {
+    pub fn new(inner: net::TcpListener, _addr: &SocketAddr)
+               -> io::Result<TcpListener> {
+        try!(set_nonblock(&inner));
+        Ok(TcpListener { inner: inner })
+    }
+
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.inner.local_addr()
+    }
+
+    pub fn try_clone(&self) -> io::Result<TcpListener> {
+        self.inner.try_clone().map(|s| TcpListener { inner: s })
+    }
+
+    pub fn accept(&self) -> io::Result<Option<TcpStream>> {
+        self.inner.accept().and_then(|(s, _)| {
+            try!(set_nonblock(&s));
+            Ok(Some(TcpStream { inner: s }))
+        }).or_else(io::to_non_block)
+    }
+}
+
+impl Evented for TcpListener {
+    fn register(&self, selector: &mut Selector, token: Token,
+                interest: EventSet, opts: PollOpt) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).register(selector, token, interest, opts)
+    }
+
+    fn reregister(&self, selector: &mut Selector, token: Token,
+                  interest: EventSet, opts: PollOpt) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).reregister(selector, token, interest, opts)
+    }
+
+    fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(selector)
+    }
+}
+
+impl FromRawFd for TcpListener {
+    unsafe fn from_raw_fd(fd: RawFd) -> TcpListener {
+        TcpListener { inner: net::TcpListener::from_raw_fd(fd) }
+    }
+}
+
+impl AsRawFd for TcpListener {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
     }
 }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -137,7 +137,7 @@
 //!   be some level of buffering of writes probably.
 
 use std::io;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::Ipv4Addr;
 
 mod awakener;
 #[macro_use]
@@ -149,7 +149,7 @@ mod buffer_pool;
 
 pub use self::awakener::Awakener;
 pub use self::selector::{Events, Selector};
-pub use self::tcp::TcpSocket;
+pub use self::tcp::{TcpStream, TcpListener};
 pub use self::udp::UdpSocket;
 
 #[derive(Copy, Clone)]
@@ -166,4 +166,3 @@ fn wouldblock() -> io::Error {
 }
 
 fn ipv4_any() -> Ipv4Addr { Ipv4Addr::new(0, 0, 0, 0) }
-fn ipv6_any() -> Ipv6Addr { Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0) }

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -232,20 +232,13 @@ pub fn test_echo_server() {
 
     let addr = localhost();
 
-    let srv = TcpSocket::v4().unwrap();
-
-    info!("setting re-use addr");
-    srv.set_reuseaddr(true).unwrap();
-    srv.bind(&addr).unwrap();
-
-    let srv = srv.listen(256).unwrap();
+    let srv = TcpListener::bind(&addr).unwrap();
 
     info!("listen for connections");
     event_loop.register(&srv, SERVER, EventSet::readable(),
                         PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
-    let (sock, _) = TcpSocket::v4().unwrap()
-        .connect(&addr).unwrap();
+    let sock = TcpStream::connect(&addr).unwrap();
 
     // Connect to the server
     event_loop.register(&sock, CLIENT, EventSet::writable(),

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -109,17 +109,12 @@ pub fn test_close_on_drop() {
     let addr = localhost();
 
     // == Create & setup server socket
-    let srv = TcpSocket::v4().unwrap();
-    srv.set_reuseaddr(true).unwrap();
-    srv.bind(&addr).unwrap();
-
-    let srv = srv.listen(256).unwrap();
+    let srv = TcpListener::bind(&addr).unwrap();
 
     event_loop.register(&srv, SERVER, EventSet::readable(), PollOpt::edge()).unwrap();
 
     // == Create & setup client socket
-    let (sock, _) = TcpSocket::v4().unwrap()
-        .connect(&addr).unwrap();
+    let sock = TcpStream::connect(&addr).unwrap();
 
     event_loop.register(&sock, CLIENT, EventSet::writable(), PollOpt::edge()).unwrap();
 

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -276,8 +276,7 @@ pub fn test_echo_server() {
     event_loop.register(&srv, SERVER, EventSet::readable(),
                             PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
-    let (sock, _) = TcpSocket::v4().unwrap()
-        .connect(&addr).unwrap();
+    let sock = TcpStream::connect(&addr).unwrap();
 
     // Connect to the server
     event_loop.register(&sock, CLIENT, EventSet::writable(),

--- a/test/test_notify.rs
+++ b/test/test_notify.rs
@@ -47,11 +47,7 @@ pub fn test_notify() {
     let addr = localhost();
 
     // Setup a server socket so that the event loop blocks
-    let srv = TcpSocket::v4().unwrap();
-    srv.set_reuseaddr(true).unwrap();
-    srv.bind(&addr).unwrap();
-
-    let srv = srv.listen(256).unwrap();
+    let srv = TcpListener::bind(&addr).unwrap();
 
     event_loop.register(&srv, Token(0), EventSet::all(), PollOpt::edge()).unwrap();
 

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -73,19 +73,12 @@ pub fn test_register_deregister() {
 
     let addr = localhost();
 
-    let server = TcpSocket::v4().unwrap();
-
-    info!("setting re-use addr");
-    server.set_reuseaddr(true).unwrap();
-    server.bind(&addr).unwrap();
-
-    let server = server.listen(256).unwrap();
+    let server = TcpListener::bind(&addr).unwrap();
 
     info!("register server socket");
     event_loop.register(&server, SERVER, EventSet::readable(), PollOpt::edge()).unwrap();
 
-    let (client, _) = TcpSocket::v4().unwrap()
-        .connect(&addr).unwrap();
+    let client = TcpStream::connect(&addr).unwrap();
 
     // Register client socket only as writable
     event_loop.register(&client, CLIENT, EventSet::readable(), PollOpt::level()).unwrap();

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -131,20 +131,13 @@ pub fn test_timer() {
 
     let addr = localhost();
 
-    let srv = TcpSocket::v4().unwrap();
-
-    info!("setting re-use addr");
-    srv.set_reuseaddr(true).unwrap();
-    srv.bind(&addr).unwrap();
-
-    let srv = srv.listen(256).unwrap();
+    let srv = TcpListener::bind(&addr).unwrap();
 
     info!("listening for connections");
 
     event_loop.register(&srv, SERVER, EventSet::all(), PollOpt::edge()).unwrap();
 
-    let (sock, _) = TcpSocket::v4().unwrap()
-        .connect(&addr).unwrap();
+    let sock = TcpStream::connect(&addr).unwrap();
 
     // Connect to the server
     event_loop.register(&sock, CLIENT, EventSet::all(), PollOpt::edge()).unwrap();


### PR DESCRIPTION
This commit removes `mio::tcp::TcpSocket` as a public type, only exposing the
`TcpStream` and `TcpListener` types. This change is motivated for a few reasons:

1. This mirrors the design of `std::net` more closely by having a static
   distinction between types and statically ruling out cases like calling
   `peer_addr` on a `TcpListener`.
2. This allows re-using standard extension methods on the `std::net` types,
   especially in the Windows implementation (which is now greatly simplified).

The primary reason to have `TcpSocket`, however, is to have fine-grained control
over socket creation and the ability to set various options. This is
implemented, however, in the `net2` extension crate which provides the
`TcpBuilder` type to configure a socket before it's bound/listened/etc. Methods
are provided on mio's `TcpStream` and `TcpListener` to be constructed from these
bare types so they can be passed in.

Closes #249