### PR TITLE
prevent Io::into_raw_fd from dropping self

### DIFF
--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -1,5 +1,6 @@
 use {io, poll, Evented, Ready, Poll, PollOpt, Token};
 use std::io::{Read, Write};
+use std::mem;
 use std::os::unix::io::{IntoRawFd, AsRawFd, FromRawFd, RawFd};
 use nix::fcntl::FcntlArg::F_SETFL;
 use nix::fcntl::{fcntl, O_NONBLOCK};
@@ -41,7 +42,10 @@ impl FromRawFd for Io {
 
 impl IntoRawFd for Io {
     fn into_raw_fd(self) -> RawFd {
-        self.fd
+        // Forget self to prevent drop() from closing self.fd.
+        let fd = self.fd;
+        mem::forget(self);
+        fd
     }
 }
 


### PR DESCRIPTION
Currently it closes its own fd immediately before returning. It looks like this affects `UnixSocket` too, since it contains an `Io`, though I'm not sure if either of these have any callers currently?

Related thought: Although I don't think it's exposed publicly, the `From<RawFd>` implementation for `Io` lets safe code create two `Io`'s from the same fd, which leads to a double close. I think that sort of thing is why `from_raw_fd` is unsafe. I'll put up a second PR to see what deleting that safe constructor looks like, and maybe you can let me know what you think?