### PR TITLE
Finish completing accept/connect on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ libc   = "0.2.4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.1"
-miow   = "0.1.1"
+miow   = "0.1.3"
 
 [dev-dependencies]
 env_logger = "0.3.0"

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -13,6 +13,7 @@ mod test_battery;
 mod test_close_on_drop;
 mod test_double_register;
 mod test_echo_server;
+mod test_local_addr_ready;
 mod test_multicast;
 mod test_notify;
 mod test_oneshot;
@@ -21,6 +22,7 @@ mod test_register_deregister;
 mod test_register_multiple_event_loops;
 mod test_reregister_without_poll;
 mod test_smoke;
+mod test_subprocess_pipe;
 mod test_tcp;
 mod test_tcp_level;
 mod test_tick;
@@ -28,7 +30,6 @@ mod test_timer;
 mod test_udp_level;
 mod test_udp_socket;
 mod test_uds_shutdown;
-mod test_subprocess_pipe;
 
 // ===== Unix only tests =====
 #[cfg(unix)]

--- a/test/test_local_addr_ready.rs
+++ b/test/test_local_addr_ready.rs
@@ -1,0 +1,66 @@
+use mio::*;
+use mio::tcp::{TcpListener, TcpStream};
+
+const LISTEN: Token = Token(0);
+const CLIENT: Token = Token(1);
+const SERVER: Token = Token(2);
+
+struct MyHandler {
+    listener: TcpListener,
+    connected: TcpStream,
+    accepted: Option<TcpStream>,
+}
+
+impl Handler for MyHandler {
+    type Timeout = ();
+    type Message = ();
+
+    fn ready(&mut self,
+             event_loop: &mut EventLoop<MyHandler>,
+             token: Token,
+             _: EventSet) {
+        match token {
+            LISTEN => {
+                let sock = self.listener.accept().unwrap().unwrap().0;
+                event_loop.register(&sock,
+                                    SERVER,
+                                    EventSet::writable(),
+                                    PollOpt::edge()).unwrap();
+                self.accepted = Some(sock);
+            }
+            SERVER => {
+                self.accepted.as_ref().unwrap().peer_addr().unwrap();
+                self.accepted.as_ref().unwrap().local_addr().unwrap();
+                self.accepted.as_mut().unwrap().try_write(&[1, 2, 3]).unwrap();
+                self.accepted = None;
+            }
+            CLIENT => {
+                self.connected.peer_addr().unwrap();
+                self.connected.local_addr().unwrap();
+                event_loop.shutdown();
+            }
+            _ => panic!("unexpected token"),
+        }
+    }
+}
+
+#[test]
+fn local_addr_ready() {
+    let addr = "127.0.0.1:0".parse().unwrap();
+    let server = TcpListener::bind(&addr).unwrap();
+    let addr = server.local_addr().unwrap();
+
+    let mut event_loop = EventLoop::new().unwrap();
+    event_loop.register(&server, LISTEN, EventSet::readable(),
+                        PollOpt::edge()).unwrap();
+
+    let sock = TcpStream::connect(&addr).unwrap();
+    event_loop.register(&sock, CLIENT, EventSet::readable(),
+                        PollOpt::edge()).unwrap();
+
+    event_loop.run(&mut MyHandler {
+        listener: server,
+        connected: sock,
+        accepted: None,
+    }).unwrap();
+}


### PR DESCRIPTION
Apparently there are extra steps that need to be taken after a socket finishes
being accepted and/or connected on Windows to prepare state like calling
getsockaddr and getpeeraddr. This updates the `miow` binding to where it has
these functions, then calls those functions in these situations.

Closes #397