### PR TITLE
Reduce unnecessary poll wakeups

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -48,7 +48,7 @@ impl Poll {
         Ok(())
     }
 
-    pub fn poll(&mut self, timeout_ms: usize) -> io::Result<usize> {
+    pub fn poll(&mut self, timeout_ms: Option<usize>) -> io::Result<usize> {
         try!(self.selector.select(&mut self.events, timeout_ms));
         Ok(self.events.len())
     }

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -34,13 +34,12 @@ impl Selector {
     }
 
     /// Wait for events from the OS
-    pub fn select(&mut self, evts: &mut Events, timeout_ms: usize) -> io::Result<()> {
-        use std::{isize, slice};
+    pub fn select(&mut self, evts: &mut Events, timeout_ms: Option<usize>) -> io::Result<()> {
+        use std::{cmp, i32, slice};
 
-        let timeout_ms = if timeout_ms >= isize::MAX as usize {
-            isize::MAX
-        } else {
-            timeout_ms as isize
+        let timeout_ms = match timeout_ms {
+            None => -1 as i32,
+            Some(x) => cmp::min(i32::MAX as usize, x) as i32,
         };
 
         let dst = unsafe {
@@ -50,7 +49,7 @@ impl Selector {
         };
 
         // Wait for epoll events for at most timeout_ms milliseconds
-        let cnt = try!(epoll_wait(self.epfd, dst, timeout_ms)
+        let cnt = try!(epoll_wait(self.epfd, dst, timeout_ms as isize)
                            .map_err(super::from_nix_error));
 
         unsafe { evts.events.set_len(cnt); }

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -1,7 +1,8 @@
 use {io, EventSet, PollOpt, Token};
 use event::IoEvent;
-use nix::sys::event::{EventFilter, EventFlag, FilterFlag, KEvent, kqueue, kevent};
+use nix::sys::event::{EventFilter, EventFlag, FilterFlag, KEvent, kqueue, kevent, kevent_ts};
 use nix::sys::event::{EV_ADD, EV_CLEAR, EV_DELETE, EV_DISABLE, EV_ENABLE, EV_EOF, EV_ERROR, EV_ONESHOT};
+use libc::{timespec, time_t, c_long};
 use std::{fmt, slice};
 use std::os::unix::io::RawFd;
 use std::collections::HashMap;
@@ -37,8 +38,13 @@ impl Selector {
         self.id
     }
 
-    pub fn select(&mut self, evts: &mut Events, timeout_ms: usize) -> io::Result<()> {
-        let cnt = try!(kevent(self.kq, &[], evts.as_mut_slice(), timeout_ms)
+    pub fn select(&mut self, evts: &mut Events, timeout_ms: Option<usize>) -> io::Result<()> {
+        let timeout = timeout_ms.map(|x| timespec {
+            tv_sec: (x / 1000) as time_t,
+            tv_nsec: ((x % 1000) * 1_000_000) as c_long
+        });
+
+        let cnt = try!(kevent_ts(self.kq, &[], evts.as_mut_slice(), timeout)
                                   .map_err(super::from_nix_error));
 
         self.changes.sys_events.clear();

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -65,15 +65,19 @@ impl<T> Timer<T> {
     }
 
     // Number of ms remaining until the next tick
-    pub fn next_tick_in_ms(&self) -> u64 {
+    pub fn next_tick_in_ms(&self) -> Option<u64> {
+        if self.entries.count() == 0 {
+            return None;
+        }
+
         let now = self.now_ms();
         let nxt = self.start + (self.tick + 1) * self.tick_ms;
 
         if nxt <= now {
-            return 0;
+            return Some(0);
         }
 
-        nxt - now
+        Some(nxt - now)
     }
 
     /*

--- a/test/smoke.rs
+++ b/test/smoke.rs
@@ -26,7 +26,7 @@ fn reregister_before_register() {
 #[test]
 fn run_once_with_nothing() {
     let mut e = EventLoop::<E>::new().unwrap();
-    e.run_once(&mut E).unwrap();
+    e.run_once(&mut E, Some(100)).unwrap();
 }
 
 #[test]
@@ -35,5 +35,5 @@ fn add_then_drop() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     e.register(&l, Token(1), EventSet::all(), PollOpt::edge()).unwrap();
     drop(l);
-    e.run_once(&mut E).unwrap();
+    e.run_once(&mut E, Some(100)).unwrap();
 }

--- a/test/tcp.rs
+++ b/test/tcp.rs
@@ -245,7 +245,7 @@ fn listen_then_close() {
     drop(l);
 
     let mut h = H;
-    e.run_once(&mut h).unwrap();
+    e.run_once(&mut h, Some(100)).unwrap();
 }
 
 fn assert_send<T: Send>() {

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -222,8 +222,7 @@ impl Handler for Echo {
 pub fn test_echo_server() {
     debug!("Starting TEST_ECHO_SERVER");
     let mut config = EventLoopConfig::new();
-    config.io_poll_timeout_ms(1_000)
-          .notify_capacity(1_048_576)
+    config.notify_capacity(1_048_576)
           .messages_per_tick(64)
           .timer_tick_ms(100)
           .timer_wheel_size(1_024)

--- a/test/test_tcp_level.rs
+++ b/test/test_tcp_level.rs
@@ -18,13 +18,13 @@ pub fn test_tcp_listener_level_triggered() {
     let s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
     poll.register(&s1, Token(1), EventSet::readable(), PollOpt::edge()).unwrap();
 
-    poll.poll(MS).unwrap();
+    poll.poll(Some(MS)).unwrap();
     let events = filter(&poll, Token(0));
 
     assert_eq!(events.len(), 1);
     assert_eq!(events[0], IoEvent::new(EventSet::readable(), Token(0)));
 
-    poll.poll(MS).unwrap();
+    poll.poll(Some(MS)).unwrap();
     let events = filter(&poll, Token(0));
     assert_eq!(events.len(), 1);
     assert_eq!(events[0], IoEvent::new(EventSet::readable(), Token(0)));
@@ -32,21 +32,21 @@ pub fn test_tcp_listener_level_triggered() {
     // Accept the connection then test that the events stop
     let _ = l.accept().unwrap();
 
-    poll.poll(MS).unwrap();
+    poll.poll(Some(MS)).unwrap();
     let events = filter(&poll, Token(0));
     assert!(events.is_empty(), "actual={:?}", events);
 
     let s3 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
     poll.register(&s3, Token(2), EventSet::readable(), PollOpt::edge()).unwrap();
 
-    poll.poll(MS).unwrap();
+    poll.poll(Some(MS)).unwrap();
     let events = filter(&poll, Token(0));
     assert_eq!(events.len(), 1);
     assert_eq!(events[0], IoEvent::new(EventSet::readable(), Token(0)));
 
     drop(l);
 
-    poll.poll(MS).unwrap();
+    poll.poll(Some(MS)).unwrap();
     let events = filter(&poll, Token(0));
     assert!(events.is_empty());
 }
@@ -64,7 +64,7 @@ pub fn test_tcp_stream_level_triggered() {
     let mut s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
     poll.register(&s1, Token(1), EventSet::readable() | EventSet::writable(), PollOpt::level()).unwrap();
 
-    let _ = poll.poll(MS).unwrap();
+    let _ = poll.poll(Some(MS)).unwrap();
     let events: Vec<IoEvent> = poll.events().collect();
     assert!(events.len() == 2, "actual={:?}", events);
     assert_eq!(filter(&poll, Token(1))[0], IoEvent::new(EventSet::writable(), Token(1)));
@@ -72,7 +72,7 @@ pub fn test_tcp_stream_level_triggered() {
     // Server side of socket
     let (mut s1_tx, _) = l.accept().unwrap().unwrap();
 
-    poll.poll(MS).unwrap();
+    poll.poll(Some(MS)).unwrap();
     let events = filter(&poll, Token(1));
     assert_eq!(events.len(), 1);
     assert_eq!(events[0], IoEvent::new(EventSet::writable(), Token(1)));
@@ -88,7 +88,7 @@ pub fn test_tcp_stream_level_triggered() {
     thread::sleep_ms(250);
 
     // Poll rx end
-    poll.poll(MS).unwrap();
+    poll.poll(Some(MS)).unwrap();
     let events = filter(&poll, Token(1));
     assert!(events.len() == 1, "actual={:?}", events);
     assert_eq!(events[0], IoEvent::new(EventSet::readable() | EventSet::writable(), Token(1)));
@@ -100,7 +100,7 @@ pub fn test_tcp_stream_level_triggered() {
 
     assert_eq!(res, b"hello world!");
 
-    poll.poll(MS).unwrap();
+    poll.poll(Some(MS)).unwrap();
     let events = filter(&poll, Token(1));
     assert!(events.len() == 1);
     assert_eq!(events[0], IoEvent::new(EventSet::writable(), Token(1)));
@@ -108,7 +108,7 @@ pub fn test_tcp_stream_level_triggered() {
     // Closing the socket clears all active level events
     drop(s1);
 
-    poll.poll(MS).unwrap();
+    poll.poll(Some(MS)).unwrap();
     let events = filter(&poll, Token(1));
     assert!(events.is_empty());
 }

--- a/test/test_tick.rs
+++ b/test/test_tick.rs
@@ -55,7 +55,7 @@ pub fn test_tick() {
     let mut handler = TestHandler::new();
 
     for _ in 0..2 {
-        event_loop.run_once(&mut handler).unwrap();
+        event_loop.run_once(&mut handler, None).unwrap();
     }
 
     assert!(handler.tick == 2, "actual={}", handler.tick);

--- a/test/test_udp_level.rs
+++ b/test/test_udp_level.rs
@@ -16,7 +16,7 @@ pub fn test_udp_level_triggered() {
     poll.register(&rx, Token(1), EventSet::all(), PollOpt::level()).unwrap();
 
     for _ in 0..2 {
-        poll.poll(MS).unwrap();
+        poll.poll(Some(MS)).unwrap();
 
         let tx_events = filter(&poll, Token(0));
         assert_eq!(1, tx_events.len());
@@ -32,7 +32,7 @@ pub fn test_udp_level_triggered() {
     thread::sleep_ms(250);
 
     for _ in 0..2 {
-        poll.poll(MS).unwrap();
+        poll.poll(Some(MS)).unwrap();
         let rx_events = filter(&poll, Token(1));
         assert_eq!(1, rx_events.len());
         assert_eq!(rx_events[0], IoEvent::new(EventSet::readable() | EventSet::writable(), Token(1)));
@@ -43,7 +43,7 @@ pub fn test_udp_level_triggered() {
     }
 
     for _ in 0..2 {
-        poll.poll(MS).unwrap();
+        poll.poll(Some(MS)).unwrap();
         let rx_events = filter(&poll, Token(1));
         assert_eq!(1, rx_events.len());
         assert_eq!(rx_events[0], IoEvent::new(EventSet::writable(), Token(1)));
@@ -52,14 +52,14 @@ pub fn test_udp_level_triggered() {
     tx.send_to(b"hello world!", &rx.local_addr().unwrap()).unwrap();
     thread::sleep_ms(250);
 
-    poll.poll(MS).unwrap();
+    poll.poll(Some(MS)).unwrap();
     let rx_events = filter(&poll, Token(1));
     assert_eq!(1, rx_events.len());
     assert_eq!(rx_events[0], IoEvent::new(EventSet::readable() | EventSet::writable(), Token(1)));
 
     drop(rx);
 
-    poll.poll(MS).unwrap();
+    poll.poll(Some(MS)).unwrap();
     let rx_events = filter(&poll, Token(1));
     assert!(rx_events.is_empty());
 }


### PR DESCRIPTION
Based on #280 by luca-barbieri

Currently run() results in the process waking up every second or every timer
tick if set lower because a timeout is passed to the OS wait function.

This changes the code so that run_once() still uses the timeout, but
run() will instruct the OS to wait forever when there are no timers.

The notify mechanism already uses a pipe for awakening the event loop,
so there should be no need to use a timeout for that.

This saves CPU time and battery, and is generally the correct behavior.

Miscellaneous notes:

 * We also fix epoll because the maximum timeout supported by the Linux kernel is
   i32::MAX, not isize::MAX.
 * We fix next_tick_ms() being truncated from u64 to usize
 * It requires carllerche/nix-rust#192 to allow specifying no timeout to kevent()
 * The public API of Poll::poll is changed, but that can be avoided if desired.

Closes #289