### PR TITLE
mio: don't wake up every second/timer tick when run() is called

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude       = [
 
 [dependencies]
 log   = "0.3.1"
-nix   = { git = "https://github.com/carllerche/nix-rust", rev = "f37e45628e" }
+nix   = { git = "https://github.com/carllerche/nix-rust", rev = "c17d5b32a77e49bc2c53b21f25a7ebf9be607cba" }
 libc  = "0.1.8"
 slab  = "0.1.0"
 clock_ticks = "0.0.5"

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -72,7 +72,7 @@ pub struct EventLoop<H: Handler> {
     timer: Timer<H::Timeout>,
     notify: Notify<H::Message>,
     config: EventLoopConfig,
-    pub tick_ms: Option<usize>
+    tick_ms: Option<usize>
 }
 
 // Token used to represent notifications
@@ -216,6 +216,21 @@ impl<H: Handler> EventLoop<H> {
     /// stopped or is scheduled to stop on the next tick.
     pub fn is_running(&self) -> bool {
         self.run
+    }
+
+    pub fn tick_ms(&self) -> Option<usize> {
+        self.tick_ms
+    }
+
+    pub fn set_tick_ms(&mut self, tick_ms: Option<usize>) {
+        self.tick_ms = tick_ms
+    }
+
+    pub fn shorten_tick_ms(&mut self, tick_ms: usize) {
+        match self.tick_ms {
+            Some(old) if old <= tick_ms => {}
+            _ => {self.tick_ms = Some(tick_ms)}
+        }
     }
 
     /// Registers an IO handle with the event loop.
@@ -489,7 +504,7 @@ mod tests {
     #[test]
     pub fn broken_pipe() {
         let mut event_loop: EventLoop<BrokenPipeHandler> = EventLoop::new().unwrap();
-        event_loop.tick_ms = Some(10);
+        event_loop.set_tick_ms(Some(10));
         let (reader, _) = unix::pipe().unwrap();
 
         // On Darwin this returns a "broken pipe" error.

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -50,7 +50,7 @@ impl Poll {
         Ok(())
     }
 
-    pub fn poll(&mut self, timeout_ms: usize) -> io::Result<usize> {
+    pub fn poll(&mut self, timeout_ms: Option<usize>) -> io::Result<usize> {
         try!(self.selector.select(&mut self.events, timeout_ms));
         Ok(self.events.len())
     }

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -82,19 +82,19 @@ impl Selector {
 
     pub fn select(&mut self,
                   events: &mut Events,
-                  timeout_ms: usize) -> io::Result<()> {
+                  timeout_ms: Option<usize>) -> io::Result<()> {
         // If we have some deferred events then we only want to poll for I/O
         // events, so clamp the timeout to 0 in that case.
         let timeout = if self.inner.defers.lock().unwrap().len() > 0 {
-            0
+            Some(0)
         } else {
-            timeout_ms as u32
+            timeout_ms.map(|x| x as u32)
         };
 
         // Clear out the previous list of I/O events and get some more!
         events.events.truncate(0);
         let inner = self.inner.clone();
-        let n = match inner.port.get_many(&mut events.statuses, Some(timeout)) {
+        let n = match inner.port.get_many(&mut events.statuses, timeout) {
             Ok(statuses) => statuses.len(),
             Err(ref e) if e.raw_os_error() == Some(WAIT_TIMEOUT as i32) => 0,
             Err(e) => return Err(e),

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -76,6 +76,15 @@ impl<T> Timer<T> {
         nxt - now
     }
 
+    // Number of ms remaining until the next timer, or None if no timers
+    pub fn next_timer_in_ms(&self) -> Option<u64> {
+        if self.entries.count() == 0 {
+            None
+        } else {
+            Some(self.next_tick_in_ms())
+        }
+    }
+
     /*
      *
      * ===== Initialization =====

--- a/test/smoke.rs
+++ b/test/smoke.rs
@@ -1,6 +1,6 @@
 extern crate mio;
 
-use mio::{EventLoop, Handler, Token, EventSet, PollOpt};
+use mio::{EventLoop, EventLoopConfig, Handler, Token, EventSet, PollOpt};
 use mio::tcp::TcpListener;
 
 struct E;
@@ -25,13 +25,17 @@ fn reregister_before_register() {
 
 #[test]
 fn run_once_with_nothing() {
-    let mut e = EventLoop::<E>::new().unwrap();
+    let mut config = EventLoopConfig::new();
+    config.io_poll_timeout_ms(Some(10));
+    let mut e = EventLoop::<E>::configured(config).unwrap();
     e.run_once(&mut E).unwrap();
 }
 
 #[test]
 fn add_then_drop() {
-    let mut e = EventLoop::<E>::new().unwrap();
+    let mut config = EventLoopConfig::new();
+    config.io_poll_timeout_ms(Some(10));
+    let mut e = EventLoop::<E>::configured(config).unwrap();
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     e.register(&l, Token(1), EventSet::all(), PollOpt::edge()).unwrap();
     drop(l);

--- a/test/smoke.rs
+++ b/test/smoke.rs
@@ -1,6 +1,6 @@
 extern crate mio;
 
-use mio::{EventLoop, EventLoopConfig, Handler, Token, EventSet, PollOpt};
+use mio::{EventLoop, Handler, Token, EventSet, PollOpt};
 use mio::tcp::TcpListener;
 
 struct E;
@@ -25,17 +25,15 @@ fn reregister_before_register() {
 
 #[test]
 fn run_once_with_nothing() {
-    let mut config = EventLoopConfig::new();
-    config.io_poll_timeout_ms(Some(10));
-    let mut e = EventLoop::<E>::configured(config).unwrap();
+    let mut e = EventLoop::<E>::new().unwrap();
+    e.tick_ms = Some(10);
     e.run_once(&mut E).unwrap();
 }
 
 #[test]
 fn add_then_drop() {
-    let mut config = EventLoopConfig::new();
-    config.io_poll_timeout_ms(Some(10));
-    let mut e = EventLoop::<E>::configured(config).unwrap();
+    let mut e = EventLoop::<E>::new().unwrap();
+    e.tick_ms = Some(10);
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     e.register(&l, Token(1), EventSet::all(), PollOpt::edge()).unwrap();
     drop(l);

--- a/test/smoke.rs
+++ b/test/smoke.rs
@@ -26,14 +26,14 @@ fn reregister_before_register() {
 #[test]
 fn run_once_with_nothing() {
     let mut e = EventLoop::<E>::new().unwrap();
-    e.tick_ms = Some(10);
+    e.set_tick_ms(Some(10));
     e.run_once(&mut E).unwrap();
 }
 
 #[test]
 fn add_then_drop() {
     let mut e = EventLoop::<E>::new().unwrap();
-    e.tick_ms = Some(10);
+    e.set_tick_ms(Some(10));
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     e.register(&l, Token(1), EventSet::all(), PollOpt::edge()).unwrap();
     drop(l);

--- a/test/tcp.rs
+++ b/test/tcp.rs
@@ -239,7 +239,7 @@ fn listen_then_close() {
     }
 
     let mut e = EventLoop::new().unwrap();
-    e.tick_ms = Some(10);
+    e.set_tick_ms(Some(10));
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     e.register(&l, Token(1), EventSet::readable(), PollOpt::edge()).unwrap();

--- a/test/tcp.rs
+++ b/test/tcp.rs
@@ -6,7 +6,7 @@ use std::net;
 use std::sync::mpsc::channel;
 use std::thread;
 
-use mio::{EventLoop, EventLoopConfig, Handler, Token, EventSet, PollOpt, TryRead, TryWrite};
+use mio::{EventLoop, Handler, Token, EventSet, PollOpt, TryRead, TryWrite};
 use mio::tcp::{TcpListener, TcpStream};
 
 #[test]
@@ -238,9 +238,8 @@ fn listen_then_close() {
         }
     }
 
-    let mut config = EventLoopConfig::new();
-    config.io_poll_timeout_ms(Some(10));
-    let mut e = EventLoop::configured(config).unwrap();
+    let mut e = EventLoop::new().unwrap();
+    e.tick_ms = Some(10);
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     e.register(&l, Token(1), EventSet::readable(), PollOpt::edge()).unwrap();

--- a/test/tcp.rs
+++ b/test/tcp.rs
@@ -6,7 +6,7 @@ use std::net;
 use std::sync::mpsc::channel;
 use std::thread;
 
-use mio::{EventLoop, Handler, Token, EventSet, PollOpt, TryRead, TryWrite};
+use mio::{EventLoop, EventLoopConfig, Handler, Token, EventSet, PollOpt, TryRead, TryWrite};
 use mio::tcp::{TcpListener, TcpStream};
 
 #[test]
@@ -238,7 +238,9 @@ fn listen_then_close() {
         }
     }
 
-    let mut e = EventLoop::new().unwrap();
+    let mut config = EventLoopConfig::new();
+    config.io_poll_timeout_ms(Some(10));
+    let mut e = EventLoop::configured(config).unwrap();
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     e.register(&l, Token(1), EventSet::readable(), PollOpt::edge()).unwrap();

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -222,8 +222,7 @@ impl Handler for Echo {
 pub fn test_echo_server() {
     debug!("Starting TEST_ECHO_SERVER");
     let mut config = EventLoopConfig::new();
-    config.io_poll_timeout_ms(Some(1_000))
-          .notify_capacity(1_048_576)
+    config.notify_capacity(1_048_576)
           .messages_per_tick(64)
           .timer_tick_ms(100)
           .timer_wheel_size(1_024)

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -222,7 +222,7 @@ impl Handler for Echo {
 pub fn test_echo_server() {
     debug!("Starting TEST_ECHO_SERVER");
     let mut config = EventLoopConfig::new();
-    config.io_poll_timeout_ms(1_000)
+    config.io_poll_timeout_ms(Some(1_000))
           .notify_capacity(1_048_576)
           .messages_per_tick(64)
           .timer_tick_ms(100)


### PR DESCRIPTION
Currently run() results in the process waking up every second or every timer
tick if set lower because a timeout is passed to the OS wait function.

This changes the code so that run_once() still uses the timeout, but
run() will instruct the OS to wait forever when there are no timers.

The notify mechanism already uses a pipe for awakening the event loop,
so there should be no need to use a timeout for that.

This saves CPU time and battery, and is generally the correct behavior.

Miscellaneous notes:
- We also fix epoll because the maximum timeout supported by the Linux kernel is i32::MAX, not isize::MAX.
- We fix next_tick_ms() being truncated from u64 to usize
- It requires carllerche/nix-rust#192 to allow specifying no timeout to kevent()
- The public API of Poll::poll is changed, but that can be avoided if desired.

The choice of usize-types milliseconds for the timeout is not ideal, but should be good enough for now: epoll_wait() doesn't support any higher resolution, so kernel high-resolution timers would be required for better resolution on Linux and a dedicated API might be needed anyway for those.

NOTE: this introduces a next_timer_ms() function that currently uses the next tick if any timer is present. This is obviously not good and instead it should return the time until the first timer, but I'm not sure if the current timer implementation copes with that. The timer implementation itself seems to have serious problems anyway like no handling for times far in the future and no way to get the first timer in O(1).

Only lightly tested, please review.
