### PR TITLE
NetBSD tweaks

### DIFF
--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -77,6 +77,7 @@ impl Selector {
         self.ev_push(fd, token, filter, flags);
     }
 
+    #[cfg(not(target_os = "netbsd"))]
     fn ev_push(&mut self, fd: RawFd, token: usize, filter: EventFilter, flags: EventFlag) {
         self.changes.sys_events.push(
             KEvent {
@@ -86,6 +87,19 @@ impl Selector {
                 fflags: FilterFlag::empty(),
                 data: 0,
                 udata: token
+            });
+    }
+
+    #[cfg(target_os = "netbsd")]
+    fn ev_push(&mut self, fd: RawFd, token: usize, filter: EventFilter, flags: EventFlag) {
+        self.changes.sys_events.push(
+            KEvent {
+                ident: fd as ::libc::uintptr_t,
+                filter: filter,
+                flags: flags,
+                fflags: FilterFlag::empty(),
+                data: 0,
+                udata: token as i64
             });
     }
 

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -4,10 +4,12 @@ mod epoll;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub use self::epoll::{Events, Selector};
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "dragonfly"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd",
+    target_os = "dragonfly", target_os = "netbsd",))]
 mod kqueue;
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "dragonfly"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd",
+    target_os = "dragonfly", target_os = "netbsd",))]
 pub use self::kqueue::{Events, Selector};
 
 mod awakener;
@@ -89,4 +91,3 @@ mod nix {
         dup,
     };
 }
-


### PR DESCRIPTION
Two minor tweaks to get mio running under netbsd.  The conditional compilation for `ev_push` is because netbsd uses an i64 for `data`, instead of usize like the other OS's.

This depends on https://github.com/rust-lang-nursery/net2-rs/pull/20 and https://github.com/carllerche/nix-rust/pull/207 (and subsequently bumping the revision of nix-rust in `Cargo.toml` once/if merged)

Verified by cross-compiling the Getting Started ping_pong demo for a rumprun unikernel (which uses the netbsd drivers). There may well be other problems or something that I didn't tweak correctly, since the example only touches a small portion of the mio codebase...but it should at least provide a base to work from.

Obligatory, fun screenshot:

![mio_rumprun_qemu](https://cloud.githubusercontent.com/assets/1224228/11324038/d1270448-90f2-11e5-913b-56e27ea46291.png)