### PR TITLE
Implement Drop for kqueue Selector

### DIFF
--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -1,5 +1,6 @@
 use {io, EventSet, PollOpt, Token};
 use event::{self, Event};
+use nix::unistd::close;
 use nix::sys::event::{EventFilter, EventFlag, FilterFlag, KEvent, kqueue, kevent, kevent_ts};
 use nix::sys::event::{EV_ADD, EV_CLEAR, EV_DELETE, EV_DISABLE, EV_ENABLE, EV_EOF, EV_ERROR, EV_ONESHOT};
 use libc::{timespec, time_t, c_long};
@@ -132,6 +133,12 @@ impl Selector {
 
         self.changes.sys_events.clear();
         result
+    }
+}
+
+impl Drop for Selector {
+    fn drop(&mut self) {
+        let _ = close(self.kq);
     }
 }
 


### PR DESCRIPTION
Should fix issues where mio encounters a "Too many open files" error
when using kqueue.

Fixes #372