### PR TITLE
Implement level triggering for windows

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -276,9 +276,8 @@ impl fmt::Debug for EventSet {
     }
 }
 
-
 // Keep this struct internal to mio
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct IoEvent {
     pub kind: EventSet,
     pub token: Token

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ mod token;
 pub use event::{
     PollOpt,
     EventSet,
+    IoEvent,
 };
 pub use event_loop::{
     EventLoop,
@@ -157,7 +158,8 @@ pub use notify::{
     NotifyError,
 };
 pub use poll::{
-    Poll
+    Poll,
+    Events,
 };
 pub use timer::{
     Timeout,

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -189,15 +189,16 @@ impl<M: Send> NotifyInner<M> {
 
 impl<M: Send> Evented for Notify<M> {
     fn register(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
+        assert!(opts.is_edge(), "awakener can only be registered using edge-triggered events");
         self.inner.awaken.register(selector, token, interest, opts)
     }
 
-    fn reregister(&self, selector: &mut Selector, token: Token, interest: EventSet, opts: PollOpt) -> io::Result<()> {
-        self.inner.awaken.reregister(selector, token, interest, opts)
+    fn reregister(&self, _: &mut Selector, _: Token, _: EventSet, _: PollOpt) -> io::Result<()> {
+        panic!("awakener is never reregistered");
     }
 
-    fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
-        self.inner.awaken.deregister(selector)
+    fn deregister(&self, _: &mut Selector) -> io::Result<()> {
+        panic!("awakener is never deregistered");
     }
 }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -2,8 +2,6 @@ use {sys, Evented, Token};
 use event::{EventSet, IoEvent, PollOpt};
 use std::{fmt, io};
 
-pub use sys::{Events};
-
 pub struct Poll {
     selector: sys::Selector,
     events: sys::Events,
@@ -58,6 +56,13 @@ impl Poll {
     pub fn event(&self, idx: usize) -> IoEvent {
         self.events.get(idx)
     }
+
+    pub fn events(&self) -> Events {
+        Events {
+            curr: 0,
+            poll: self,
+        }
+    }
 }
 
 impl fmt::Debug for Poll {
@@ -66,3 +71,21 @@ impl fmt::Debug for Poll {
     }
 }
 
+pub struct Events<'a> {
+    curr: usize,
+    poll: &'a Poll,
+}
+
+impl<'a> Iterator for Events<'a> {
+    type Item = IoEvent;
+
+    fn next(&mut self) -> Option<IoEvent> {
+        if self.curr == self.poll.events.len() {
+            return None;
+        }
+
+        let ret = self.poll.event(self.curr);
+        self.curr += 1;
+        Some(ret)
+    }
+}

--- a/src/sys/windows/awakener.rs
+++ b/src/sys/windows/awakener.rs
@@ -53,6 +53,6 @@ impl Evented for Awakener {
     }
 
     fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
-        self.iocp().deregister(selector)
+        self.iocp().checked_deregister(selector)
     }
 }

--- a/test/test.rs
+++ b/test/test.rs
@@ -15,9 +15,10 @@ mod test_multicast;
 mod test_notify;
 mod test_register_deregister;
 mod test_register_multiple_event_loops;
-#[cfg(unix)]
+mod test_tcp_level;
 mod test_tick;
 mod test_timer;
+mod test_udp_level;
 mod test_udp_socket;
 
 // ===== Unix only tests =====

--- a/test/test_tcp_level.rs
+++ b/test/test_tcp_level.rs
@@ -1,0 +1,118 @@
+use mio::*;
+use mio::tcp::*;
+use std::io::Write;
+use std::thread;
+
+const MS: usize = 1_000;
+
+#[test]
+pub fn test_tcp_listener_level_triggered() {
+    let mut poll = Poll::new().unwrap();
+
+    // Create the listener
+    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+
+    // Register the listener with `Poll`
+    poll.register(&l, Token(0), EventSet::readable(), PollOpt::level()).unwrap();
+
+    let s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
+    poll.register(&s1, Token(1), EventSet::readable(), PollOpt::edge()).unwrap();
+
+    poll.poll(MS).unwrap();
+    let events = filter(&poll, Token(0));
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0], IoEvent::new(EventSet::readable(), Token(0)));
+
+    poll.poll(MS).unwrap();
+    let events = filter(&poll, Token(0));
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0], IoEvent::new(EventSet::readable(), Token(0)));
+
+    // Accept the connection then test that the events stop
+    let _ = l.accept().unwrap();
+
+    poll.poll(MS).unwrap();
+    let events = filter(&poll, Token(0));
+    assert!(events.is_empty(), "actual={:?}", events);
+
+    let s3 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
+    poll.register(&s3, Token(2), EventSet::readable(), PollOpt::edge()).unwrap();
+
+    poll.poll(MS).unwrap();
+    let events = filter(&poll, Token(0));
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0], IoEvent::new(EventSet::readable(), Token(0)));
+
+    drop(l);
+
+    poll.poll(MS).unwrap();
+    let events = filter(&poll, Token(0));
+    assert!(events.is_empty());
+}
+
+#[test]
+pub fn test_tcp_stream_level_triggered() {
+    let mut poll = Poll::new().unwrap();
+
+    // Create the listener
+    let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+
+    // Register the listener with `Poll`
+    poll.register(&l, Token(0), EventSet::readable(), PollOpt::edge()).unwrap();
+
+    let mut s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
+    poll.register(&s1, Token(1), EventSet::readable() | EventSet::writable(), PollOpt::level()).unwrap();
+
+    let _ = poll.poll(MS).unwrap();
+    let events: Vec<IoEvent> = poll.events().collect();
+    assert!(events.len() == 2, "actual={:?}", events);
+    assert_eq!(filter(&poll, Token(1))[0], IoEvent::new(EventSet::writable(), Token(1)));
+
+    // Server side of socket
+    let (mut s1_tx, _) = l.accept().unwrap().unwrap();
+
+    poll.poll(MS).unwrap();
+    let events = filter(&poll, Token(1));
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0], IoEvent::new(EventSet::writable(), Token(1)));
+
+    // Register the socket
+    poll.register(&s1_tx, Token(123), EventSet::readable(), PollOpt::edge()).unwrap();
+
+    // Write some data
+    let res = s1_tx.write(b"hello world!");
+    assert!(res.unwrap() > 0);
+
+    // Sleep a bit to ensure it arrives at dest
+    thread::sleep_ms(250);
+
+    // Poll rx end
+    poll.poll(MS).unwrap();
+    let events = filter(&poll, Token(1));
+    assert!(events.len() == 1, "actual={:?}", events);
+    assert_eq!(events[0], IoEvent::new(EventSet::readable() | EventSet::writable(), Token(1)));
+
+    // Reading the data should clear it
+    let mut res = vec![];
+    while s1.try_read_buf(&mut res).unwrap().is_some() {
+    }
+
+    assert_eq!(res, b"hello world!");
+
+    poll.poll(MS).unwrap();
+    let events = filter(&poll, Token(1));
+    assert!(events.len() == 1);
+    assert_eq!(events[0], IoEvent::new(EventSet::writable(), Token(1)));
+
+    // Closing the socket clears all active level events
+    drop(s1);
+
+    poll.poll(MS).unwrap();
+    let events = filter(&poll, Token(1));
+    assert!(events.is_empty());
+}
+
+fn filter(poll: &Poll, token: Token) -> Vec<IoEvent> {
+    poll.events().filter(|e| e.token == token).collect()
+}

--- a/test/test_tick.rs
+++ b/test/test_tick.rs
@@ -1,5 +1,6 @@
 use mio::*;
-use std::io::Write;
+use mio::tcp::*;
+use std::thread;
 
 struct TestHandler {
     tick: usize,
@@ -28,6 +29,7 @@ impl Handler for TestHandler {
     }
 
     fn ready(&mut self, _event_loop: &mut EventLoop<TestHandler>, token: Token, events: EventSet) {
+        debug!("READY: {:?} - {:?}", token, events);
         if events.is_readable() {
             debug!("Handler::ready() readable event");
             assert_eq!(token, Token(0));
@@ -42,16 +44,17 @@ pub fn test_tick() {
     debug!("Starting TEST_TICK");
     let mut event_loop = EventLoop::new().ok().expect("Couldn't make event loop");
 
-    let (reader, mut writer) = unix::pipe().unwrap();
+    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    event_loop.register(&listener, Token(0), EventSet::readable(), PollOpt::level()).unwrap();
 
-    event_loop.register(&reader, Token(0), EventSet::all(),
-                        PollOpt::level()).unwrap();
+    let client = TcpStream::connect(&listener.local_addr().unwrap()).unwrap();
+    event_loop.register(&client, Token(1), EventSet::readable(), PollOpt::edge()).unwrap();
+
+    thread::sleep_ms(250);
 
     let mut handler = TestHandler::new();
-    writer.write(&[0u8]).unwrap();
 
     for _ in 0..2 {
-
         event_loop.run_once(&mut handler).unwrap();
     }
 

--- a/test/test_udp_level.rs
+++ b/test/test_udp_level.rs
@@ -1,0 +1,69 @@
+use mio::*;
+use mio::udp::*;
+use std::thread;
+
+const MS: usize = 1_000;
+
+#[test]
+pub fn test_udp_level_triggered() {
+    let mut poll = Poll::new().unwrap();
+
+    // Create the listener
+    let tx = UdpSocket::bound(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let rx = UdpSocket::bound(&"127.0.0.1:0".parse().unwrap()).unwrap();
+
+    poll.register(&tx, Token(0), EventSet::all(), PollOpt::level()).unwrap();
+    poll.register(&rx, Token(1), EventSet::all(), PollOpt::level()).unwrap();
+
+    for _ in 0..2 {
+        poll.poll(MS).unwrap();
+
+        let tx_events = filter(&poll, Token(0));
+        assert_eq!(1, tx_events.len());
+        assert_eq!(tx_events[0], IoEvent::new(EventSet::writable(), Token(0)));
+
+        let rx_events = filter(&poll, Token(1));
+        assert_eq!(1, rx_events.len());
+        assert_eq!(rx_events[0], IoEvent::new(EventSet::writable(), Token(1)));
+    }
+
+    tx.send_to(b"hello world!", &rx.local_addr().unwrap()).unwrap();
+
+    thread::sleep_ms(250);
+
+    for _ in 0..2 {
+        poll.poll(MS).unwrap();
+        let rx_events = filter(&poll, Token(1));
+        assert_eq!(1, rx_events.len());
+        assert_eq!(rx_events[0], IoEvent::new(EventSet::readable() | EventSet::writable(), Token(1)));
+    }
+
+    let mut buf = [0; 200];
+    while rx.recv_from(&mut buf).unwrap().is_some() {
+    }
+
+    for _ in 0..2 {
+        poll.poll(MS).unwrap();
+        let rx_events = filter(&poll, Token(1));
+        assert_eq!(1, rx_events.len());
+        assert_eq!(rx_events[0], IoEvent::new(EventSet::writable(), Token(1)));
+    }
+
+    tx.send_to(b"hello world!", &rx.local_addr().unwrap()).unwrap();
+    thread::sleep_ms(250);
+
+    poll.poll(MS).unwrap();
+    let rx_events = filter(&poll, Token(1));
+    assert_eq!(1, rx_events.len());
+    assert_eq!(rx_events[0], IoEvent::new(EventSet::readable() | EventSet::writable(), Token(1)));
+
+    drop(rx);
+
+    poll.poll(MS).unwrap();
+    let rx_events = filter(&poll, Token(1));
+    assert!(rx_events.is_empty());
+}
+
+fn filter(poll: &Poll, token: Token) -> Vec<IoEvent> {
+    poll.events().filter(|e| e.token == token).collect()
+}


### PR DESCRIPTION
The windows selector uses a linked list of currently active level-triggered events. When an event arrives and the socket is registered with level-triggered, the event is tracked in this linked list. Every call to select events will include all elements in this list. When an operation is performed on the socket such that the socket is no longer ready, the event is removed from the linked list.

Closes #241

## Remaining

- [x] Move calls to `unset_readiness` into `schedule_foo` functions.
- [x] Possibly combine `Registration::deregister` & `deregister2`
- [x] Remove `LinkedList`
- [x] UDP support
- [x] Uncomment prior tests using level