### PR TITLE
Relax the Send bound on notify messages.

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -381,25 +381,23 @@ impl <H: Handler> Drop for EventLoop<H> {
 }
 
 /// Sends messages to the EventLoop from other threads.
-pub struct Sender<M: Send> {
+pub struct Sender<M> {
     notify: Notify<M>
 }
 
-impl<M: Send> Clone for Sender<M> {
+impl<M> Clone for Sender<M> {
     fn clone(&self) -> Sender<M> {
         Sender { notify: self.notify.clone() }
     }
 }
 
-impl<M: Send> fmt::Debug for Sender<M> {
+impl<M> fmt::Debug for Sender<M> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "Sender<?> {{ ... }}")
     }
 }
 
-unsafe impl<M: Send> Sync for Sender<M> { }
-
-impl<M: Send> Sender<M> {
+impl<M> Sender<M> {
     fn new(notify: Notify<M>) -> Sender<M> {
         Sender { notify: notify }
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -3,7 +3,7 @@ use {EventLoop, EventSet, Token};
 #[allow(unused_variables)]
 pub trait Handler: Sized {
     type Timeout;
-    type Message: Send;
+    type Message;
 
     /// Invoked when the socket represented by `token` is ready to be operated
     /// on. `events` indicates the specific operations that are

--- a/src/util/mpmc_bounded_queue.rs
+++ b/src/util/mpmc_bounded_queue.rs
@@ -57,13 +57,13 @@ struct State<T> {
 }
 
 unsafe impl<T: Send> Send for State<T> {}
-unsafe impl<T: Sync> Sync for State<T> {}
+unsafe impl<T: Send + Sync> Sync for State<T> {}
 
 pub struct Queue<T> {
     state: Arc<State<T>>,
 }
 
-impl<T: Send> State<T> {
+impl<T> State<T> {
     fn with_capacity(capacity: usize) -> State<T> {
         let capacity = if capacity < 2 || (capacity & (capacity - 1)) != 0 {
             if capacity < 2 {
@@ -145,7 +145,7 @@ impl<T: Send> State<T> {
     }
 }
 
-impl<T: Send> Queue<T> {
+impl<T> Queue<T> {
     pub fn with_capacity(capacity: usize) -> Queue<T> {
         Queue{
             state: Arc::new(State::with_capacity(capacity))
@@ -161,7 +161,7 @@ impl<T: Send> Queue<T> {
     }
 }
 
-impl<T: Send> Clone for Queue<T> {
+impl<T> Clone for Queue<T> {
     fn clone(&self) -> Queue<T> {
         Queue { state: self.state.clone() }
     }


### PR DESCRIPTION
With the relaxed bound, all types can be used as notify messages, but only if
the notify message type is Send will Senders be Send or Sync (and then notify
messages can actually travel between threads).