### PR TITLE
Remove now default 'sudo: false'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-sudo: false
 rust:
   - nightly
   - 1.3.0


### PR DESCRIPTION
'sudo: false' is now the default on Travis CI