### PR TITLE
Adding FreeBSD to supported systems list

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Currently supported platforms:
 * Windows
 * Android
 * NetBSD
+* FreeBSD
 
 There are potentially others. If you find that Mio works on another
 platform, submit a PR to update the list!


### PR DESCRIPTION
ADD:
  - README.md: Adding FreeBSD to supported settings.


```bash
ian@ian-desktop ~/D/r/pingpong> uname -a
FreeBSD ian-desktop 10.3-RELEASE-p5 FreeBSD 10.3-RELEASE-p5 #0: Thu Jun 30 03:52:15 UTC 2016     root@amd64-builder.pcbsd.org:/usr/obj/usr/src/sys/GENERIC  amd64
ian@ian-desktop ~/D/r/pingpong> cargo run
    Updating registry `https://github.com/rust-lang/crates.io-index`
 Downloading mio v0.5.1
 Downloading bytes v0.3.0
 Downloading time v0.1.35
 Downloading winapi v0.2.8
 Downloading slab v0.1.3
 Downloading libc v0.2.15
 Downloading log v0.3.6
 Downloading nix v0.5.1
 Downloading miow v0.1.3
 Downloading net2 v0.2.26
 Downloading kernel32-sys v0.2.2
 Downloading winapi-build v0.1.1
 Downloading bitflags v0.4.0
 Downloading ws2_32-sys v0.2.1
 Downloading cfg-if v0.1.0
     Running `target/debug/pingpong`
Hello, world!
```