### PR TITLE
Only call `reuse_address` on Unix

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -190,8 +190,10 @@ impl TcpListener {
             SocketAddr::V6(..) => TcpBuilder::new_v6(),
         });
 
-        // Set SO_REUSEADDR
-        try!(sock.reuse_address(true));
+        // Set SO_REUSEADDR, but only on Unix (mirrors what libstd does)
+        if cfg!(unix) {
+            try!(sock.reuse_address(true));
+        }
 
         // Bind the socket
         try!(sock.bind(addr));

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -257,3 +257,10 @@ fn test_tcp_sockets_are_send() {
     assert_send::<TcpListener>();
     assert_send::<TcpStream>();
 }
+
+#[test]
+fn bind_twice_bad() {
+    let l1 = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = l1.local_addr().unwrap();
+    assert!(TcpListener::bind(&addr).is_err());
+}


### PR DESCRIPTION
The standard library only Does this on Unix, and otherwise it's a source of
divergent behavior on Windows.

Closes #400