### PR TITLE
Implement error::Error for TimerError

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -313,10 +313,6 @@ impl error::Error for TimerError {
     fn description(&self) -> &str {
         self.desc
     }
-
-    fn cause(&self) -> Option<&error::Error> {
-        None
-    }
 }
 
 #[derive(Debug)]

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -296,7 +296,7 @@ pub struct TimerError {
 
 impl fmt::Display for TimerError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.desc)
+        write!(fmt, "{}: {}", self.kind, self.desc)
     }
 }
 
@@ -322,6 +322,14 @@ impl error::Error for TimerError {
 #[derive(Debug)]
 pub enum TimerErrorKind {
     TimerOverflow,
+}
+
+impl fmt::Display for TimerErrorKind {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            TimerOverflow => write!(fmt, "TimerOverflow"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,7 +1,7 @@
 use token::Token;
 use util::Slab;
 use time::precise_time_ns;
-use std::{usize, iter};
+use std::{error, fmt, usize, iter};
 use std::cmp::max;
 
 use self::TimerErrorKind::TimerOverflow;
@@ -294,12 +294,28 @@ pub struct TimerError {
     desc: &'static str,
 }
 
+impl fmt::Display for TimerError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.desc)
+    }
+}
+
 impl TimerError {
     fn overflow() -> TimerError {
         TimerError {
             kind: TimerOverflow,
             desc: "too many timer entries"
         }
+    }
+}
+
+impl error::Error for TimerError {
+    fn description(&self) -> &str {
+        self.desc
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        None
     }
 }
 


### PR DESCRIPTION
I'm currently trying to wrap Mio for a coroutine library, and this will help me simplify my error handling. I think it is also a plus for Mio to implement the standard error traits as widely as possible.