### PR TITLE
Add test case for deregister then slab remove

### DIFF
--- a/test/test.rs
+++ b/test/test.rs
@@ -20,6 +20,7 @@ mod test_timer;
 mod test_udp_socket;
 #[cfg(unix)]
 mod test_unix_echo_server;
+mod test_deregister_remove;
 
 mod ports {
     use std::net::SocketAddr;

--- a/test/test_deregister_remove.rs
+++ b/test/test_deregister_remove.rs
@@ -1,0 +1,141 @@
+use mio::*;
+use mio::tcp::*;
+use mio::util::Slab;
+use std::io;
+use super::localhost;
+
+const SERVER: Token = Token(0);
+const CLIENT: Token = Token(1);
+
+struct Server {
+    sock: TcpListener,
+    conns: Slab<TcpStream>
+}
+
+impl Server {
+    fn accept(&mut self, event_loop: &mut EventLoop<TestHandler>) -> io::Result<()> {
+        debug!("server accepting socket");
+
+        let sock = self.sock.accept().unwrap().unwrap();
+        let tok = self.conns.insert(sock)
+            .ok().expect("could not add socket to slab");
+
+        // Register the connection
+        event_loop.register(&self.conns[tok], tok, EventSet::readable(), PollOpt::edge() | PollOpt::oneshot())
+            .ok().expect("could not register socket with event loop");
+
+        Ok(())
+    }
+
+    fn readable(&mut self, event_loop: &mut EventLoop<TestHandler>, tok: Token) -> io::Result<()> {
+        debug!("server conn readable; tok={:?}", tok);
+
+        let mut buf = [0; 4096];
+
+        let bytes = self.conns[tok].try_read(&mut buf[..]).unwrap();
+        debug!("READ={:?}", bytes);
+
+        event_loop.reregister(&self.conns[tok], tok, EventSet::readable(), PollOpt::edge() | PollOpt::oneshot())
+    }
+}
+
+struct Client {
+    sock: TcpStream,
+    token: Token,
+    msg_count: usize,
+}
+
+
+// Sends a message and expects to receive the same exact message, one at a time
+impl Client {
+    fn new(sock: TcpStream, tok: Token) -> Client {
+
+        Client {
+            sock: sock,
+            token: tok,
+            msg_count: 0,
+        }
+    }
+
+    fn writable(&mut self, event_loop: &mut EventLoop<TestHandler>) -> io::Result<()> {
+        debug!("client socket writable");
+
+        if self.msg_count > 2 {
+            event_loop.shutdown();
+        }
+
+        let mut buf = [1];
+        let bytes = self.sock.try_write(&mut buf[..]);
+        debug!("WROTE={:?} bytes", bytes);
+        self.msg_count += 1;
+        event_loop.reregister(&self.sock, self.token, EventSet::writable(), PollOpt::edge() | PollOpt::oneshot())
+    }
+}
+
+struct TestHandler {
+    server: Server,
+    client: Client,
+}
+
+impl TestHandler {
+    fn new(srv: TcpListener, client: TcpStream ) -> TestHandler {
+        TestHandler {
+            server: Server {
+                sock: srv,
+                conns: Slab::new_starting_at(Token(2), 128)
+            },
+            client: Client::new(client, CLIENT)
+        }
+    }
+}
+
+impl Handler for TestHandler {
+    type Timeout = usize;
+    type Message = ();
+
+    fn ready(&mut self, event_loop: &mut EventLoop<TestHandler>, token: Token, events: EventSet) {
+        if events.is_readable() {
+            match token {
+                SERVER => self.server.accept(event_loop).unwrap(),
+                CLIENT => panic!("received readable for token 1"),
+                _ => {
+                    self.server.readable(event_loop, token).unwrap();
+
+                    // now that the readable event has reregistered itself, manually deregister it
+                    // and remove the connection from the slab
+                    event_loop.deregister(&self.server.conns[token]).unwrap();
+                    self.server.conns.remove(token);
+                }
+            }
+        }
+
+        if events.is_writable() {
+            match token {
+                SERVER => panic!("received writable for token 0"),
+                CLIENT => self.client.writable(event_loop).unwrap(),
+                _ => panic!("received writable for connection")
+            };
+        }
+    }
+}
+
+#[test]
+pub fn test_deregister_remove() {
+    ::env_logger::init().unwrap();
+    debug!("Starting TEST_REGISTER_REMOVE");
+    let mut event_loop = EventLoop::new().unwrap();
+
+    let addr = localhost();
+    let srv = TcpListener::bind(&addr).unwrap();
+
+    info!("listen for connections");
+    event_loop.register(&srv, SERVER, EventSet::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+
+    let sock = TcpStream::connect(&addr).unwrap();
+
+    // Connect to the server
+    event_loop.register(&sock, CLIENT, EventSet::writable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+
+    // Start the event loop
+    event_loop.run(&mut TestHandler::new(srv, sock)).unwrap();
+}


### PR DESCRIPTION
Test a condition where a connection reregisters itself and then later
deregisters itself and removes itself from the connection slab. When
this happens, mio will still try and handle events for that
token/connection when using kqueue.

Note: if the connection deregisters and does _not_ remove itself from
the connection slab, then mio will not try and handle events for that
token/connection when using kqueue.

Note: this does not seem to matter when using epoll.

Log of test failure:
```
$ RUST_LOG=trace RUST_BACKTRACE=1 cargo test test_deregister_remove::test_deregister_remove

running 1 test
DEBUG:test::test_deregister_remove: Starting TEST_REGISTER_REMOVE
TRACE:mio::poll: registering with poller
TRACE:mio::sys::unix::kqueue: registering; token=Token(18446744073709551615); interests=Readable | Writable
INFO:test::test_deregister_remove: listen for connections
TRACE:mio::poll: registering with poller
TRACE:mio::sys::unix::kqueue: registering; token=Token(0); interests=Readable
TRACE:mio::poll: registering with poller
TRACE:mio::sys::unix::kqueue: registering; token=Token(1); interests=Writable
TRACE:mio::event_loop: event loop tick
TRACE:mio::event_loop: event=IoEvent { kind: Writable, token: Token(18446744073709551615) }
TRACE:mio::event_loop: event=IoEvent { kind: Readable, token: Token(0) }
DEBUG:test::test_deregister_remove: server accepting socket
TRACE:mio::poll: registering with poller
TRACE:mio::sys::unix::kqueue: registering; token=Token(2); interests=Readable
TRACE:mio::event_loop: event=IoEvent { kind: Writable, token: Token(1) }
DEBUG:test::test_deregister_remove: client socket writable
DEBUG:test::test_deregister_remove: WROTE=Ok(Some(1)) bytes
TRACE:mio::poll: registering with poller
TRACE:mio::sys::unix::kqueue: registering; token=Token(1); interests=Writable
TRACE:mio::timer: tick_to; now=0; tick=0
TRACE:mio::timer: ticking; curr=Token(18446744073709551615)
TRACE:mio::event_loop: event loop tick
TRACE:mio::event_loop: event=IoEvent { kind: Readable, token: Token(2) }
DEBUG:test::test_deregister_remove: server conn readable; tok=Token(2)
DEBUG:test::test_deregister_remove: READ=Some(1)
TRACE:mio::poll: registering with poller
TRACE:mio::sys::unix::kqueue: registering; token=Token(2); interests=Readable
TRACE:mio::poll: deregistering IO with poller
TRACE:mio::event_loop: event=IoEvent { kind: Writable, token: Token(1) }
DEBUG:test::test_deregister_remove: client socket writable
DEBUG:test::test_deregister_remove: WROTE=Ok(Some(1)) bytes
TRACE:mio::poll: registering with poller
TRACE:mio::sys::unix::kqueue: registering; token=Token(1); interests=Writable
TRACE:mio::timer: tick_to; now=0; tick=1
TRACE:mio::event_loop: event loop tick
TRACE:mio::event_loop: event=IoEvent { kind: Readable | Writable, token: Token(2) }
DEBUG:test::test_deregister_remove: server conn readable; tok=Token(2)
test test_deregister_remove::test_deregister_remove ... FAILED

failures:

---- test_deregister_remove::test_deregister_remove stdout ----
	thread 'test_deregister_remove::test_deregister_remove' panicked at 'invalid index', ../src/libcore/option.rs:332

stack backtrace:
   1:        0x10bb3d850 - sys::backtrace::tracing::imp::write::h5eae06ee4288506cVks
   2:        0x10bb40cab - panicking::on_panic::hf2970156b8548126NXw
   3:        0x10bb32582 - rt::unwind::begin_unwind_inner::h5c58ec90c1a4644c0sw
   4:        0x10bb32c0d - rt::unwind::begin_unwind_fmt::h5a6da7c1a29307d36rw
   5:        0x10bb40957 - rust_begin_unwind
   6:        0x10bb61b80 - panicking::panic_fmt::h272a520f43a4257f8PE
   7:        0x10ba3cb6c - option::Option<T>::expect::h15973906137350301830
   8:        0x10ba3ca47 - Slab<T, I>.ops..IndexMut<I>::index_mut::h15229310430276528471
   9:        0x10ba3c51b - test_deregister_remove::Server::readable::h63e20da2f6478ec5fVd
  10:        0x10ba3f64e - test_deregister_remove::TestHandler.Handler::ready::h91d81e079a529321E3d
  11:        0x10ba420e3 - event_loop::EventLoop<H>::io_event::h17124134394579665990
  12:        0x10ba42074 - event_loop::EventLoop<H>::io_process::h4946922162973064403
  13:        0x10ba41c03 - event_loop::EventLoop<H>::run_once::h7428217901890795507
  14:        0x10ba41561 - event_loop::EventLoop<H>::run::h8504926306627181909
  15:        0x10ba40637 - test_deregister_remove::test_deregister_remove::h749418ad0e9878beM5d
  16:        0x10ba78ebb - boxed::F.FnBox<A>::call_box::h1114553862285000087
  17:        0x10ba7bc55 - boxed::F.FnBox<A>::call_box::h10881169691237074744
  18:        0x10ba79602 - rt::unwind::try::try_fn::h1415043113644552063
  19:        0x10bb40908 - __rust_try
  20:        0x10bb3cd20 - rt::unwind::try::inner_try::h445685aa67c6bfc0Tow
  21:        0x10ba797b2 - boxed::F.FnBox<A>::call_box::h16827267939334967293
  22:        0x10bb3fcbd - sys::thread::Thread::new::thread_start::h2921c73b7c72e024BNv
  23:     0x7fff8bc27059 - _pthread_body
  24:     0x7fff8bc26fd6 - _pthread_start


failures:
    test_deregister_remove::test_deregister_remove

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured

DEBUG:cargo: handle_error; err=CliError { error: , unknown: false, exit_code: 101 }
```