### PR TITLE
Coerce kqueue filter to always listen for hup

### DIFF
--- a/src/util/mpmc_bounded_queue.rs
+++ b/src/util/mpmc_bounded_queue.rs
@@ -181,12 +181,12 @@ mod tests {
         assert_eq!(None, q.pop());
         let (tx, rx) = channel();
 
-        for _ in (0..nthreads) {
+        for _ in 0..nthreads {
             let q = q.clone();
             let tx = tx.clone();
             thread::spawn(move || {
                 let q = q;
-                for i in (0..nmsgs) {
+                for i in 0..nmsgs {
                     assert!(q.push(i).is_ok());
                 }
                 tx.send(()).unwrap();
@@ -194,7 +194,7 @@ mod tests {
         }
 
         let mut completion_rxs = vec![];
-        for _ in (0..nthreads) {
+        for _ in 0..nthreads {
             let (tx, rx) = channel();
             completion_rxs.push(rx);
             let q = q.clone();
@@ -217,7 +217,7 @@ mod tests {
         for rx in completion_rxs.iter_mut() {
             assert_eq!(nmsgs, rx.recv().unwrap());
         }
-        for _ in (0..nthreads) {
+        for _ in 0..nthreads {
             rx.recv().unwrap();
         }
     }

--- a/test/test.rs
+++ b/test/test.rs
@@ -14,6 +14,7 @@ mod test_echo_server;
 mod test_multicast;
 mod test_notify;
 mod test_register_deregister;
+mod test_eventset_hup;
 #[cfg(unix)]
 mod test_tick;
 mod test_timer;

--- a/test/test_eventset_hup.rs
+++ b/test/test_eventset_hup.rs
@@ -1,0 +1,38 @@
+use mio::{EventLoop, Handler, Token, EventSet, PollOpt};
+use mio::tcp::{TcpListener, TcpStream};
+use super::localhost;
+
+struct H { listener: TcpListener }
+
+impl Handler for H {
+    type Timeout = ();
+    type Message = ();
+
+    fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token, _events: EventSet) {
+        if token == Token(1) {
+            let (s, _) = self.listener.accept().unwrap().unwrap();
+            event_loop.register(&s, Token(3), EventSet::all(), PollOpt::edge()).unwrap();
+            drop(s);
+        } else if token == Token(2) {
+            event_loop.shutdown();
+        }
+    }
+}
+
+#[test]
+pub fn test_eventset_hup() {
+
+    ::env_logger::init().unwrap();
+    debug!("Starting TEST_EVENTSET_HUP");
+
+    let addr = localhost();
+    let l = TcpListener::bind(&addr).unwrap();
+    let s = TcpStream::connect(&addr).unwrap();
+
+    let mut e = EventLoop::new().unwrap();
+    e.register(&l, Token(1), EventSet::readable(), PollOpt::edge()).unwrap();
+    e.register(&s, Token(2), EventSet::hup(), PollOpt::edge()).unwrap();
+
+    let mut h = H { listener: l };
+    e.run(&mut h).unwrap();
+}


### PR DESCRIPTION
Changes the kqueue registration code to check if both the read and write
filters are disabled. If they are and we want to listen for hup, it
forces the read filter to be enabled.

Fixes #240