### PR TITLE
Align UdpSocket with std::net::UdpSocket

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,5 +1,5 @@
 use {io, sys, Evented, EventSet, Poll, PollOpt, Token};
-use std::net::{IpAddr, SocketAddr};
+use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 #[derive(Debug)]
 pub struct UdpSocket {
@@ -7,72 +7,207 @@ pub struct UdpSocket {
 }
 
 impl UdpSocket {
-    /// Returns a new, unbound, non-blocking, IPv4 UDP socket
-    pub fn v4() -> io::Result<UdpSocket> {
-        sys::UdpSocket::v4()
-            .map(From::from)
+    /// Creates a UDP socket from the given address.
+    pub fn bind(addr: &SocketAddr) -> io::Result<UdpSocket> {
+        let socket = try!(net::UdpSocket::bind(addr));
+        UdpSocket::from_socket(socket)
     }
 
-    /// Returns a new, unbound, non-blocking, IPv6 UDP socket
-    pub fn v6() -> io::Result<UdpSocket> {
-        sys::UdpSocket::v6()
-            .map(From::from)
+    /// Creates a new mio-wrapped socket from an underlying and bound std
+    /// socket.
+    ///
+    /// This function requires that `socket` has previously been bound to an
+    /// address to work correctly, and returns an I/O object which can be used
+    /// with mio to send/receive UDP messages.
+    ///
+    /// This can be used in conjunction with net2's `UdpBuilder` interface to
+    /// configure a socket before it's handed off to mio, such as setting
+    /// options like `reuse_address` or binding to multiple addresses.
+    pub fn from_socket(socket: net::UdpSocket) -> io::Result<UdpSocket> {
+        Ok(UdpSocket {
+            sys: try!(sys::UdpSocket::new(socket)),
+        })
     }
 
-    pub fn bound(addr: &SocketAddr) -> io::Result<UdpSocket> {
-        // Create the socket
-        let sock = try!(match *addr {
-            SocketAddr::V4(..) => UdpSocket::v4(),
-            SocketAddr::V6(..) => UdpSocket::v6(),
-        });
-
-        // Bind the socket
-        try!(sock.bind(addr));
-
-        Ok(sock)
-    }
-
-    pub fn bind(&self, addr: &SocketAddr) -> io::Result<()> {
-        self.sys.bind(addr)
-    }
-
+    /// Returns the socket address that this socket was created from.
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.sys.local_addr()
     }
 
+    /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// The returned `UdpSocket` is a reference to the same socket that this
+    /// object references. Both handles will read and write the same port, and
+    /// options set on one socket will be propagated to the other.
     pub fn try_clone(&self) -> io::Result<UdpSocket> {
         self.sys.try_clone()
             .map(From::from)
     }
 
+    /// Sends data on the socket to the given address. On success, returns the
+    /// number of bytes written.
+    ///
+    /// Address type can be any implementor of `ToSocketAddrs` trait. See its
+    /// documentation for concrete examples.
     pub fn send_to(&self, buf: &[u8], target: &SocketAddr)
                    -> io::Result<Option<usize>> {
         self.sys.send_to(buf, target)
     }
 
+    /// Receives data from the socket. On success, returns the number of bytes
+    /// read and the address from whence the data came.
     pub fn recv_from(&self, buf: &mut [u8])
                      -> io::Result<Option<(usize, SocketAddr)>> {
         self.sys.recv_from(buf)
     }
 
+    /// Gets the value of the `SO_BROADCAST` option for this socket.
+    ///
+    /// For more information about this option, see
+    /// [`set_broadcast`][link].
+    ///
+    /// [link]: #method.set_broadcast
+    pub fn broadcast(&self) -> io::Result<bool> {
+        self.sys.broadcast()
+    }
+
+    /// Sets the value of the `SO_BROADCAST` option for this socket.
+    ///
+    /// When enabled, this socket is allowed to send packets to a broadcast
+    /// address.
     pub fn set_broadcast(&self, on: bool) -> io::Result<()> {
         self.sys.set_broadcast(on)
     }
 
-    pub fn set_multicast_loop(&self, on: bool) -> io::Result<()> {
-        self.sys.set_multicast_loop(on)
+    /// Gets the value of the `IP_MULTICAST_LOOP` option for this socket.
+    ///
+    /// For more information about this option, see
+    /// [`set_multicast_loop_v4`][link].
+    ///
+    /// [link]: #method.set_multicast_loop_v4
+    pub fn multicast_loop_v4(&self) -> io::Result<bool> {
+        self.sys.multicast_loop_v4()
     }
 
-    pub fn join_multicast(&self, multi: &IpAddr) -> io::Result<()> {
-        self.sys.join_multicast(multi)
+    /// Sets the value of the `IP_MULTICAST_LOOP` option for this socket.
+    ///
+    /// If enabled, multicast packets will be looped back to the local socket.
+    /// Note that this may not have any affect on IPv6 sockets.
+    pub fn set_multicast_loop_v4(&self, on: bool) -> io::Result<()> {
+        self.sys.set_multicast_loop_v4(on)
     }
 
-    pub fn leave_multicast(&self, multi: &IpAddr) -> io::Result<()> {
-        self.sys.leave_multicast(multi)
+    /// Gets the value of the `IP_MULTICAST_TTL` option for this socket.
+    ///
+    /// For more information about this option, see
+    /// [`set_multicast_ttl_v4`][link].
+    ///
+    /// [link]: #method.set_multicast_ttl_v4
+    pub fn multicast_ttl_v4(&self) -> io::Result<u32> {
+        self.sys.multicast_ttl_v4()
     }
 
-    pub fn set_multicast_time_to_live(&self, ttl: i32) -> io::Result<()> {
-        self.sys.set_multicast_time_to_live(ttl)
+    /// Sets the value of the `IP_MULTICAST_TTL` option for this socket.
+    ///
+    /// Indicates the time-to-live value of outgoing multicast packets for
+    /// this socket. The default value is 1 which means that multicast packets
+    /// don't leave the local network unless explicitly requested.
+    ///
+    /// Note that this may not have any affect on IPv6 sockets.
+    pub fn set_multicast_ttl_v4(&self, ttl: u32) -> io::Result<()> {
+        self.sys.set_multicast_ttl_v4(ttl)
+    }
+
+    /// Gets the value of the `IPV6_MULTICAST_LOOP` option for this socket.
+    ///
+    /// For more information about this option, see
+    /// [`set_multicast_loop_v6`][link].
+    ///
+    /// [link]: #method.set_multicast_loop_v6
+    pub fn multicast_loop_v6(&self) -> io::Result<bool> {
+        self.sys.multicast_loop_v6()
+    }
+
+    /// Sets the value of the `IPV6_MULTICAST_LOOP` option for this socket.
+    ///
+    /// Controls whether this socket sees the multicast packets it sends itself.
+    /// Note that this may not have any affect on IPv4 sockets.
+    pub fn set_multicast_loop_v6(&self, on: bool) -> io::Result<()> {
+        self.sys.set_multicast_loop_v6(on)
+    }
+
+    /// Gets the value of the `IP_TTL` option for this socket.
+    ///
+    /// For more information about this option, see [`set_ttl`][link].
+    ///
+    /// [link]: #method.set_ttl
+    pub fn ttl(&self) -> io::Result<u32> {
+        self.sys.ttl()
+    }
+
+    /// Sets the value for the `IP_TTL` option on this socket.
+    ///
+    /// This value sets the time-to-live field that is used in every packet sent
+    /// from this socket.
+    pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
+        self.sys.set_ttl(ttl)
+    }
+
+    /// Executes an operation of the `IP_ADD_MEMBERSHIP` type.
+    ///
+    /// This function specifies a new multicast group for this socket to join.
+    /// The address must be a valid multicast address, and `interface` is the
+    /// address of the local interface with which the system should join the
+    /// multicast group. If it's equal to `INADDR_ANY` then an appropriate
+    /// interface is chosen by the system.
+    pub fn join_multicast_v4(&self,
+                             multiaddr: &Ipv4Addr,
+                             interface: &Ipv4Addr) -> io::Result<()> {
+        self.sys.join_multicast_v4(multiaddr, interface)
+    }
+
+    /// Executes an operation of the `IPV6_ADD_MEMBERSHIP` type.
+    ///
+    /// This function specifies a new multicast group for this socket to join.
+    /// The address must be a valid multicast address, and `interface` is the
+    /// index of the interface to join/leave (or 0 to indicate any interface).
+    pub fn join_multicast_v6(&self,
+                             multiaddr: &Ipv6Addr,
+                             interface: u32) -> io::Result<()> {
+        self.sys.join_multicast_v6(multiaddr, interface)
+    }
+
+    /// Executes an operation of the `IP_DROP_MEMBERSHIP` type.
+    ///
+    /// For more information about this option, see
+    /// [`join_multicast_v4`][link].
+    ///
+    /// [link]: #method.join_multicast_v4
+    pub fn leave_multicast_v4(&self,
+                              multiaddr: &Ipv4Addr,
+                              interface: &Ipv4Addr) -> io::Result<()> {
+        self.sys.leave_multicast_v4(multiaddr, interface)
+    }
+
+    /// Executes an operation of the `IPV6_DROP_MEMBERSHIP` type.
+    ///
+    /// For more information about this option, see
+    /// [`join_multicast_v6`][link].
+    ///
+    /// [link]: #method.join_multicast_v6
+    pub fn leave_multicast_v6(&self,
+                              multiaddr: &Ipv6Addr,
+                              interface: u32) -> io::Result<()> {
+        self.sys.leave_multicast_v6(multiaddr, interface)
+    }
+
+    /// Get the value of the `SO_ERROR` option on this socket.
+    ///
+    /// This will retrieve the stored error in the underlying socket, clearing
+    /// the field in the process. This can be useful for checking errors between
+    /// calls.
+    pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+        self.sys.take_error()
     }
 }
 

--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -1,6 +1,5 @@
 use {io};
 use sys::unix::{nix, Io};
-use std::net::SocketAddr;
 use std::os::unix::io::{AsRawFd, RawFd};
 pub use net::tcp::Shutdown;
 
@@ -49,44 +48,10 @@ pub fn accept(io: &Io, nonblock: bool) -> io::Result<RawFd> {
 }
 
 // UDP & UDS
-#[inline]
-pub fn recvfrom(io: &Io, buf: &mut [u8]) -> io::Result<(usize, nix::SockAddr)> {
-    nix::recvfrom(io.as_raw_fd(), buf)
-        .map_err(super::from_nix_error)
-}
-
-// UDP & UDS
-#[inline]
-pub fn sendto(io: &Io, buf: &[u8], target: &nix::SockAddr) -> io::Result<usize> {
-    nix::sendto(io.as_raw_fd(), buf, target, nix::MSG_DONTWAIT)
-        .map_err(super::from_nix_error)
-}
-
-pub fn getsockname(io: &Io) -> io::Result<nix::SockAddr> {
-    nix::getsockname(io.as_raw_fd())
-        .map_err(super::from_nix_error)
-}
 
 #[inline]
 pub fn dup(io: &Io) -> io::Result<Io> {
     nix::dup(io.as_raw_fd())
         .map_err(super::from_nix_error)
         .map(Io::from_raw_fd)
-}
-
-/*
- *
- * ===== Helpers =====
- *
- */
-
-pub fn to_nix_addr(addr: &SocketAddr) -> nix::SockAddr {
-    nix::SockAddr::Inet(nix::InetAddr::from_std(addr))
-}
-
-pub fn to_std_addr(addr: nix::SockAddr) -> SocketAddr {
-    match addr {
-        nix::SockAddr::Inet(ref addr) => addr.to_std(),
-        _ => panic!("unexpected unix socket address"),
-    }
 }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -137,7 +137,6 @@
 //!   be some level of buffering of writes probably.
 
 use std::io;
-use std::net::Ipv4Addr;
 
 mod awakener;
 #[macro_use]
@@ -164,5 +163,3 @@ fn bad_state() -> io::Error {
 fn wouldblock() -> io::Error {
     io::Error::new(io::ErrorKind::WouldBlock, "operation would block")
 }
-
-fn ipv4_any() -> Ipv4Addr { Ipv4Addr::new(0, 0, 0, 0) }

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -81,14 +81,15 @@ pub fn test_multicast() {
     let addr = localhost();
     let any = "0.0.0.0:0".parse().unwrap();
 
-    let tx = UdpSocket::bound(&any).unwrap();
-    let rx = UdpSocket::bound(&addr).unwrap();
+    let tx = UdpSocket::bind(&any).unwrap();
+    let rx = UdpSocket::bind(&addr).unwrap();
 
     info!("Joining group 227.1.1.100");
-    rx.join_multicast(&"227.1.1.100".parse().unwrap()).unwrap();
+    let any = "0.0.0.0".parse().unwrap();
+    rx.join_multicast_v4(&"227.1.1.100".parse().unwrap(), &any).unwrap();
 
     info!("Joining group 227.1.1.101");
-    rx.join_multicast(&"227.1.1.101".parse().unwrap()).unwrap();
+    rx.join_multicast_v4(&"227.1.1.101".parse().unwrap(), &any).unwrap();
 
     info!("Registering SENDER");
     event_loop.register(&tx, SENDER, EventSet::writable(), PollOpt::edge()).unwrap();

--- a/test/test_register_multiple_event_loops.rs
+++ b/test/test_register_multiple_event_loops.rs
@@ -51,7 +51,7 @@ fn test_tcp_register_multiple_event_loops() {
 #[test]
 fn test_udp_register_multiple_event_loops() {
     let addr = localhost();
-    let socket = UdpSocket::bound(&addr).unwrap();
+    let socket = UdpSocket::bind(&addr).unwrap();
 
     let mut event_loop_1 = EventLoop::<MyHandler>::new().unwrap();
     event_loop_1.register(&socket, Token(0), EventSet::all(), PollOpt::edge()).unwrap();

--- a/test/test_udp_level.rs
+++ b/test/test_udp_level.rs
@@ -11,8 +11,8 @@ pub fn test_udp_level_triggered() {
     let mut events = Events::new();
 
     // Create the listener
-    let tx = UdpSocket::bound(&"127.0.0.1:0".parse().unwrap()).unwrap();
-    let rx = UdpSocket::bound(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let tx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let rx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     poll.register(&tx, Token(0), EventSet::all(), PollOpt::level()).unwrap();
     poll.register(&rx, Token(1), EventSet::all(), PollOpt::level()).unwrap();

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -77,8 +77,8 @@ pub fn test_udp_socket() {
     let addr = localhost();
     let any = str::FromStr::from_str("0.0.0.0:0").unwrap();
 
-    let tx = UdpSocket::bound(&any).unwrap();
-    let rx = UdpSocket::bound(&addr).unwrap();
+    let tx = UdpSocket::bind(&any).unwrap();
+    let rx = UdpSocket::bind(&addr).unwrap();
 
     assert_send::<UdpSocket>();
     assert_sync::<UdpSocket>();


### PR DESCRIPTION
* Remove the `bind` methods and change it into a constructor
* Remove `bound` as this is replaced by `bind`
* Add `from_socket` akin to `TcpStream::connect_stream`
* Re-synchronize all methods for `setsockopt` with libstd, removing some old,
  adding new ones, and adding accessors.