### PR TITLE
kqueue: fix bug where an error on registration prevented the changelist from getting flushed.

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -485,4 +485,29 @@ mod tests {
 
         assert_eq!(str::from_utf8(b.flip().bytes()).unwrap(), "hello");
     }
+
+    pub struct BrokenPipeHandler;
+
+    impl Handler for BrokenPipeHandler {
+        type Timeout = ();
+        type Message = ();
+        fn ready(&mut self, _: &mut EventLoop<Self>, token: Token, _: EventSet) {
+            if token == Token(1) {
+                panic!("Received ready() on a closed pipe.");
+            }
+        }
+    }
+
+    #[test]
+    pub fn broken_pipe() {
+        let mut event_loop: EventLoop<BrokenPipeHandler> = EventLoop::new().unwrap();
+        let (reader, _) = unix::pipe().unwrap();
+
+        // On Darwin this returns a "broken pipe" error.
+        let _ = event_loop.register(&reader, Token(1), EventSet::all(), PollOpt::edge());
+
+        let mut handler = BrokenPipeHandler;
+        drop(reader);
+        event_loop.run_once(&mut handler).unwrap();
+    }
 }

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -21,7 +21,7 @@ impl Selector {
     }
 
     pub fn select(&mut self, evts: &mut Events, timeout_ms: usize) -> io::Result<()> {
-        let cnt = try!(kevent(self.kq, self.changes.as_slice(), evts.as_mut_slice(), timeout_ms)
+        let cnt = try!(kevent(self.kq, &[], evts.as_mut_slice(), timeout_ms)
                                   .map_err(super::from_nix_error));
 
         self.changes.sys_events.clear();
@@ -90,11 +90,11 @@ impl Selector {
     }
 
     fn flush_changes(&mut self) -> io::Result<()> {
-        try!(kevent(self.kq, self.changes.as_slice(), &mut [], 0)
-             .map_err(super::from_nix_error));
+        let result = kevent(self.kq, self.changes.as_slice(), &mut [], 0).map(|_| ())
+            .map_err(super::from_nix_error).map(|_| ());
 
         self.changes.sys_events.clear();
-        Ok(())
+        result
     }
 }
 


### PR DESCRIPTION
The new test case fails in the current implementation.