### PR TITLE
Return remote peer address in TcpListener::accept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `EventLoopConfig` is now a builder instead of having public struct fields. It
   is also no longer `Copy`. (#259)
 * `TcpSocket` is no longer exported in the public API (#262)
+* `TcpListener` now returns the remote peer address from `accept` as well (#275)
 
 # 0.4.1 (July 21)
 

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -200,9 +200,10 @@ impl TcpListener {
     /// Accepts a new `TcpStream`.
     ///
     /// Returns a `Ok(None)` when the socket `WOULDBLOCK`, this means the stream
-    /// will be ready at a later point.
-    pub fn accept(&self) -> io::Result<Option<TcpStream>> {
-        self.sys.accept().map(|o| o.map(|s| TcpStream { sys: s }))
+    /// will be ready at a later point. If an accepted stream is returned, the
+    /// address of the peer is returned along with it
+    pub fn accept(&self) -> io::Result<Option<(TcpStream, SocketAddr)>> {
+        self.sys.accept().map(|o| o.map(|(s, a)| (TcpStream { sys: s }, a)))
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
@@ -234,7 +235,7 @@ impl TryAccept for TcpListener {
     type Output = TcpStream;
 
     fn accept(&self) -> io::Result<Option<TcpStream>> {
-        TcpListener::accept(self)
+        TcpListener::accept(self).map(|a| a.map(|(s, _)| s))
     }
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -121,10 +121,10 @@ impl TcpListener {
         self.inner.try_clone().map(|s| TcpListener { inner: s })
     }
 
-    pub fn accept(&self) -> io::Result<Option<TcpStream>> {
-        self.inner.accept().and_then(|(s, _)| {
+    pub fn accept(&self) -> io::Result<Option<(TcpStream, SocketAddr)>> {
+        self.inner.accept().and_then(|(s, a)| {
             try!(set_nonblock(&s));
-            Ok(Some(TcpStream { inner: s }))
+            Ok(Some((TcpStream { inner: s }, a)))
         }).or_else(io::to_non_block)
     }
 }

--- a/test/tcp.rs
+++ b/test/tcp.rs
@@ -202,7 +202,7 @@ fn connect_then_close() {
         fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token,
                  _events: EventSet) {
             if token == Token(1) {
-                let s = self.listener.accept().unwrap().unwrap();
+                let s = self.listener.accept().unwrap().unwrap().0;
                 event_loop.register(&s, Token(3), EventSet::all(),
                                         PollOpt::edge()).unwrap();
                 drop(s);

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -75,7 +75,7 @@ impl EchoServer {
     fn accept(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
         debug!("server accepting socket");
 
-        let sock = self.sock.accept().unwrap().unwrap();
+        let sock = self.sock.accept().unwrap().unwrap().0;
         let conn = EchoConn::new(sock,);
         let tok = self.conns.insert(conn)
             .ok().expect("could not add connection to slab");

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -87,7 +87,7 @@ impl EchoServer {
     fn accept(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
         debug!("server accepting socket");
 
-        let sock = self.sock.accept().unwrap().unwrap();
+        let sock = self.sock.accept().unwrap().unwrap().0;
         let conn = EchoConn::new(sock,);
         let tok = self.conns.insert(conn)
             .ok().expect("could not add connection to slab");

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -24,7 +24,7 @@ impl TestHandler {
     fn handle_read(&mut self, event_loop: &mut EventLoop<TestHandler>, token: Token, _: EventSet) {
         match token {
             SERVER => {
-                let mut sock = self.server.accept().unwrap().unwrap();
+                let mut sock = self.server.accept().unwrap().unwrap().0;
                 sock.try_write_buf(&mut SliceBuf::wrap("foobar".as_bytes())).unwrap();
             }
             CLIENT => {

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -36,7 +36,7 @@ impl TestHandler {
         match tok {
             SERVER => {
                 debug!("server connection ready for accept");
-                let conn = self.srv.accept().unwrap().unwrap();
+                let conn = self.srv.accept().unwrap().unwrap().0;
                 event_loop.register(&conn, CONN, EventSet::all(),
                                         PollOpt::edge()).unwrap();
                 event_loop.timeout_ms(conn, 200).unwrap();


### PR DESCRIPTION
This brings the API more in line with the `std::net::TcpListener`'s signature by
returning a pair of both the accepted connection and the remote socket address
if successful.

Closes #258