### PR TITLE
Use clock_ticks 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name          = "mio"
-version       = "0.4.3"
+version       = "0.4.4"
 license       = "MIT"
 authors       = ["Carl Lerche <me@carllerche.com>"]
 description   = "Lightweight non-blocking IO"
@@ -24,7 +24,7 @@ libc  = "0.1.8"
 slab  = "0.1.0"
 bytes = "0.2.11"
 winapi = "0.1.23"
-clock_ticks = "0.0.5"
+clock_ticks = "0.1.0"
 
 [dev-dependencies]
 env_logger = "0.3.0"


### PR DESCRIPTION
clock_ticks 0.0.5 had a wildcard dependency on libc, which is now pulling in 0.2.0, which breaks the build on Windows.

clock_ticks 0.1.0 specifies libc 0.1, which should fix things again.

I've taken the liberty of bumping the version number to 0.4.4 - it'd be great if you could publish this so we can all have fixed builds again.

Thanks!