### PR TITLE
Associate sockets with a `Selector`

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -2,7 +2,7 @@ use {EventSet, Selector, PollOpt, Token};
 use bytes::{Buf, MutBuf};
 
 // Re-export the io::Result / Error types for convenience
-pub use std::io::{Read, Write, Result, Error};
+pub use std::io::{Read, Write, Result, Error, ErrorKind};
 
 /// A value that may be registered with an `EventLoop`
 pub trait Evented {

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -5,19 +5,36 @@ use nix::sys::event::{EV_ADD, EV_CLEAR, EV_DELETE, EV_DISABLE, EV_ENABLE, EV_EOF
 use std::{fmt, slice};
 use std::os::unix::io::RawFd;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+
+/// Each Selector has a globally unique(ish) ID associated with it. This ID
+/// gets tracked by `TcpStream`, `TcpListener`, etc... when they are first
+/// registered with the `Selector`. If a type that is previously associatd with
+/// a `Selector` attempts to register itself with a different `Selector`, the
+/// operation will return with an error. This matches windows behavior.
+static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 
 #[derive(Debug)]
 pub struct Selector {
+    id: usize,
     kq: RawFd,
     changes: Events
 }
 
 impl Selector {
     pub fn new() -> io::Result<Selector> {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let kq = try!(kqueue().map_err(super::from_nix_error));
+
         Ok(Selector {
-            kq: try!(kqueue().map_err(super::from_nix_error)),
+            id: id,
+            kq: kq,
             changes: Events::new()
         })
+    }
+
+    pub fn id(&self) -> usize {
+        self.id
     }
 
     pub fn select(&mut self, evts: &mut Events, timeout_ms: usize) -> io::Result<()> {

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,25 +1,37 @@
 use {io, Evented, EventSet, Io, IpAddr, PollOpt, Selector, Token};
 use io::MapNonBlock;
 use sys::unix::{net, nix, Socket};
+use std::cell::Cell;
 use std::net::SocketAddr;
 use std::os::unix::io::{RawFd, AsRawFd, FromRawFd};
 
 #[derive(Debug)]
 pub struct UdpSocket {
     io: Io,
+    selector_id: Cell<Option<usize>>,
 }
 
 impl UdpSocket {
     /// Returns a new, unbound, non-blocking, IPv4 UDP socket
     pub fn v4() -> io::Result<UdpSocket> {
         net::socket(nix::AddressFamily::Inet, nix::SockType::Datagram, true)
-            .map(|fd| UdpSocket { io: Io::from_raw_fd(fd) })
+            .map(|fd| {
+                UdpSocket {
+                    io: Io::from_raw_fd(fd),
+                    selector_id: Cell::new(None),
+                }
+            })
     }
 
     /// Returns a new, unbound, non-blocking, IPv6 UDP socket
     pub fn v6() -> io::Result<UdpSocket> {
         net::socket(nix::AddressFamily::Inet6, nix::SockType::Datagram, true)
-            .map(|fd| UdpSocket { io: Io::from_raw_fd(fd) })
+            .map(|fd| {
+                UdpSocket {
+                    io: Io::from_raw_fd(fd),
+                    selector_id: Cell::new(None),
+                }
+            })
     }
 
     pub fn bind(&self, addr: &SocketAddr) -> io::Result<()> {
@@ -32,8 +44,12 @@ impl UdpSocket {
     }
 
     pub fn try_clone(&self) -> io::Result<UdpSocket> {
-        net::dup(&self.io)
-            .map(From::from)
+        net::dup(&self.io).map(|io| {
+            UdpSocket {
+                io: io,
+                selector_id: self.selector_id.clone(),
+            }
+        })
     }
 
     pub fn send_to(&self, buf: &[u8], target: &SocketAddr)
@@ -113,10 +129,22 @@ impl UdpSocket {
         nix::setsockopt(self.as_raw_fd(), nix::sockopt::IpMulticastTtl, &v)
             .map_err(super::from_nix_error)
     }
+
+    fn associate_selector(&self, selector: &Selector) -> io::Result<()> {
+        let selector_id = self.selector_id.get();
+
+        if selector_id.is_some() && selector_id != Some(selector.id()) {
+            Err(io::Error::new(io::ErrorKind::Other, "socket already registered"))
+        } else {
+            self.selector_id.set(Some(selector.id()));
+            Ok(())
+        }
+    }
 }
 
 impl Evented for UdpSocket {
     fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
+        try!(self.associate_selector(selector));
         self.io.register(selector, token, interest, opts)
     }
 
@@ -132,15 +160,12 @@ impl Evented for UdpSocket {
 impl Socket for UdpSocket {
 }
 
-impl From<Io> for UdpSocket {
-    fn from(io: Io) -> UdpSocket {
-        UdpSocket { io: io }
-    }
-}
-
 impl FromRawFd for UdpSocket {
     unsafe fn from_raw_fd(fd: RawFd) -> UdpSocket {
-        UdpSocket { io: Io::from_raw_fd(fd) }
+        UdpSocket {
+            io: Io::from_raw_fd(fd),
+            selector_id: Cell::new(None),
+        }
     }
 }
 

--- a/test/test.rs
+++ b/test/test.rs
@@ -14,10 +14,13 @@ mod test_echo_server;
 mod test_multicast;
 mod test_notify;
 mod test_register_deregister;
+mod test_register_multiple_event_loops;
 #[cfg(unix)]
 mod test_tick;
 mod test_timer;
 mod test_udp_socket;
+
+// ===== Unix only tests =====
 #[cfg(unix)]
 mod test_unix_echo_server;
 #[cfg(unix)]

--- a/test/test_register_multiple_event_loops.rs
+++ b/test/test_register_multiple_event_loops.rs
@@ -1,0 +1,71 @@
+use super::localhost;
+use mio::*;
+use mio::tcp::*;
+use mio::udp::*;
+use std::io::ErrorKind;
+
+struct MyHandler;
+
+impl Handler for MyHandler {
+    type Timeout = ();
+    type Message = ();
+}
+
+#[test]
+fn test_tcp_register_multiple_event_loops() {
+    let addr = localhost();
+    let listener = TcpListener::bind(&addr).unwrap();
+
+    let mut event_loop_1 = EventLoop::<MyHandler>::new().unwrap();
+    event_loop_1.register(&listener, Token(0), EventSet::all(), PollOpt::edge()).unwrap();
+
+    let mut event_loop_2 = EventLoop::<MyHandler>::new().unwrap();
+
+    // Try registering the same socket with the initial one
+    let res = event_loop_2.register(&listener, Token(0), EventSet::all(), PollOpt::edge());
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
+
+    // Try cloning the socket and registering it again
+    let listener2 = listener.try_clone().unwrap();
+    let res = event_loop_2.register(&listener2, Token(0), EventSet::all(), PollOpt::edge());
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
+
+    // Try the stream
+    let stream = TcpStream::connect(&addr).unwrap();
+
+    event_loop_1.register(&stream, Token(1), EventSet::all(), PollOpt::edge()).unwrap();
+
+    let res = event_loop_2.register(&stream, Token(1), EventSet::all(), PollOpt::edge());
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
+
+    // Try cloning the socket and registering it again
+    let stream2 = stream.try_clone().unwrap();
+    let res = event_loop_2.register(&stream2, Token(1), EventSet::all(), PollOpt::edge());
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
+}
+
+#[test]
+fn test_udp_register_multiple_event_loops() {
+    let addr = localhost();
+    let socket = UdpSocket::bound(&addr).unwrap();
+
+    let mut event_loop_1 = EventLoop::<MyHandler>::new().unwrap();
+    event_loop_1.register(&socket, Token(0), EventSet::all(), PollOpt::edge()).unwrap();
+
+    let mut event_loop_2 = EventLoop::<MyHandler>::new().unwrap();
+
+    // Try registering the same socket with the initial one
+    let res = event_loop_2.register(&socket, Token(0), EventSet::all(), PollOpt::edge());
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
+
+    // Try cloning the socket and registering it again
+    let socket2 = socket.try_clone().unwrap();
+    let res = event_loop_2.register(&socket2, Token(0), EventSet::all(), PollOpt::edge());
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
+}


### PR DESCRIPTION
Closes #308

Windows requires that sockets are used exclusively with a single IOCP handle.
Unix platforms do not have this requirement. In order to provide a cross
platform API, Mio's network types artificially impose this limitations on Unix
platforms.

If a user of Mio would like to use a single socket with multiple event loops
on Unix platforms, this is possible by using `std::net` types and the
`EventedFd` wrapper.

/cc @alexcrichton 