### PR TITLE
Extract Events from Poll

### DIFF
--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -34,7 +34,7 @@ impl Selector {
     }
 
     /// Wait for events from the OS
-    pub fn select(&mut self, evts: &mut Events, awakener: Token, timeout_ms: Option<usize>) -> io::Result<bool> {
+    pub fn select(&self, evts: &mut Events, awakener: Token, timeout_ms: Option<usize>) -> io::Result<bool> {
         use std::{cmp, i32, slice};
 
         let timeout_ms = match timeout_ms {

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -45,7 +45,7 @@ impl Selector {
         self.id
     }
 
-    pub fn select(&mut self, evts: &mut Events, awakener: Token, timeout_ms: Option<usize>) -> io::Result<bool> {
+    pub fn select(&self, evts: &mut Events, awakener: Token, timeout_ms: Option<usize>) -> io::Result<bool> {
         let timeout = timeout_ms.map(|x| timespec {
             tv_sec: (x / 1000) as time_t,
             tv_nsec: ((x % 1000) * 1_000_000) as c_long

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -55,7 +55,7 @@ impl Selector {
         })
     }
 
-    pub fn select(&mut self, events: &mut Events, awakener: Token, timeout_ms: Option<usize>) -> io::Result<bool> {
+    pub fn select(&self, events: &mut Events, awakener: Token, timeout_ms: Option<usize>) -> io::Result<bool> {
         let mut ret = false;
 
         // If we have some deferred events then we only want to poll for I/O

--- a/test/test_oneshot.rs
+++ b/test/test_oneshot.rs
@@ -10,6 +10,7 @@ pub fn test_tcp_edge_oneshot() {
     let _ = ::env_logger::init();
 
     let mut poll = Poll::new().unwrap();
+    let mut events = Events::new();
 
     // Create the listener
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
@@ -21,13 +22,13 @@ pub fn test_tcp_edge_oneshot() {
     let mut s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
     poll.register(&s1, Token(1), EventSet::writable(), PollOpt::level()).unwrap();
 
-    wait_for(&mut poll, Token(0));
+    wait_for(&mut poll, &mut events, Token(0));
 
     // Get pair
     let (mut s2, _) = l.accept().unwrap().unwrap();
     poll.register(&s2, Token(2), EventSet::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
-    wait_for(&mut poll, Token(1));
+    wait_for(&mut poll, &mut events, Token(1));
 
     let res = s1.write(b"foo").unwrap();
     assert_eq!(3, res);
@@ -35,7 +36,7 @@ pub fn test_tcp_edge_oneshot() {
     let mut buf = [0; 1];
 
     for byte in b"foo" {
-        wait_for(&mut poll, Token(2));
+        wait_for(&mut poll, &mut events, Token(2));
 
         assert_eq!(1, s2.read(&mut buf).unwrap());
         assert_eq!(*byte, buf[0]);
@@ -48,12 +49,14 @@ pub fn test_tcp_edge_oneshot() {
     }
 }
 
-fn wait_for(poll: &mut Poll, token: Token) {
+fn wait_for(poll: &mut Poll, events: &mut Events, token: Token) {
     loop {
         println!("~~~~~~ WAITING FOR: {:?}", token);
-        poll.poll(Some(Duration::from_millis(MS))).unwrap();
+        poll.poll(events, Some(Duration::from_millis(MS))).unwrap();
 
-        let cnt = poll.events().filter(|e| e.token() == token).count();
+        let cnt = (0..events.len()).map(|i| events.get(i).unwrap())
+                                   .filter(|e| e.token() == token)
+                                   .count();
 
         assert!(cnt < 2, "token appeared multiple times in poll results; cnt={:}", cnt);
 

--- a/test/test_reregister_without_poll.rs
+++ b/test/test_reregister_without_poll.rs
@@ -7,7 +7,8 @@ const MS: u64 = 1_000;
 
 #[test]
 pub fn test_reregister_different_without_poll() {
-    let mut poll = Poll::new().unwrap();
+    let mut events = Events::new();
+    let poll = Poll::new().unwrap();
 
     // Create the listener
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
@@ -22,6 +23,6 @@ pub fn test_reregister_different_without_poll() {
 
     poll.reregister(&l, Token(0), EventSet::writable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
-    poll.poll(Some(Duration::from_millis(MS))).unwrap();
-    assert_eq!(poll.events().len(), 0);
+    poll.poll(&mut events, Some(Duration::from_millis(MS))).unwrap();
+    assert_eq!(events.len(), 0);
 }

--- a/test/test_udp_level.rs
+++ b/test/test_udp_level.rs
@@ -7,7 +7,8 @@ const MS: u64 = 1_000;
 
 #[test]
 pub fn test_udp_level_triggered() {
-    let mut poll = Poll::new().unwrap();
+    let poll = Poll::new().unwrap();
+    let mut events = Events::new();
 
     // Create the listener
     let tx = UdpSocket::bound(&"127.0.0.1:0".parse().unwrap()).unwrap();
@@ -17,13 +18,13 @@ pub fn test_udp_level_triggered() {
     poll.register(&rx, Token(1), EventSet::all(), PollOpt::level()).unwrap();
 
     for _ in 0..2 {
-        poll.poll(Some(Duration::from_millis(MS))).unwrap();
+        poll.poll(&mut events, Some(Duration::from_millis(MS))).unwrap();
 
-        let tx_events = filter(&poll, Token(0));
+        let tx_events = filter(&events, Token(0));
         assert_eq!(1, tx_events.len());
         assert_eq!(tx_events[0], Event::new(EventSet::writable(), Token(0)));
 
-        let rx_events = filter(&poll, Token(1));
+        let rx_events = filter(&events, Token(1));
         assert_eq!(1, rx_events.len());
         assert_eq!(rx_events[0], Event::new(EventSet::writable(), Token(1)));
     }
@@ -33,8 +34,8 @@ pub fn test_udp_level_triggered() {
     sleep_ms(250);
 
     for _ in 0..2 {
-        poll.poll(Some(Duration::from_millis(MS))).unwrap();
-        let rx_events = filter(&poll, Token(1));
+        poll.poll(&mut events, Some(Duration::from_millis(MS))).unwrap();
+        let rx_events = filter(&events, Token(1));
         assert_eq!(1, rx_events.len());
         assert_eq!(rx_events[0], Event::new(EventSet::readable() | EventSet::writable(), Token(1)));
     }
@@ -44,8 +45,8 @@ pub fn test_udp_level_triggered() {
     }
 
     for _ in 0..2 {
-        poll.poll(Some(Duration::from_millis(MS))).unwrap();
-        let rx_events = filter(&poll, Token(1));
+        poll.poll(&mut events, Some(Duration::from_millis(MS))).unwrap();
+        let rx_events = filter(&events, Token(1));
         assert_eq!(1, rx_events.len());
         assert_eq!(rx_events[0], Event::new(EventSet::writable(), Token(1)));
     }
@@ -53,18 +54,20 @@ pub fn test_udp_level_triggered() {
     tx.send_to(b"hello world!", &rx.local_addr().unwrap()).unwrap();
     sleep_ms(250);
 
-    poll.poll(Some(Duration::from_millis(MS))).unwrap();
-    let rx_events = filter(&poll, Token(1));
+    poll.poll(&mut events, Some(Duration::from_millis(MS))).unwrap();
+    let rx_events = filter(&events, Token(1));
     assert_eq!(1, rx_events.len());
     assert_eq!(rx_events[0], Event::new(EventSet::readable() | EventSet::writable(), Token(1)));
 
     drop(rx);
 
-    poll.poll(Some(Duration::from_millis(MS))).unwrap();
-    let rx_events = filter(&poll, Token(1));
+    poll.poll(&mut events, Some(Duration::from_millis(MS))).unwrap();
+    let rx_events = filter(&events, Token(1));
     assert!(rx_events.is_empty());
 }
 
-fn filter(poll: &Poll, token: Token) -> Vec<Event> {
-    poll.events().filter(|e| e.token() == token).collect()
+fn filter(events: &Events, token: Token) -> Vec<Event> {
+    (0..events.len()).map(|i| events.get(i).unwrap())
+                     .filter(|e| e.token() == token)
+                     .collect()
 }


### PR DESCRIPTION
This will eventually allow one Poll to be used from multiple threads because the
methods now only all need `&self` rather than `&mut self`