### PR TITLE
impl std::fmt::Debug for mio::Timeout

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -37,7 +37,7 @@ pub struct Builder {
     capacity: usize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Timeout {
     // Reference into the timer entry slab
     token: Token,


### PR DESCRIPTION
closes #409