### PR TITLE
Add an Events::with_capacity constructor

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -275,24 +275,50 @@ impl fmt::Debug for Poll {
     }
 }
 
+/// A buffer for I/O events to get placed into, passed to `Poll::poll`.
+///
+/// This structure is normally re-used on each turn of the event loop and will
+/// contain any I/O events that happen during a `poll`. After a call to `poll`
+/// returns the various accessor methods on this structure can be used to
+/// iterate over the underlying events that ocurred.
 pub struct Events {
     inner: sys::Events,
 }
 
 impl Events {
+    /// Creates a new blank set of events ready to get passed to `poll`.
+    ///
+    /// Note that this constructor will attempt to select a "reasonable" default
+    /// capacity for the events returned.
     pub fn new() -> Events {
+        Events::with_capacity(1024)
+    }
+
+    /// Create a net blank set of events capable of holding up to `capacity`
+    /// events.
+    ///
+    /// This parameter typically is an indicator on how many events can be
+    /// returned each turn of the event loop, but it is not necessarily a hard
+    /// limit across platforms.
+    pub fn with_capacity(capacity: usize) -> Events {
         Events {
-            inner: sys::Events::new(),
+            inner: sys::Events::with_capacity(capacity),
         }
     }
+
+    /// Returns the `idx`-th event.
+    ///
+    /// Returns `None` if `idx` is greater than the length of this event buffer.
     pub fn get(&self, idx: usize) -> Option<Event> {
         self.inner.get(idx)
     }
 
+    /// Returns how many events this buffer contains.
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
+    /// Returns whether this buffer contains 0 events.
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -147,9 +147,9 @@ pub struct Events {
 }
 
 impl Events {
-    pub fn new() -> Events {
+    pub fn with_capacity(u: usize) -> Events {
         Events {
-            events: Vec::with_capacity(1024),
+            events: Vec::with_capacity(u)
         }
     }
 

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -159,11 +159,11 @@ pub struct Events {
 }
 
 impl Events {
-    pub fn new() -> Events {
+    pub fn with_capacity(cap: usize) -> Events {
         Events {
-            sys_events: Vec::with_capacity(1024),
-            events: Vec::with_capacity(1024),
-            event_map: HashMap::with_capacity(1024)
+            sys_events: Vec::with_capacity(cap),
+            events: Vec::with_capacity(cap),
+            event_map: HashMap::with_capacity(cap)
         }
     }
 

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -301,17 +301,13 @@ pub struct Events {
 }
 
 impl Events {
-    pub fn new() -> Events {
-        // Use a nice large space for receiving I/O events (currently the same
-        // as unix's 1024) and then also prepare the output vector to have the
-        // same space.
-        //
-        // Note that it's possible for the output `events` to grow beyond 1024
+    pub fn with_capacity(cap: usize) -> Events {
+        // Note that it's possible for the output `events` to grow beyond the
         // capacity as it can also include deferred events, but that's certainly
         // not the end of the world!
         Events {
-            statuses: vec![CompletionStatus::zero(); 1024].into_boxed_slice(),
-            events: Vec::with_capacity(1024),
+            statuses: vec![CompletionStatus::zero(); cap].into_boxed_slice(),
+            events: Vec::with_capacity(cap),
         }
     }
 


### PR DESCRIPTION
Should allow tuning how many events can get returned from one turn of an event
loop, in theory at least. Somewhat related to #427 where memory tuning may
matter in some situations.