### PR TITLE
EPOLL_CLOEXEC first became available in libc 0.2.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ net2     = "0.2.19"
 
 [target.'cfg(unix)'.dependencies]
 nix    = "0.6.0"
-libc   = "0.2.4"
+libc   = "0.2.14"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.1"


### PR DESCRIPTION
Per https://github.com/rust-lang/libc/commit/357f97f5a692e20fc232d1ea711d49e572c2a86a