### PR TITLE
Added set_reuse_address() and as_raw_socket() APIs

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -74,6 +74,10 @@ impl UdpSocket {
     pub fn set_multicast_time_to_live(&self, ttl: i32) -> io::Result<()> {
         self.sys.set_multicast_time_to_live(ttl)
     }
+
+    pub fn set_reuse_address(&self, reuse_address: bool) -> io::Result<()> {
+        self.sys.set_reuse_address(reuse_address)
+    }
 }
 
 impl Evented for UdpSocket {

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -508,6 +508,12 @@ impl TcpListener {
     }
 }
 
+impl AsRawSocket for TcpListener {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.inner().socket.as_raw_socket()
+    }
+}
+
 impl ListenerImp {
     fn inner(&self) -> MutexGuard<ListenerInner> {
         self.inner.inner.lock().unwrap()

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -219,6 +219,10 @@ impl UdpSocket {
         try!(self.inner().socket.socket()).set_multicast_ttl_v4(ttl as u32)
     }
 
+    pub fn set_reuse_address(&self, reuse_address: bool) -> io::Result<()> {
+        try!(self.inner().socket.builder()).reuse_address(reuse_address).map(|_| ())
+    }
+
     fn inner(&self) -> MutexGuard<Inner> {
         self.imp.inner()
     }
@@ -234,6 +238,15 @@ impl UdpSocket {
                     me.iocp.defer(EventSet::writable());
                 }
             }
+        }
+    }
+}
+
+impl AsRawSocket for UdpSocket {
+    fn as_raw_socket(&self) -> RawSocket {
+        match self.inner().socket {
+            Socket::Bound(ref s) => s.as_raw_socket(),
+            _ => INVALID_SOCKET,
         }
     }
 }


### PR DESCRIPTION
Using the set_reuse_address() API that is being introduced in this commit for ~~TcpListener and~~ UdpSocket sets SO_REUSEADDR on all platforms.
Furthermore it also sets SO_REUSEPORT on BSD platforms for UdpSockets, to implement a near-cross-platform behaviour, since most other platforms treat SO_REUSEADDR as if both options would have been set on BSD.

----

IMHO This PR is a good solution for #186. Since mio should be a abstraction of the differences between all platforms, it's necessary to provide a `reuse_address` API that hides those differences too and the solution in this commit implements the biggest common ground between those.
If someone depends on some platform specific behavior I recommend the usage of `as_raw_fd()` and the newly introduced `as_raw_socket()` functions instead (combined with `cfg!()` and the usual C APIs).
Furthermore this PR adds `ws2_32-sys` as a dependency but I don't think that this poses a problem since `miow` also depends on it.