### PR TITLE
fix/windows-crash: fix crash due to unwrap on Windows

### DIFF
--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::io::{self, Read, Write, Cursor};
+use std::io::{self, Read, Write, Cursor, ErrorKind};
 use std::mem;
 use std::net::{self, SocketAddr};
 use std::os::windows::prelude::*;
@@ -568,7 +568,14 @@ fn accept_done(status: &CompletionStatus, dst: &mut Vec<EventRef>) {
     };
     trace!("finished an accept");
     me.accept = match me.accept_buf.parse(&me.socket) {
-        Ok(buf) => State::Ready((socket, buf.remote().unwrap())),
+        Ok(buf) => {
+            if let Some(remote_addr) = buf.remote() {
+                State::Ready((socket, remote_addr))
+            } else {
+                State::Error(io::Error::new(ErrorKind::Other,
+                                            "Could not obtain remote address"));
+            }
+        }
         Err(e) => State::Error(e),
     };
     me2.push(&mut me, EventSet::readable(), dst);

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -573,7 +573,7 @@ fn accept_done(status: &CompletionStatus, dst: &mut Vec<EventRef>) {
                 State::Ready((socket, remote_addr))
             } else {
                 State::Error(io::Error::new(ErrorKind::Other,
-                                            "Could not obtain remote address"));
+                                            "Could not obtain remote address"))
             }
         }
         Err(e) => State::Error(e),


### PR DESCRIPTION
We run into cases every now and then when the remote address returned by miow crate is None. This usually happens during severing of connection and hence we are no longer interested in the remote address anyway. However mio crate tries to unwrap the returned option crashing in several of our usages (esp. when stressed). This fix aims to prevent that crash.