### PR TITLE
Remove all warnings during cargo test.

### DIFF
--- a/test/test.rs
+++ b/test/test.rs
@@ -54,7 +54,8 @@ mod ports {
     }
 }
 
-pub fn sleep_ms(ms: usize) {
+pub fn sleep_ms(ms: u64) {
     use std::thread;
-    thread::sleep_ms(ms as u32);
+    use std::time::Duration;
+    thread::sleep(Duration::from_millis(ms));
 }

--- a/test/test_battery.rs
+++ b/test/test_battery.rs
@@ -1,8 +1,7 @@
-use {sleep_ms};
+use {localhost, sleep_ms};
 use mio::*;
 use mio::tcp::*;
 use mio::util::Slab;
-use super::localhost;
 use std::collections::LinkedList;
 use std::{io, thread};
 

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -1,7 +1,7 @@
 use mio::*;
 use bytes::ByteBuf;
 use mio::tcp::*;
-use super::localhost;
+use localhost;
 
 use self::TestState::{Initial, AfterRead, AfterHup};
 

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -3,7 +3,7 @@ use mio::tcp::*;
 use bytes::{Buf, ByteBuf, MutByteBuf, SliceBuf};
 use mio::util::Slab;
 use std::io;
-use super::localhost;
+use localhost;
 
 const SERVER: Token = Token(0);
 const CLIENT: Token = Token(1);

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -3,7 +3,7 @@ use mio::udp::*;
 use bytes::{Buf, MutBuf, RingBuf, SliceBuf};
 use std::str;
 use std::net::{SocketAddr};
-use super::localhost;
+use localhost;
 
 const LISTENER: Token = Token(0);
 const SENDER: Token = Token(1);

--- a/test/test_notify.rs
+++ b/test/test_notify.rs
@@ -1,7 +1,6 @@
-use {sleep_ms};
+use {localhost, sleep_ms};
 use mio::*;
 use mio::tcp::*;
-use super::localhost;
 use std::thread;
 
 struct TestHandler {
@@ -174,7 +173,7 @@ pub fn test_notify_drop() {
     notify.send(MessageDrop(tx_notif_2)).unwrap();
 
     // We ensure the message is indeed stuck in the queue
-    thread::sleep_ms(100);
+    sleep_ms(100);
     assert!(rx_notif_2.try_recv().is_err());
 
     // Give the order to drop the event loop

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -1,7 +1,7 @@
 use mio::*;
 use mio::tcp::*;
 use bytes::SliceBuf;
-use super::localhost;
+use localhost;
 
 const SERVER: Token = Token(0);
 const CLIENT: Token = Token(1);

--- a/test/test_register_multiple_event_loops.rs
+++ b/test/test_register_multiple_event_loops.rs
@@ -1,4 +1,4 @@
-use super::localhost;
+use localhost;
 use mio::*;
 use mio::tcp::*;
 use mio::udp::*;

--- a/test/test_tcp_level.rs
+++ b/test/test_tcp_level.rs
@@ -1,7 +1,7 @@
 use mio::*;
 use mio::tcp::*;
 use std::io::Write;
-use std::thread;
+use sleep_ms;
 
 const MS: usize = 1_000;
 
@@ -85,7 +85,7 @@ pub fn test_tcp_stream_level_triggered() {
     assert!(res.unwrap() > 0);
 
     // Sleep a bit to ensure it arrives at dest
-    thread::sleep_ms(250);
+    sleep_ms(250);
 
     // Poll rx end
     poll.poll(Some(MS)).unwrap();

--- a/test/test_tick.rs
+++ b/test/test_tick.rs
@@ -1,6 +1,6 @@
 use mio::*;
 use mio::tcp::*;
-use std::thread;
+use {sleep_ms};
 
 struct TestHandler {
     tick: usize,
@@ -50,7 +50,7 @@ pub fn test_tick() {
     let client = TcpStream::connect(&listener.local_addr().unwrap()).unwrap();
     event_loop.register(&client, Token(1), EventSet::readable(), PollOpt::edge()).unwrap();
 
-    thread::sleep_ms(250);
+    sleep_ms(250);
 
     let mut handler = TestHandler::new();
 

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -1,7 +1,7 @@
 use mio::*;
 use mio::tcp::*;
 use bytes::{Buf, ByteBuf, SliceBuf};
-use super::localhost;
+use localhost;
 
 use self::TestState::{Initial, AfterRead, AfterHup};
 

--- a/test/test_udp_level.rs
+++ b/test/test_udp_level.rs
@@ -1,6 +1,6 @@
 use mio::*;
 use mio::udp::*;
-use std::thread;
+use sleep_ms;
 
 const MS: usize = 1_000;
 
@@ -29,7 +29,7 @@ pub fn test_udp_level_triggered() {
 
     tx.send_to(b"hello world!", &rx.local_addr().unwrap()).unwrap();
 
-    thread::sleep_ms(250);
+    sleep_ms(250);
 
     for _ in 0..2 {
         poll.poll(Some(MS)).unwrap();
@@ -50,7 +50,7 @@ pub fn test_udp_level_triggered() {
     }
 
     tx.send_to(b"hello world!", &rx.local_addr().unwrap()).unwrap();
-    thread::sleep_ms(250);
+    sleep_ms(250);
 
     poll.poll(Some(MS)).unwrap();
     let rx_events = filter(&poll, Token(1));

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -1,8 +1,8 @@
 use mio::*;
 use mio::udp::*;
 use bytes::{Buf, RingBuf, SliceBuf, MutBuf};
-use super::localhost;
 use std::str;
+use localhost;
 
 const LISTENER: Token = Token(0);
 const SENDER: Token = Token(1);


### PR DESCRIPTION
Primarily replace uses of the deprecated ::std::thread::sleep_ms with the util
test function sleep_ms.

Also did some small cleanup of imports.