### PR TITLE
windows: Finish pending writes when a socket is dropped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ libc   = "0.2.4"
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.1"
 miow   = "0.1.3"
+kernel32-sys = "0.2"
 
 [dev-dependencies]
 env_logger = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,9 @@ extern crate miow;
 #[cfg(windows)]
 extern crate winapi;
 
+#[cfg(windows)]
+extern crate kernel32;
+
 #[macro_use]
 extern crate log;
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -162,10 +162,6 @@ enum Family {
     V4, V6,
 }
 
-fn bad_state() -> io::Error {
-    io::Error::new(io::ErrorKind::Other, "bad state to make this function call")
-}
-
 fn wouldblock() -> io::Error {
     io::Error::new(io::ErrorKind::WouldBlock, "operation would block")
 }

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -2,7 +2,6 @@ use std::fmt;
 use std::io::{self, Read, Write, Cursor, ErrorKind};
 use std::mem;
 use std::net::{self, SocketAddr};
-use std::os::windows::prelude::*;
 use std::sync::{Mutex, MutexGuard};
 
 use miow::iocp::CompletionStatus;
@@ -55,16 +54,17 @@ struct StreamIo {
     inner: Mutex<StreamInner>,
     read: Overlapped, // also used for connect
     write: Overlapped,
+    socket: net::TcpStream,
 }
 
 struct ListenerIo {
     inner: Mutex<ListenerInner>,
     accept: Overlapped,
     family: Family,
+    socket: net::TcpListener,
 }
 
 struct StreamInner {
-    socket: net::TcpStream,
     iocp: Registration,
     deferred_connect: Option<SocketAddr>,
     read: State<Vec<u8>, Cursor<Vec<u8>>>,
@@ -72,7 +72,6 @@ struct StreamInner {
 }
 
 struct ListenerInner {
-    socket: net::TcpListener,
     iocp: Registration,
     accept: State<net::TcpStream, (net::TcpStream, SocketAddr)>,
     accept_buf: AcceptAddrsBuf,
@@ -94,8 +93,8 @@ impl TcpStream {
                 inner: FromRawArc::new(StreamIo {
                     read: Overlapped::new(read_done),
                     write: Overlapped::new(write_done),
+                    socket: socket,
                     inner: Mutex::new(StreamInner {
-                        socket: socket,
                         iocp: Registration::new(),
                         deferred_connect: deferred_connect,
                         read: State::Empty,
@@ -112,32 +111,32 @@ impl TcpStream {
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
-        self.inner().socket.peer_addr()
+        self.imp.inner.socket.peer_addr()
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
-        self.inner().socket.local_addr()
+        self.imp.inner.socket.local_addr()
     }
 
     pub fn try_clone(&self) -> io::Result<TcpStream> {
-        self.inner().socket.try_clone().map(|s| TcpStream::new(s, None))
+        self.imp.inner.socket.try_clone().map(|s| TcpStream::new(s, None))
     }
 
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
-        self.inner().socket.shutdown(how)
+        self.imp.inner.socket.shutdown(how)
     }
 
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
-        net2::TcpStreamExt::set_nodelay(&self.inner().socket, nodelay)
+        net2::TcpStreamExt::set_nodelay(&self.imp.inner.socket, nodelay)
     }
 
     pub fn set_keepalive(&self, seconds: Option<u32>) -> io::Result<()> {
         let dur = seconds.map(|s| s * 1000);
-        net2::TcpStreamExt::set_keepalive_ms(&self.inner().socket, dur)
+        net2::TcpStreamExt::set_keepalive_ms(&self.imp.inner.socket, dur)
     }
 
     pub fn take_socket_error(&self) -> io::Result<()> {
-        net2::TcpStreamExt::take_error(&self.inner().socket).and_then(|e| {
+        net2::TcpStreamExt::take_error(&self.imp.inner.socket).and_then(|e| {
             match e {
                 Some(e) => Err(e),
                 None => Ok(())
@@ -221,11 +220,11 @@ impl StreamImp {
         self.inner.inner.lock().unwrap()
     }
 
-    fn schedule_connect(&self, addr: &SocketAddr, me: &mut StreamInner)
-                        -> io::Result<()> {
+    fn schedule_connect(&self, addr: &SocketAddr) -> io::Result<()> {
         unsafe {
             trace!("scheduling a connect");
-            try!(me.socket.connect_overlapped(addr, self.inner.read.get_mut()));
+            try!(self.inner.socket.connect_overlapped(addr,
+                                                      self.inner.read.get_mut()));
         }
         // see docs above on StreamImp.inner for rationale on forget
         mem::forget(self.clone());
@@ -257,7 +256,8 @@ impl StreamImp {
             trace!("scheduling a read");
             let cap = buf.capacity();
             buf.set_len(cap);
-            me.socket.read_overlapped(&mut buf, self.inner.read.get_mut())
+            self.inner.socket.read_overlapped(&mut buf,
+                                              self.inner.read.get_mut())
         };
         match res {
             Ok(_) => {
@@ -299,7 +299,8 @@ impl StreamImp {
 
         trace!("scheduling a write");
         let err = unsafe {
-            me.socket.write_overlapped(&buf[pos..], self.inner.write.get_mut())
+            self.inner.socket.write_overlapped(&buf[pos..],
+                                               self.inner.write.get_mut())
         };
         match err {
             Ok(_) => {
@@ -321,9 +322,7 @@ impl StreamImp {
     /// socket was closed then we don't want to actually push the event onto our
     /// selector as otherwise it's just a spurious notification.
     fn add_readiness(&self, me: &mut StreamInner, set: EventSet) {
-        if me.socket.as_raw_socket() != INVALID_SOCKET {
-            me.iocp.set_readiness(set | me.iocp.readiness());
-        }
+        me.iocp.set_readiness(set | me.iocp.readiness());
     }
 }
 
@@ -360,7 +359,7 @@ fn read_done(status: &CompletionStatus) {
     // If a read didn't complete, then the connect must have just finished.
     trace!("finished a connect");
 
-    match me.socket.connect_complete() {
+    match me2.inner.socket.connect_complete() {
         Ok(()) => {
             me2.add_readiness(&mut me, EventSet::writable());
             me2.schedule_read(&mut me);
@@ -394,29 +393,25 @@ impl Evented for TcpStream {
     fn register(&self, poll: &Poll, token: Token,
                 interest: EventSet, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
-        let me = &mut *me;
-        try!(me.iocp.register_socket(&me.socket, poll, token, interest, opts,
-                                     &self.registration));
+        try!(me.iocp.register_socket(&self.imp.inner.socket, poll, token,
+                                     interest, opts, &self.registration));
 
         // If we were connected before being registered process that request
         // here and go along our merry ways. Note that the callback for a
         // successful connect will worry about generating writable/readable
         // events and scheduling a new read.
         if let Some(addr) = me.deferred_connect.take() {
-            return self.imp.schedule_connect(&addr, me).map(|_| ())
+            return self.imp.schedule_connect(&addr).map(|_| ())
         }
-        self.post_register(interest, me);
+        self.post_register(interest, &mut me);
         Ok(())
     }
 
     fn reregister(&self, poll: &Poll, token: Token,
                   interest: EventSet, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
-        {
-            let me = &mut *me;
-            try!(me.iocp.reregister_socket(&me.socket, poll, token, interest,
-                                           opts, &self.registration));
-        }
+        try!(me.iocp.reregister_socket(&self.imp.inner.socket, poll, token,
+                                       interest, opts, &self.registration));
         self.post_register(interest, &mut me);
         Ok(())
     }
@@ -434,8 +429,6 @@ impl fmt::Debug for TcpStream {
 
 impl Drop for TcpStream {
     fn drop(&mut self) {
-        let inner = self.inner();
-
         // If we're still internally reading, we're no longer interested. Note
         // though that we don't cancel any writes which may have been issued to
         // preserve the same semantics as Unix.
@@ -443,9 +436,11 @@ impl Drop for TcpStream {
         // Note that "Empty" here may mean that a connect is pending, so we
         // cancel even if that happens as well.
         unsafe {
-            match inner.read {
+            match self.inner().read {
                 State::Pending(_) | State::Empty => {
-                    drop(super::cancel(&inner.socket, &self.imp.inner.read));
+                    trace!("cancelling active TCP read");
+                    drop(super::cancel(&self.imp.inner.socket,
+                                       &self.imp.inner.read));
                 }
                 State::Ready(_) | State::Error(_) => {}
             }
@@ -469,8 +464,8 @@ impl TcpListener {
                 inner: FromRawArc::new(ListenerIo {
                     accept: Overlapped::new(accept_done),
                     family: family,
+                    socket: socket,
                     inner: Mutex::new(ListenerInner {
-                        socket: socket,
                         iocp: Registration::new(),
                         accept: State::Empty,
                         accept_buf: AcceptAddrsBuf::new(),
@@ -501,18 +496,17 @@ impl TcpListener {
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
-        self.inner().socket.local_addr()
+        self.imp.inner.socket.local_addr()
     }
 
     pub fn try_clone(&self) -> io::Result<TcpListener> {
-        let inner = self.inner();
-        inner.socket.try_clone().map(|s| {
+        self.imp.inner.socket.try_clone().map(|s| {
             TcpListener::new_family(s, self.imp.inner.family)
         })
     }
 
     pub fn take_socket_error(&self) -> io::Result<()> {
-        net2::TcpListenerExt::take_error(&self.inner().socket).and_then(|e| {
+        net2::TcpListenerExt::take_error(&self.imp.inner.socket).and_then(|e| {
             match e {
                 Some(e) => Err(e),
                 None => Ok(())
@@ -543,8 +537,8 @@ impl ListenerImp {
             Family::V6 => TcpBuilder::new_v6(),
         }.and_then(|builder| unsafe {
             trace!("scheduling an accept");
-            me.socket.accept_overlapped(&builder, &mut me.accept_buf,
-                                        self.inner.accept.get_mut())
+            self.inner.socket.accept_overlapped(&builder, &mut me.accept_buf,
+                                                self.inner.accept.get_mut())
         });
         match res {
             Ok((socket, _)) => {
@@ -561,9 +555,7 @@ impl ListenerImp {
 
     // See comments in StreamImp::push
     fn add_readiness(&self, me: &mut ListenerInner, set: EventSet) {
-        if me.socket.as_raw_socket() != INVALID_SOCKET {
-            me.iocp.set_readiness(set | me.iocp.readiness());
-        }
+        me.iocp.set_readiness(set | me.iocp.readiness());
     }
 }
 
@@ -578,8 +570,8 @@ fn accept_done(status: &CompletionStatus) {
         _ => unreachable!(),
     };
     trace!("finished an accept");
-    let result = me.socket.accept_complete(&socket).and_then(|()| {
-        me.accept_buf.parse(&me.socket)
+    let result = me2.inner.socket.accept_complete(&socket).and_then(|()| {
+        me.accept_buf.parse(&me2.inner.socket)
     }).and_then(|buf| {
         buf.remote().ok_or_else(|| {
             io::Error::new(ErrorKind::Other, "could not obtain remote address")
@@ -596,20 +588,18 @@ impl Evented for TcpListener {
     fn register(&self, poll: &Poll, token: Token,
                 interest: EventSet, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
-        let me = &mut *me;
-        try!(me.iocp.register_socket(&me.socket, poll, token, interest, opts,
-                                     &self.registration));
-        self.imp.schedule_accept(me);
+        try!(me.iocp.register_socket(&self.imp.inner.socket, poll, token,
+                                     interest, opts, &self.registration));
+        self.imp.schedule_accept(&mut me);
         Ok(())
     }
 
     fn reregister(&self, poll: &Poll, token: Token,
                   interest: EventSet, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
-        let me = &mut *me;
-        try!(me.iocp.reregister_socket(&me.socket, poll, token, interest,
-                                       opts, &self.registration));
-        self.imp.schedule_accept(me);
+        try!(me.iocp.reregister_socket(&self.imp.inner.socket, poll, token,
+                                       interest, opts, &self.registration));
+        self.imp.schedule_accept(&mut me);
         Ok(())
     }
 
@@ -626,13 +616,13 @@ impl fmt::Debug for TcpListener {
 
 impl Drop for TcpListener {
     fn drop(&mut self) {
-        let inner = self.inner();
-
         // If we're still internally reading, we're no longer interested.
         unsafe {
-            match inner.accept {
+            match self.inner().accept {
                 State::Pending(_) => {
-                    drop(super::cancel(&inner.socket, &self.imp.inner.accept));
+                    trace!("cancelling active TCP accept");
+                    drop(super::cancel(&self.imp.inner.socket,
+                                       &self.imp.inner.accept));
                 }
                 State::Empty |
                 State::Ready(_) |

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -8,7 +8,6 @@ use std::io::prelude::*;
 use std::io;
 use std::mem;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::os::windows::prelude::*;
 use std::sync::{Mutex, MutexGuard};
 
 #[allow(unused_imports)]
@@ -20,7 +19,6 @@ use miow::net::UdpSocketExt as MiowUdpSocketExt;
 
 use {Evented, EventSet, Poll, PollOpt, Token};
 use poll;
-use sys::windows::bad_state;
 use sys::windows::from_raw_arc::FromRawArc;
 use sys::windows::selector::{Overlapped, Registration};
 
@@ -37,20 +35,15 @@ struct Imp {
 struct Io {
     read: Overlapped,
     write: Overlapped,
+    socket: net::UdpSocket,
     inner: Mutex<Inner>,
 }
 
 struct Inner {
-    socket: Socket,
     iocp: Registration,
     read: State<Vec<u8>, Vec<u8>>,
     write: State<Vec<u8>, (Vec<u8>, usize)>,
     read_buf: SocketAddrBuf,
-}
-
-enum Socket {
-    Empty,
-    Bound(net::UdpSocket),
 }
 
 enum State<T, U> {
@@ -68,8 +61,8 @@ impl UdpSocket {
                 inner: FromRawArc::new(Io {
                     read: Overlapped::new(recv_done),
                     write: Overlapped::new(send_done),
+                    socket: socket,
                     inner: Mutex::new(Inner {
-                        socket: Socket::Bound(socket),
                         iocp: Registration::new(),
                         read: State::Empty,
                         write: State::Empty,
@@ -81,12 +74,11 @@ impl UdpSocket {
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
-        try!(self.inner().socket.socket()).local_addr()
+        self.imp.inner.socket.local_addr()
     }
 
     pub fn try_clone(&self) -> io::Result<UdpSocket> {
-        let me = self.inner();
-        try!(me.socket.socket()).try_clone().and_then(UdpSocket::new)
+        self.imp.inner.socket.try_clone().and_then(UdpSocket::new)
     }
 
     /// Note that unlike `TcpStream::write` this function will not attempt to
@@ -105,7 +97,6 @@ impl UdpSocket {
             _ => return Ok(None),
         }
 
-        let s = try!(me.socket.socket());
         if !me.iocp.registered() {
             return Ok(None)
         }
@@ -117,8 +108,8 @@ impl UdpSocket {
         let amt = try!(owned_buf.write(buf));
         try!(unsafe {
             trace!("scheduling a send");
-            s.send_to_overlapped(&owned_buf, target,
-                                 self.imp.inner.write.get_mut())
+            self.imp.inner.socket.send_to_overlapped(&owned_buf, target,
+                                                     self.imp.inner.write.get_mut())
         });
         me.write = State::Pending(owned_buf);
         mem::forget(self.imp.clone());
@@ -158,71 +149,71 @@ impl UdpSocket {
     }
 
     pub fn broadcast(&self) -> io::Result<bool> {
-        try!(self.inner().socket.socket()).broadcast()
+        self.imp.inner.socket.broadcast()
     }
 
     pub fn set_broadcast(&self, on: bool) -> io::Result<()> {
-        try!(self.inner().socket.socket()).set_broadcast(on)
+        self.imp.inner.socket.set_broadcast(on)
     }
 
     pub fn multicast_loop_v4(&self) -> io::Result<bool> {
-        try!(self.inner().socket.socket()).multicast_loop_v4()
+        self.imp.inner.socket.multicast_loop_v4()
     }
 
     pub fn set_multicast_loop_v4(&self, on: bool) -> io::Result<()> {
-        try!(self.inner().socket.socket()).set_multicast_loop_v4(on)
+        self.imp.inner.socket.set_multicast_loop_v4(on)
     }
 
     pub fn multicast_ttl_v4(&self) -> io::Result<u32> {
-        try!(self.inner().socket.socket()).multicast_ttl_v4()
+        self.imp.inner.socket.multicast_ttl_v4()
     }
 
     pub fn set_multicast_ttl_v4(&self, ttl: u32) -> io::Result<()> {
-        try!(self.inner().socket.socket()).set_multicast_ttl_v4(ttl)
+        self.imp.inner.socket.set_multicast_ttl_v4(ttl)
     }
 
     pub fn multicast_loop_v6(&self) -> io::Result<bool> {
-        try!(self.inner().socket.socket()).multicast_loop_v6()
+        self.imp.inner.socket.multicast_loop_v6()
     }
 
     pub fn set_multicast_loop_v6(&self, on: bool) -> io::Result<()> {
-        try!(self.inner().socket.socket()).set_multicast_loop_v6(on)
+        self.imp.inner.socket.set_multicast_loop_v6(on)
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
-        try!(self.inner().socket.socket()).ttl()
+        self.imp.inner.socket.ttl()
     }
 
     pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
-        try!(self.inner().socket.socket()).set_ttl(ttl)
+        self.imp.inner.socket.set_ttl(ttl)
     }
 
     pub fn join_multicast_v4(&self,
                              multiaddr: &Ipv4Addr,
                              interface: &Ipv4Addr) -> io::Result<()> {
-        try!(self.inner().socket.socket()).join_multicast_v4(multiaddr, interface)
+        self.imp.inner.socket.join_multicast_v4(multiaddr, interface)
     }
 
     pub fn join_multicast_v6(&self,
                              multiaddr: &Ipv6Addr,
                              interface: u32) -> io::Result<()> {
-        try!(self.inner().socket.socket()).join_multicast_v6(multiaddr, interface)
+        self.imp.inner.socket.join_multicast_v6(multiaddr, interface)
     }
 
     pub fn leave_multicast_v4(&self,
                               multiaddr: &Ipv4Addr,
                               interface: &Ipv4Addr) -> io::Result<()> {
-        try!(self.inner().socket.socket()).leave_multicast_v4(multiaddr, interface)
+        self.imp.inner.socket.leave_multicast_v4(multiaddr, interface)
     }
 
     pub fn leave_multicast_v6(&self,
                               multiaddr: &Ipv6Addr,
                               interface: u32) -> io::Result<()> {
-        try!(self.inner().socket.socket()).leave_multicast_v6(multiaddr, interface)
+        self.imp.inner.socket.leave_multicast_v6(multiaddr, interface)
     }
 
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
-        try!(self.inner().socket.socket()).take_error()
+        self.imp.inner.socket.take_error()
     }
 
     fn inner(&self) -> MutexGuard<Inner> {
@@ -252,10 +243,6 @@ impl Imp {
             State::Empty => {}
             _ => return,
         }
-        let socket = match me.socket {
-            Socket::Empty => return,
-            Socket::Bound(ref s) => s,
-        };
 
         let interest = me.iocp.readiness();
         me.iocp.set_readiness(interest & !EventSet::readable());
@@ -265,8 +252,8 @@ impl Imp {
             trace!("scheduling a read");
             let cap = buf.capacity();
             buf.set_len(cap);
-            socket.recv_from_overlapped(&mut buf, &mut me.read_buf,
-                                        self.inner.read.get_mut())
+            self.inner.socket.recv_from_overlapped(&mut buf, &mut me.read_buf,
+                                                   self.inner.read.get_mut())
         };
         match res {
             Ok(_) => {
@@ -283,9 +270,6 @@ impl Imp {
 
     // See comments in tcp::StreamImp::push
     fn add_readiness(&self, me: &Inner, set: EventSet) {
-        if let Socket::Empty = me.socket {
-            return
-        }
         me.iocp.set_readiness(set | me.iocp.readiness());
     }
 }
@@ -294,15 +278,9 @@ impl Evented for UdpSocket {
     fn register(&self, poll: &Poll, token: Token,
                 interest: EventSet, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
-        {
-            let me = &mut *me;
-            let socket = match me.socket {
-                Socket::Bound(ref s) => s as &AsRawSocket,
-                Socket::Empty => return Err(bad_state()),
-            };
-            try!(me.iocp.register_socket(socket, poll, token, interest, opts,
-                                         &self.registration));
-        }
+        try!(me.iocp.register_socket(&self.imp.inner.socket,
+                                     poll, token, interest, opts,
+                                     &self.registration));
         self.post_register(interest, &mut me);
         Ok(())
     }
@@ -310,15 +288,9 @@ impl Evented for UdpSocket {
     fn reregister(&self, poll: &Poll, token: Token,
                   interest: EventSet, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
-        {
-            let me = &mut *me;
-            let socket = match me.socket {
-                Socket::Bound(ref s) => s as &AsRawSocket,
-                Socket::Empty => return Err(bad_state()),
-            };
-            try!(me.iocp.reregister_socket(socket, poll, token, interest,
-                                           opts, &self.registration));
-        }
+        try!(me.iocp.reregister_socket(&self.imp.inner.socket,
+                                       poll, token, interest,
+                                       opts, &self.registration));
         self.post_register(interest, &mut me);
         Ok(())
     }
@@ -344,22 +316,13 @@ impl Drop for UdpSocket {
         unsafe {
             match inner.read {
                 State::Pending(_) => {
-                    drop(super::cancel(inner.socket.socket().unwrap(),
+                    drop(super::cancel(&self.imp.inner.socket,
                                        &self.imp.inner.read));
                 }
                 State::Empty |
                 State::Ready(_) |
                 State::Error(_) => {}
             }
-        }
-    }
-}
-
-impl Socket {
-    fn socket(&self) -> io::Result<&net::UdpSocket> {
-        match *self {
-            Socket::Bound(ref s) => Ok(s),
-            Socket::Empty => Err(bad_state()),
         }
     }
 }

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -31,6 +31,7 @@ mod test_timer;
 mod test_udp_level;
 mod test_udp_socket;
 mod test_uds_shutdown;
+mod test_write_then_drop;
 
 // ===== Unix only tests =====
 #[cfg(unix)]

--- a/test/test_write_then_drop.rs
+++ b/test/test_write_then_drop.rs
@@ -12,7 +12,6 @@ fn write_then_drop() {
     let mut s = TcpStream::connect(&addr).unwrap();
 
     let poll = Poll::new().unwrap();
-    let mut events = Events::new();
 
     a.register(&poll,
                Token(1),
@@ -23,7 +22,10 @@ fn write_then_drop() {
                EventSet::none(),
                PollOpt::edge()).unwrap();
 
-    poll.poll(&mut events, None).unwrap();
+    let mut events = Events::new();
+    while events.len() == 0 {
+        poll.poll(&mut events, None).unwrap();
+    }
     assert_eq!(events.len(), 1);
     assert_eq!(events.get(0).unwrap().token(), Token(1));
 
@@ -34,7 +36,10 @@ fn write_then_drop() {
                 EventSet::writable(),
                 PollOpt::edge()).unwrap();
 
-    poll.poll(&mut events, None).unwrap();
+    let mut events = Events::new();
+    while events.len() == 0 {
+        poll.poll(&mut events, None).unwrap();
+    }
     assert_eq!(events.len(), 1);
     assert_eq!(events.get(0).unwrap().token(), Token(2));
 
@@ -45,7 +50,69 @@ fn write_then_drop() {
                  Token(3),
                  EventSet::readable(),
                  PollOpt::edge()).unwrap();
-    poll.poll(&mut events, None).unwrap();
+    let mut events = Events::new();
+    while events.len() == 0 {
+        poll.poll(&mut events, None).unwrap();
+    }
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.get(0).unwrap().token(), Token(3));
+
+    let mut buf = [0; 10];
+    assert_eq!(s.read(&mut buf).unwrap(), 4);
+    assert_eq!(&buf[0..4], &[1, 2, 3, 4]);
+}
+
+#[test]
+fn write_then_deregister() {
+    drop(::env_logger::init());
+
+    let a = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = a.local_addr().unwrap();
+    let mut s = TcpStream::connect(&addr).unwrap();
+
+    let poll = Poll::new().unwrap();
+
+    a.register(&poll,
+               Token(1),
+               EventSet::readable(),
+               PollOpt::edge()).unwrap();
+    s.register(&poll,
+               Token(3),
+               EventSet::none(),
+               PollOpt::edge()).unwrap();
+
+    let mut events = Events::new();
+    while events.len() == 0 {
+        poll.poll(&mut events, None).unwrap();
+    }
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.get(0).unwrap().token(), Token(1));
+
+    let mut s2 = a.accept().unwrap().unwrap().0;
+
+    s2.register(&poll,
+                Token(2),
+                EventSet::writable(),
+                PollOpt::edge()).unwrap();
+
+    let mut events = Events::new();
+    while events.len() == 0 {
+        poll.poll(&mut events, None).unwrap();
+    }
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.get(0).unwrap().token(), Token(2));
+
+    s2.write(&[1, 2, 3, 4]).unwrap();
+    s2.deregister(&poll).unwrap();
+
+    s.reregister(&poll,
+                 Token(3),
+                 EventSet::readable(),
+                 PollOpt::edge()).unwrap();
+    let mut events = Events::new();
+    while events.len() == 0 {
+        poll.poll(&mut events, None).unwrap();
+    }
     assert_eq!(events.len(), 1);
     assert_eq!(events.get(0).unwrap().token(), Token(3));
 

--- a/test/test_write_then_drop.rs
+++ b/test/test_write_then_drop.rs
@@ -1,0 +1,49 @@
+use std::io::{Write, Read};
+
+use mio::tcp::{TcpStream, TcpListener};
+use mio::{Poll, Events, EventSet, PollOpt, Token, Evented};
+
+#[test]
+fn write_then_drop() {
+    let a = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = a.local_addr().unwrap();
+    let mut s = TcpStream::connect(&addr).unwrap();
+
+    let poll = Poll::new().unwrap();
+    let mut events = Events::new();
+
+    a.register(&poll,
+               Token(1),
+               EventSet::readable(),
+               PollOpt::edge()).unwrap();
+
+    poll.poll(&mut events, None).unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.get(0).unwrap().token(), Token(1));
+
+    let mut s2 = a.accept().unwrap().unwrap().0;
+
+    s2.register(&poll,
+                Token(2),
+                EventSet::writable(),
+                PollOpt::edge()).unwrap();
+
+    poll.poll(&mut events, None).unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.get(0).unwrap().token(), Token(2));
+
+    s2.write(&[1, 2, 3, 4]).unwrap();
+    drop(s2);
+
+    s.register(&poll,
+               Token(3),
+               EventSet::readable(),
+               PollOpt::edge()).unwrap();
+    poll.poll(&mut events, None).unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events.get(0).unwrap().token(), Token(3));
+
+    let mut buf = [0; 10];
+    assert_eq!(s.read(&mut buf).unwrap(), 4);
+    assert_eq!(&buf[0..4], &[1, 2, 3, 4]);
+}


### PR DESCRIPTION
On Unix the kernel will do this for us, but on Windows we need to do it ourselves. Previously we would forcibly close a socket whenever a socket was dropped on Windows. This would leave around its associated Arc (for completion events), but it would cancel all I/O in flight.

Now we instead allow writes to finish (we don't cancel them), and we just cancel any reads that are in flight. This should ensure that we actually get around to closing the socket in a timely fashion (not blocked on a read that'll never come) but we'll still ensure that all the data we said we wrote actually gets written.

Closes #423 

cc @seanmonstar 