### PR TITLE
fix/windows-crash: fix crash due to unwrap on Windows

### DIFF
--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -5,11 +5,11 @@ use std::net::{self, SocketAddr};
 use std::os::unix::io::{RawFd, FromRawFd, AsRawFd};
 
 use libc;
-use net2::{TcpStreamExt, TcpListenerExt};
+use net2::{TcpStreamExt};
 use nix::fcntl::FcntlArg::F_SETFL;
 use nix::fcntl::{fcntl, O_NONBLOCK};
 
-use {io, Evented, EventSet, PollOpt, Selector, Token, TryAccept};
+use {io, Evented, EventSet, PollOpt, Selector, Token};
 use sys::unix::eventedfd::EventedFd;
 
 #[derive(Debug)]


### PR DESCRIPTION
We run into cases every now and then when the remote address returned by miow crate is None. This usually happens during severing of connection and hence we are no longer interested in the remote address anyway. However mio crate tries to unwrap the returned option crashing in several of our usages (esp. when stressed). This fix aims to prevent that crash.