### PR TITLE
Add a link to an article about "rotor" library

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Please submit PRs containing links to MIO resources.
 * [My Basic Understanding of mio and Asynchronous IO](http://hermanradtke.com/2015/07/12/my-basic-understanding-of-mio-and-async-io.html)
 * [Creating A Multi-echo Server using Rust and mio](http://hermanradtke.com/2015/07/22/creating-a-multi-echo-server-using-rust-and-mio.html)
 * [Writing Scalable Chat Service from Scratch](http://nbaksalyar.github.io/2015/07/10/writing-chat-in-rust.html)
+* [Design Notes About Rotor Library](https://medium.com/@paulcolomiets/asynchronous-io-in-rust-36b623e7b965)
 
 ### Libraries
 


### PR DESCRIPTION
I've set link text to something different from article title because I feel the original title is too generic to be useful in this list. Feel free to change this.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/carllerche/mio/274)
<!-- Reviewable:end -->
