### PR TITLE
Support sending/receiving FDs over UNIX sockets

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -55,17 +55,13 @@ pub trait TryWrite {
 
 impl<T: Read> TryRead for T {
     fn try_read(&mut self, dst: &mut [u8]) -> Result<Option<usize>> {
-        self.read(dst)
-            .map(|cnt| Some(cnt))
-            .or_else(to_non_block)
+        self.read(dst).map_non_block()
     }
 }
 
 impl<T: Write> TryWrite for T {
     fn try_write(&mut self, src: &[u8]) -> Result<Option<usize>> {
-        self.write(src)
-            .map(|cnt| Some(cnt))
-            .or_else(to_non_block)
+        self.write(src).map_non_block()
     }
 }
 
@@ -81,12 +77,26 @@ pub trait TryAccept {
  *
  */
 
-pub fn to_non_block<T>(err: Error) -> Result<Option<T>> {
-    use std::io::ErrorKind::WouldBlock;
+/// A helper trait to provide the map_non_block function on Results.
+pub trait MapNonBlock<T> {
+    /// Maps a `Result<T>` to a `Result<Option<T>>` by converting
+    /// operation-would-block errors into `Ok(None)`.
+    fn map_non_block(self) -> Result<Option<T>>;
+}
 
-    if let WouldBlock = err.kind() {
-        return Ok(None);
+impl<T> MapNonBlock<T> for Result<T> {
+    fn map_non_block(self) -> Result<Option<T>> {
+        use std::io::ErrorKind::WouldBlock;
+
+        match self {
+            Ok(value) => Ok(Some(value)),
+            Err(err) => {
+                if let WouldBlock = err.kind() {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            }
+        }
     }
-
-    Err(err)
 }

--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -1,6 +1,8 @@
 use {io, sys, Evented, EventSet, Io, PollOpt, Selector, Token, TryAccept};
+use io::MapNonBlock;
 use std::io::{Read, Write};
 use std::path::Path;
+use bytes::{Buf, MutBuf};
 
 #[derive(Debug)]
 pub struct UnixSocket {
@@ -78,6 +80,38 @@ impl UnixStream {
     pub fn try_clone(&self) -> io::Result<UnixStream> {
         self.sys.try_clone()
             .map(From::from)
+    }
+
+    pub fn read_recv_fd(&mut self, buf: &mut [u8]) -> io::Result<(usize, Option<RawFd>)> {
+        self.sys.read_recv_fd(buf)
+    }
+
+    pub fn try_read_recv_fd(&mut self, buf: &mut [u8]) -> io::Result<Option<(usize, Option<RawFd>)>> {
+        self.read_recv_fd(buf).map_non_block()
+    }
+
+    pub fn try_read_buf_recv_fd<B: MutBuf>(&mut self, buf: &mut B) -> io::Result<Option<(usize, Option<RawFd>)>> {
+        let res = self.try_read_recv_fd(unsafe { buf.mut_bytes() });
+        if let Ok(Some((cnt, _))) = res {
+            buf.advance(cnt);
+        }
+        res
+    }
+
+    pub fn write_send_fd(&mut self, buf: &[u8], fd: RawFd) -> io::Result<usize> {
+        self.sys.write_send_fd(buf, fd)
+    }
+
+    pub fn try_write_send_fd(&mut self, buf: &[u8], fd: RawFd) -> io::Result<Option<usize>> {
+        self.write_send_fd(buf, fd).map_non_block()
+    }
+
+    pub fn try_write_buf_send_fd<B: Buf>(&mut self, buf: &mut B, fd: RawFd) -> io::Result<Option<usize>> {
+        let res = self.try_write_send_fd(buf.bytes(), fd);
+        if let Ok(Some(cnt)) = res {
+            buf.advance(cnt);
+        }
+        res
     }
 }
 

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -57,6 +57,8 @@ mod nix {
         InetAddr,
         Ipv4Addr,
         Ipv6Addr,
+        ControlMessage,
+        CmsgSpace,
         MSG_DONTWAIT,
         SOCK_NONBLOCK,
         SOCK_CLOEXEC,
@@ -71,13 +73,16 @@ mod nix {
         linger,
         listen,
         recvfrom,
+        recvmsg,
         sendto,
+        sendmsg,
         setsockopt,
         socket,
         shutdown,
         Shutdown,
     };
     pub use nix::sys::time::TimeVal;
+    pub use nix::sys::uio::IoVec;
     pub use nix::unistd::{
         read,
         write,

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,3 +1,4 @@
+use io::MapNonBlock;
 use std::io::{Read, Write};
 use std::net::{self, SocketAddr};
 use std::os::unix::io::{RawFd, FromRawFd, AsRawFd};
@@ -133,8 +134,8 @@ impl TcpListener {
     pub fn accept(&self) -> io::Result<Option<(TcpStream, SocketAddr)>> {
         self.inner.accept().and_then(|(s, a)| {
             try!(set_nonblock(&s));
-            Ok(Some((TcpStream { inner: s }, a)))
-        }).or_else(io::to_non_block)
+            Ok((TcpStream { inner: s }, a))
+        }).map_non_block()
     }
 
     pub fn take_socket_error(&self) -> io::Result<()> {

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,4 +1,5 @@
 use {io, Evented, EventSet, Io, IpAddr, PollOpt, Selector, Token};
+use io::MapNonBlock;
 use sys::unix::{net, nix, Socket};
 use std::net::SocketAddr;
 use std::os::unix::io::{RawFd, AsRawFd, FromRawFd};
@@ -38,15 +39,14 @@ impl UdpSocket {
     pub fn send_to(&self, buf: &[u8], target: &SocketAddr)
                    -> io::Result<Option<usize>> {
         net::sendto(&self.io, buf, &net::to_nix_addr(target))
-            .map(Some)
-            .or_else(io::to_non_block)
+            .map_non_block()
     }
 
     pub fn recv_from(&self, buf: &mut [u8])
                      -> io::Result<Option<(usize, SocketAddr)>> {
         net::recvfrom(&self.io, buf)
-            .map(|(cnt, addr)| Some((cnt, net::to_std_addr(addr))))
-            .or_else(io::to_non_block)
+            .map(|(cnt, addr)| (cnt, net::to_std_addr(addr)))
+            .map_non_block()
     }
 
     pub fn set_broadcast(&self, on: bool) -> io::Result<()> {

--- a/src/sys/unix/uds.rs
+++ b/src/sys/unix/uds.rs
@@ -1,4 +1,5 @@
 use {io, Evented, EventSet, Io, PollOpt, Selector, Token, TryAccept};
+use io::MapNonBlock;
 use sys::unix::{net, nix, Socket};
 use std::io::{Read, Write};
 use std::path::Path;
@@ -32,8 +33,8 @@ impl UnixSocket {
 
     pub fn accept(&self) -> io::Result<Option<UnixSocket>> {
         net::accept(&self.io, true)
-            .map(|fd| Some(From::from(Io::from_raw_fd(fd))))
-            .or_else(io::to_non_block)
+            .map(|fd| From::from(Io::from_raw_fd(fd)))
+            .map_non_block()
     }
 
     /// Bind the socket to the specified address

--- a/test/test.rs
+++ b/test/test.rs
@@ -20,6 +20,8 @@ mod test_timer;
 mod test_udp_socket;
 #[cfg(unix)]
 mod test_unix_echo_server;
+#[cfg(unix)]
+mod test_unix_pass_fd;
 
 mod ports {
     use std::net::SocketAddr;

--- a/test/test_unix_pass_fd.rs
+++ b/test/test_unix_pass_fd.rs
@@ -1,0 +1,315 @@
+use mio::*;
+use mio::unix::*;
+use bytes::{Buf, ByteBuf, MutByteBuf, SliceBuf};
+use mio::util::Slab;
+use std::path::PathBuf;
+use std::io;
+use std::os::unix::io::AsRawFd;
+use tempdir::TempDir;
+
+const SERVER: Token = Token(0);
+const CLIENT: Token = Token(1);
+
+struct EchoConn {
+    sock: UnixStream,
+    pipe_fd: Option<PipeReader>,
+    token: Option<Token>,
+    interest: EventSet,
+}
+
+impl EchoConn {
+    fn new(sock: UnixStream) -> EchoConn {
+        EchoConn {
+            sock: sock,
+            pipe_fd: None,
+            token: None,
+            interest: EventSet::hup(),
+        }
+    }
+
+    fn writable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
+        let fd = self.pipe_fd.take().unwrap();
+
+        match self.sock.try_write_send_fd(b"x", fd.as_raw_fd()) {
+            Ok(None) => {
+                debug!("client flushing buf; WOULDBLOCK");
+
+                self.pipe_fd = Some(fd);
+                self.interest.insert(EventSet::writable());
+            }
+            Ok(Some(r)) => {
+                debug!("CONN : we wrote {} bytes!", r);
+
+                self.interest.insert(EventSet::readable());
+                self.interest.remove(EventSet::writable());
+            }
+            Err(e) => debug!("not implemented; client err={:?}", e),
+        }
+
+        event_loop.reregister(&self.sock, self.token.unwrap(), self.interest, PollOpt::edge() | PollOpt::oneshot())
+    }
+
+    fn readable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
+        let mut buf = ByteBuf::mut_with_capacity(2048);
+
+        match self.sock.try_read_buf(&mut buf) {
+            Ok(None) => {
+                panic!("We just got readable, but were unable to read from the socket?");
+            }
+            Ok(Some(r)) => {
+                debug!("CONN : we read {} bytes!", r);
+                self.interest.remove(EventSet::readable());
+                self.interest.insert(EventSet::writable());
+            }
+            Err(e) => {
+                debug!("not implemented; client err={:?}", e);
+                self.interest.remove(EventSet::readable());
+            }
+
+        };
+
+        // create fd to pass back. Assume that the write will work
+        // without blocking, for simplicity -- we're only testing that
+        // the FD makes it through somehow
+        let (rd, mut wr) = pipe().unwrap();
+        let mut buf = buf.flip();
+        match wr.try_write_buf(&mut buf) {
+            Ok(None) => {
+                panic!("writing to our own pipe blocked :(");
+            }
+            Ok(Some(r)) => {
+                debug!("CONN: we wrote {} bytes to the FD", r);
+            }
+            Err(e) => {
+                panic!("not implemented; client err={:?}", e);
+            }
+        }
+        self.pipe_fd = Some(rd);
+
+        event_loop.reregister(&self.sock, self.token.unwrap(), self.interest, PollOpt::edge() | PollOpt::oneshot())
+    }
+}
+
+struct EchoServer {
+    sock: UnixListener,
+    conns: Slab<EchoConn>
+}
+
+impl EchoServer {
+    fn accept(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
+        debug!("server accepting socket");
+
+        let sock = self.sock.accept().unwrap().unwrap();
+        let conn = EchoConn::new(sock);
+        let tok = self.conns.insert(conn)
+            .ok().expect("could not add connectiont o slab");
+
+        // Register the connection
+        self.conns[tok].token = Some(tok);
+        event_loop.register(&self.conns[tok].sock, tok, EventSet::readable(), PollOpt::edge() | PollOpt::oneshot())
+            .ok().expect("could not register socket with event loop");
+
+        Ok(())
+    }
+
+    fn conn_readable(&mut self, event_loop: &mut EventLoop<Echo>, tok: Token) -> io::Result<()> {
+        debug!("server conn readable; tok={:?}", tok);
+        self.conn(tok).readable(event_loop)
+    }
+
+    fn conn_writable(&mut self, event_loop: &mut EventLoop<Echo>, tok: Token) -> io::Result<()> {
+        debug!("server conn writable; tok={:?}", tok);
+        self.conn(tok).writable(event_loop)
+    }
+
+    fn conn<'a>(&'a mut self, tok: Token) -> &'a mut EchoConn {
+        &mut self.conns[tok]
+    }
+}
+
+struct EchoClient {
+    sock: UnixStream,
+    msgs: Vec<&'static str>,
+    tx: SliceBuf<'static>,
+    rx: SliceBuf<'static>,
+    mut_buf: Option<MutByteBuf>,
+    token: Token,
+    interest: EventSet,
+}
+
+
+// Sends a message and expects to receive the same exact message, one at a time
+impl EchoClient {
+    fn new(sock: UnixStream, tok: Token,  mut msgs: Vec<&'static str>) -> EchoClient {
+        let curr = msgs.remove(0);
+
+        EchoClient {
+            sock: sock,
+            msgs: msgs,
+            tx: SliceBuf::wrap(curr.as_bytes()),
+            rx: SliceBuf::wrap(curr.as_bytes()),
+            mut_buf: Some(ByteBuf::mut_with_capacity(2048)),
+            token: tok,
+            interest: EventSet::none(),
+        }
+    }
+
+    fn readable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
+        debug!("client socket readable");
+
+        let mut buf = self.mut_buf.take().unwrap();
+        let mut pipe: PipeReader;
+
+        match self.sock.try_read_buf_recv_fd(&mut buf) {
+            Ok(None) => {
+                panic!("We just got readable, but were unable to read from the socket?");
+            }
+            Ok(Some((_, None))) => {
+                panic!("Did not receive passed file descriptor");
+            }
+            Ok(Some((r, Some(fd)))) => {
+                debug!("CLIENT : We read {} bytes!", r);
+                pipe = From::<Io>::from(From::from(fd));
+            }
+            Err(e) => {
+                panic!("not implemented; client err={:?}", e);
+            }
+        };
+
+        // read the message accompanying the FD
+        let mut buf = buf.flip();
+        assert_eq!(buf.remaining(), 1);
+        assert_eq!(buf.read_byte(), Some(b'x'));
+
+        // read the data out of the FD itself
+        let mut buf = buf.flip();
+        match pipe.try_read_buf(&mut buf) {
+            Ok(None) => {
+                panic!("unimplemented");
+            }
+            Ok(Some(r)) => {
+                debug!("CLIENT : We read {} bytes from the FD", r);
+            }
+            Err(e) => {
+                panic!("not implemented, client err={:?}", e);
+            }
+        }
+
+        let mut buf = buf.flip();
+
+        debug!("CLIENT : buf = {:?} -- rx = {:?}", buf.bytes(), self.rx.bytes());
+        while buf.has_remaining() {
+            let actual = buf.read_byte().unwrap();
+            let expect = self.rx.read_byte().unwrap();
+
+            assert!(actual == expect, "actual={}; expect={}", actual, expect);
+        }
+
+        self.mut_buf = Some(buf.flip());
+
+        self.interest.remove(EventSet::readable());
+
+        if !self.rx.has_remaining() {
+            self.next_msg(event_loop).unwrap();
+        }
+
+        event_loop.reregister(&self.sock, self.token, self.interest, PollOpt::edge() | PollOpt::oneshot())
+    }
+
+    fn writable(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
+        debug!("client socket writable");
+
+        match self.sock.try_write_buf(&mut self.tx) {
+            Ok(None) => {
+                debug!("client flushing buf; WOULDBLOCK");
+                self.interest.insert(EventSet::writable());
+            }
+            Ok(Some(r)) => {
+                debug!("CLIENT : we wrote {} bytes!", r);
+                self.interest.insert(EventSet::readable());
+                self.interest.remove(EventSet::writable());
+            }
+            Err(e) => debug!("not implemented; client err={:?}", e)
+        }
+
+        event_loop.reregister(&self.sock, self.token, self.interest, PollOpt::edge() | PollOpt::oneshot())
+    }
+
+    fn next_msg(&mut self, event_loop: &mut EventLoop<Echo>) -> io::Result<()> {
+        if self.msgs.is_empty() {
+            event_loop.shutdown();
+            return Ok(());
+        }
+
+        let curr = self.msgs.remove(0);
+
+        debug!("client prepping next message");
+        self.tx = SliceBuf::wrap(curr.as_bytes());
+        self.rx = SliceBuf::wrap(curr.as_bytes());
+
+        self.interest.insert(EventSet::writable());
+        event_loop.reregister(&self.sock, self.token, self.interest, PollOpt::edge() | PollOpt::oneshot())
+    }
+}
+
+struct Echo {
+    server: EchoServer,
+    client: EchoClient,
+}
+
+impl Echo {
+    fn new(srv: UnixListener, client: UnixStream, msgs: Vec<&'static str>) -> Echo {
+        Echo {
+            server: EchoServer {
+                sock: srv,
+                conns: Slab::new_starting_at(Token(2), 128)
+            },
+            client: EchoClient::new(client, CLIENT, msgs)
+        }
+    }
+}
+
+impl Handler for Echo {
+    type Timeout = usize;
+    type Message = ();
+
+    fn ready(&mut self, event_loop: &mut EventLoop<Echo>, token: Token, events: EventSet) {
+        if events.is_readable() {
+            match token {
+                SERVER => self.server.accept(event_loop).unwrap(),
+                CLIENT => self.client.readable(event_loop).unwrap(),
+                i => self.server.conn_readable(event_loop, i).unwrap()
+            };
+        }
+
+        if events.is_writable() {
+            match token {
+                SERVER => panic!("received writable for token 0"),
+                CLIENT => self.client.writable(event_loop).unwrap(),
+                _ => self.server.conn_writable(event_loop, token).unwrap()
+            };
+        }
+    }
+}
+
+#[test]
+pub fn test_unix_pass_fd() {
+    debug!("Starting TEST_UNIX_PASS_FD");
+    let mut event_loop = EventLoop::new().unwrap();
+
+    let tmp_dir = TempDir::new("test_unix_pass_fd").unwrap();
+    let addr = tmp_dir.path().join(&PathBuf::from("sock"));
+
+    let srv = UnixListener::bind(&addr).unwrap();
+
+    info!("listen for connections");
+    event_loop.register(&srv, SERVER, EventSet::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+
+    let sock = UnixStream::connect(&addr).unwrap();
+
+    // Connect to the server
+    event_loop.register(&sock, CLIENT, EventSet::writable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+
+    // Start the event loop
+    event_loop.run(&mut Echo::new(srv, sock, vec!["foo", "bar"])).unwrap();
+}


### PR DESCRIPTION
Add `UnixStream::read_recv_fd` and `write_send_fd`, which can read and write a `RawFd` that is passed over the socket. The file descriptor is duplicated as if with `dup()`, except that it can be passed across processes.

Also add `try_read_recv_fd`, `try_read_buf_recv_fd`, `try_write_send_fd`, and `try_write_buf_send_fd`, analogous to the functions on the `TryRead` and `TryWrite` traits.

Since this functionality is unique to UNIX domain sockets, the new functions are directly on `UnixStream` and not part of a trait.

---

Depends on a nix with carllerche/nix-rust#197 (cmsg, merged earlier today) and carllerche/nix-rust#198 (fix sockaddr_un, just proposed for merge). Also I have a tiny refactoring of `to_non_block` which captures a common pattern in a more readable way IMO, but if you don't like it I can drop it.