### PR TITLE
Handler-independent event loops.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,8 @@ slab   = { git = "https://github.com/carllerche/slab", rev = "5476efcafb"  }
 bytes  = "0.3.0"
 net2   = { version = "0.2.19", default-features = false }
 
-[target.'cfg(unix)'.dependencies]
 nix    = "0.6.0"
 libc   = "0.2.4"
-
-[target.'cfg(windows)'.dependencies]
-winapi = "0.2.1"
-miow   = "0.1.1"
 
 [dev-dependencies]
 env_logger = "0.3.0"

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,9 +1,7 @@
 use {EventLoop, EventSet, Token};
 
 #[allow(unused_variables)]
-pub trait Handler: Sized {
-    type Timeout;
-    type Message;
+pub trait Handler<Timeout, Message>: Sized {
 
     /// Invoked when the socket represented by `token` is ready to be operated
     /// on. `events` indicates the specific operations that are
@@ -15,22 +13,22 @@ pub trait Handler: Sized {
     ///
     /// This function will only be invoked a single time per socket per event
     /// loop tick.
-    fn ready(&mut self, event_loop: &mut EventLoop<Self>, token: Token, events: EventSet) {
+    fn ready(&mut self, event_loop: &mut EventLoop<Timeout, Message>, token: Token, events: EventSet) {
     }
 
     /// Invoked when a message has been received via the event loop's channel.
-    fn notify(&mut self, event_loop: &mut EventLoop<Self>, msg: Self::Message) {
+    fn notify(&mut self, event_loop: &mut EventLoop<Timeout, Message>, msg: Message) {
     }
 
     /// Invoked when a timeout has completed.
-    fn timeout(&mut self, event_loop: &mut EventLoop<Self>, timeout: Self::Timeout) {
+    fn timeout(&mut self, event_loop: &mut EventLoop<Timeout, Message>, timeout: Timeout) {
     }
 
     /// Invoked when `EventLoop` has been interrupted by a signal interrupt.
-    fn interrupted(&mut self, event_loop: &mut EventLoop<Self>) {
+    fn interrupted(&mut self, event_loop: &mut EventLoop<Timeout, Message>) {
     }
 
     /// Invoked at the end of an event loop tick.
-    fn tick(&mut self, event_loop: &mut EventLoop<Self>) {
+    fn tick(&mut self, event_loop: &mut EventLoop<Timeout, Message>) {
     }
 }


### PR DESCRIPTION
I'd like to be able to use a single loop with different handlers. My use case is thrussh, a crate implementing the SSH protocol.

I'd like to do the following, with the same socket:

- Connect/authenticate, which is a CPU-intensive operation (public key cryptography). Use a specific handler for that part of the protocol.

- Upload a file with scp, taking the file from an R:std::io::Read. This needs a specific handler.

- Download a file with scp, writing it in an W:std::io::Write. This also needs a specific handler.

A possible solution would be to have an enum with the three different handlers. Unfortunately, when creating the loop, we don't know what R and W will be. Also, we might want to upload different files from different instances of std::io::Read (i.e. change R).

This pull request implements this, but probably breaks lots of other stuff. Also I've not fixed the tests yet, but I can do it if needed.