### PR TITLE
adapt to latest nix (MsgFlags::empty())

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude       = [
 
 [dependencies]
 log    = "0.3.1"
-nix    = { git = "https://github.com/carllerche/nix-rust", rev = "c4257f8a76" }
+nix    = { git = "https://github.com/carllerche/nix-rust", branch="master" }
 libc   = "0.2.4"
 slab   = "0.1.0"
 time   = "0.1.33"

--- a/src/sys/unix/uds.rs
+++ b/src/sys/unix/uds.rs
@@ -4,7 +4,7 @@ use sys::unix::{net, nix, Socket};
 use std::io::{Read, Write};
 use std::path::Path;
 use std::os::unix::io::{RawFd, IntoRawFd, AsRawFd, FromRawFd};
-pub use nix::sys::socket::Shutdown;
+pub use nix::sys::socket::{Shutdown, MsgFlags};
 
 #[derive(Debug)]
 pub struct UnixSocket {
@@ -57,7 +57,7 @@ impl UnixSocket {
     pub fn read_recv_fd(&mut self, buf: &mut [u8]) -> io::Result<(usize, Option<RawFd>)> {
         let iov = [nix::IoVec::from_mut_slice(buf)];
         let mut cmsgspace: nix::CmsgSpace<[RawFd; 1]> = nix::CmsgSpace::new();
-        let msg = try!(nix::recvmsg(self.io.as_raw_fd(), &iov, Some(&mut cmsgspace), 0)
+        let msg = try!(nix::recvmsg(self.io.as_raw_fd(), &iov, Some(&mut cmsgspace), MsgFlags::empty())
                            .map_err(super::from_nix_error));
         let mut fd = None;
         for cmsg in msg.cmsgs() {
@@ -76,7 +76,7 @@ impl UnixSocket {
         let iov = [nix::IoVec::from_slice(buf)];
         let fds = [fd];
         let cmsg = nix::ControlMessage::ScmRights(&fds);
-        nix::sendmsg(self.io.as_raw_fd(),&iov, &[cmsg], 0, None)
+        nix::sendmsg(self.io.as_raw_fd(),&iov, &[cmsg], MsgFlags::empty(), None)
             .map_err(super::from_nix_error)
     }
 }


### PR DESCRIPTION
Merging this, the project mio would no longer depend on out-dated release of nix