### PR TITLE
epoll: Should also work with Android.

### DIFF
--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 mod epoll;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub use self::epoll::{Events, Selector};
 
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "dragonfly"))]

--- a/src/util/mpmc_bounded_queue.rs
+++ b/src/util/mpmc_bounded_queue.rs
@@ -181,12 +181,12 @@ mod tests {
         assert_eq!(None, q.pop());
         let (tx, rx) = channel();
 
-        for _ in (0..nthreads) {
+        for _ in 0..nthreads {
             let q = q.clone();
             let tx = tx.clone();
             thread::spawn(move || {
                 let q = q;
-                for i in (0..nmsgs) {
+                for i in 0..nmsgs {
                     assert!(q.push(i).is_ok());
                 }
                 tx.send(()).unwrap();
@@ -194,7 +194,7 @@ mod tests {
         }
 
         let mut completion_rxs = vec![];
-        for _ in (0..nthreads) {
+        for _ in 0..nthreads {
             let (tx, rx) = channel();
             completion_rxs.push(rx);
             let q = q.clone();
@@ -217,7 +217,7 @@ mod tests {
         for rx in completion_rxs.iter_mut() {
             assert_eq!(nmsgs, rx.recv().unwrap());
         }
-        for _ in (0..nthreads) {
+        for _ in 0..nthreads {
             rx.recv().unwrap();
         }
     }


### PR DESCRIPTION
Compiled the tests in rustc-1.4-beta with gcc targeting Android API 9.
All the tests (mio, test, smoke and tcp) passed in an ARM Android 4.2.2.