### PR TITLE
Remove local implementation of IpAddr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - nightly
   - stable
   # The following Rust version represents the oldest supported version of Mio
-  - 1.6.0
+  - 1.7.0
 
 os:
   - linux

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,9 +134,6 @@ pub use io::{
 pub use net::{
     tcp,
     udp,
-    IpAddr,
-    Ipv4Addr,
-    Ipv6Addr,
 };
 #[cfg(unix)]
 pub mod unix {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,33 +1,7 @@
 //! Networking primitives
 //!
-use std::net::AddrParseError;
-use std::str::FromStr;
-
 pub mod tcp;
 pub mod udp;
 
 #[cfg(unix)]
 pub mod unix;
-
-/// An IP address, either a IPv4 or IPv6 address.
-///
-/// Once `std::net::IpAddr` is stable, this will go away.
-pub enum IpAddr {
-    V4(Ipv4Addr),
-    V6(Ipv6Addr),
-}
-
-pub use std::net::Ipv4Addr;
-pub use std::net::Ipv6Addr;
-
-impl FromStr for IpAddr {
-    type Err = AddrParseError;
-
-    fn from_str(s: &str) -> Result<IpAddr, AddrParseError> {
-        s.parse()
-            .map(IpAddr::V4)
-            .or_else(|_| {
-                s.parse().map(IpAddr::V6)
-            })
-    }
-}

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,5 +1,5 @@
-use {io, sys, Evented, EventSet, IpAddr, Poll, PollOpt, Token};
-use std::net::SocketAddr;
+use {io, sys, Evented, EventSet, Poll, PollOpt, Token};
+use std::net::{IpAddr, SocketAddr};
 
 #[derive(Debug)]
 pub struct UdpSocket {

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,8 +1,8 @@
-use {io, poll, Evented, EventSet, Io, IpAddr, Poll, PollOpt, Token};
+use {io, poll, Evented, EventSet, Io, Poll, PollOpt, Token};
 use io::MapNonBlock;
 use sys::unix::{net, nix, Socket};
 use std::cell::Cell;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::os::unix::io::{RawFd, IntoRawFd, AsRawFd, FromRawFd};
 
 #[derive(Debug)]

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::io::prelude::*;
 use std::io;
 use std::mem;
-use std::net::{self, SocketAddr};
+use std::net::{self, IpAddr, SocketAddr};
 use std::os::windows::prelude::*;
 use std::sync::{Mutex, MutexGuard};
 
@@ -17,7 +17,7 @@ use miow::iocp::CompletionStatus;
 use miow::net::SocketAddrBuf;
 use miow::net::UdpSocketExt as MiowUdpSocketExt;
 
-use {poll, Evented, EventSet, IpAddr, Poll, PollOpt, Token};
+use {poll, Evented, EventSet, Poll, PollOpt, Token};
 use sys::windows::selector::{EventRef, Overlapped, Registration};
 use sys::windows::from_raw_arc::FromRawArc;
 use sys::windows::{bad_state, Family};

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -2,7 +2,7 @@ use mio::*;
 use mio::udp::*;
 use bytes::{Buf, MutBuf, RingBuf, SliceBuf};
 use std::str;
-use std::net::{SocketAddr};
+use std::net::{SocketAddr, Ipv4Addr};
 use localhost;
 
 const LISTENER: Token = Token(0);


### PR DESCRIPTION
The `std::net::IpAddr` enum was made stable in 1.7.0.

Fixes #379 

Note: this updates the **oldest** version mio supports from 1.6 to 1.7