### PR TITLE
Add PollOpt::urgent()

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -26,6 +26,11 @@ impl PollOpt {
     }
 
     #[inline]
+    pub fn urgent() -> PollOpt {
+        PollOpt(0x100)
+    }
+
+    #[inline]
     pub fn all() -> PollOpt {
         PollOpt::edge() | PollOpt::level() | PollOpt::oneshot()
     }
@@ -43,6 +48,11 @@ impl PollOpt {
     #[inline]
     pub fn is_oneshot(&self) -> bool {
         self.contains(PollOpt::oneshot())
+    }
+
+    #[inline]
+    pub fn is_urgent(&self) -> bool {
+        self.contains(PollOpt::urgent())
     }
 
     #[inline]

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -82,7 +82,11 @@ fn ioevent_to_epoll(interest: EventSet, opts: PollOpt) -> EpollEventKind {
     let mut kind = EpollEventKind::empty();
 
     if interest.is_readable() {
-        kind.insert(EPOLLIN);
+        if opts.is_urgent() {
+            kind.insert(EPOLLPRI);
+        } else {
+            kind.insert(EPOLLIN);
+        }
     }
 
     if interest.is_writable() {
@@ -135,7 +139,7 @@ impl Events {
         let epoll = self.events[idx].events;
         let mut kind = EventSet::none();
 
-        if epoll.contains(EPOLLIN) {
+        if epoll.contains(EPOLLIN) | epoll.contains(EPOLLPRI) {
             kind = kind | EventSet::readable();
         }
 


### PR DESCRIPTION
In my project [cupi](https://github.com/cuprumpi/cupi) I need to wait for urgent events from epoll. Is it possible to add urgent events or maybe there is another way of doing things. Without using urgent I receive one unwanted event at the initialization.

I’m looking forward to 0.5 because in 0.4.3 I get strange bugs - “ready” returns tokens different from the ones I registered. I don’t get such behaviour at master, so I guess it was already fixed.