### PR TITLE
deps: use nix 0.6.0 from crates.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - nightly
   - stable
   # The following Rust version represents the oldest supported version of Mio
-  - 1.6.0
+  - 1.8.0
 
 os:
   - linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name          = "mio"
-version       = "0.5.0"
+version       = "0.5.2-dev"
 license       = "MIT"
 authors       = ["Carl Lerche <me@carllerche.com>"]
 description   = "Lightweight non-blocking IO"
@@ -19,7 +19,7 @@ exclude       = [
 
 [dependencies]
 log    = "0.3.1"
-nix    = { git = "https://github.com/carllerche/nix-rust", rev = "c4257f8a76" }
+nix    = "0.6.0"
 libc   = "0.2.4"
 slab   = "0.1.0"
 time   = "0.1.33"

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -19,8 +19,8 @@ fn test_basic_timer_without_poll() {
     // Nothing when polled immediately
     assert!(timer.poll().is_none());
 
-    // Wait for the timeout
-    sleep_ms(200);
+    // Wait for the timeout (plus some buffer)
+    sleep_ms(200 + 50);
 
     assert_eq!(Some("hello"), timer.poll());
     assert!(timer.poll().is_none());


### PR DESCRIPTION
After a bit of a drought, a new release of nix has been published
to crates.io.  Minor changes were required in order to get things
working again related to some small API changes to properly model
flags to calls like `recvmsg`.

Signed-off-by: Paul Osborne <osbpau@gmail.com>