### PR TITLE
Separate Windows and Unix deps | remove dependency on deprecated time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,18 @@ exclude       = [
   "test/**/*",
 ]
 
-[dependencies]
-log    = "0.3.1"
+[target.'cfg(unix)'.dependencies]
 nix    = { git = "https://github.com/carllerche/nix-rust", rev = "c4257f8a76" }
 libc   = "0.2.4"
-slab   = "0.1.0"
-time   = "0.1.33"
-bytes  = "0.3.0"
+
+[target.'cfg(windows)'.dependencies]
 winapi = "0.2.1"
 miow   = "0.1.1"
+
+[dependencies]
+log    = "0.3.1"
+slab   = "0.1.0"
+bytes  = "0.3.0"
 net2   = { version = "0.2.19", default-features = false }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,15 +83,16 @@
 #![cfg_attr(unix, deny(warnings))]
 
 extern crate bytes;
-extern crate time;
 extern crate slab;
-extern crate libc;
 
 #[cfg(unix)]
 extern crate nix;
 
-extern crate winapi;
-extern crate miow;
+#[cfg(unix)] extern crate libc;
+
+#[cfg(windows)] extern crate miow;
+#[cfg(windows)] extern crate winapi;
+
 extern crate net2;
 
 #[macro_use]

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -156,7 +156,7 @@ impl<T> Timer<T> {
         // Update the head slot
         self.wheel[slot] = token;
 
-        println!("inserted timout; slot={}; token={:?}", slot, token);
+        trace!("inserted timout; slot={}; token={:?}", slot, token);
 
         // Return the new timeout
         Ok(Timeout {
@@ -198,12 +198,12 @@ impl<T> Timer<T> {
     }
 
     pub fn tick_to(&mut self, now: Tick) -> Option<T> {
-        println!("tick_to; now={}; tick={}", now, self.tick);
+        trace!("tick_to; now={}; tick={}", now, self.tick);
 
         while self.tick.0 <= now.0 {
             let curr = self.next;
 
-            println!("ticking; curr={:?}", curr);
+            trace!("ticking; curr={:?}", curr);
 
             if curr == EMPTY {
                 self.tick = Tick(self.tick.0 + 1);
@@ -212,7 +212,7 @@ impl<T> Timer<T> {
                 let links = self.entries[curr].links;
 
                 if links.tick <= self.tick.0 {
-                    println!("triggering; token={:?}", curr);
+                    trace!("triggering; token={:?}", curr);
 
                     // Unlink will also advance self.next
                     self.unlink(&links, curr);
@@ -415,7 +415,7 @@ mod test {
         t.timeout("d", Duration::from_millis(440)).unwrap();
 
         tick = t.duration_to_tick(Duration::from_millis(100));
-        println!("{}", tick.0);
+        trace!("{}", tick.0);
         assert_eq!(None, t.tick_to(tick));
 
         tick = t.duration_to_tick(Duration::from_millis(200));


### PR DESCRIPTION
This might be a bit controversial wrt the separation of unix and windows deps. I'm not entirely sure what the intended behaviors are supposed to be.  But the net effect of this commit is that when you compile on Linux, it doesn't pull down or compile any of the windows based crates, this speeds things up and avoids potential snafus. 