### PR TITLE
Token now derives PartialOrd, Ord.

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Token(pub usize);
 
 use slab;


### PR DESCRIPTION
I was delighted to find that `Ord` and `PartialOrd` can be derived in this case. Closes #263.