### PR TITLE
get rid of the safe constructors for Io

### DIFF
--- a/src/deprecated/unix.rs
+++ b/src/deprecated/unix.rs
@@ -221,14 +221,14 @@ impl PipeReader {
             Err(e) => return Err(e),
             _ => {},
         }
-        return Ok(PipeReader::from(Io::from_raw_fd(stdout.into_raw_fd())));
+        return Ok(PipeReader::from(unsafe { Io::from_raw_fd(stdout.into_raw_fd()) }));
     }
     pub fn from_stderr(stderr: process::ChildStderr) -> io::Result<Self> {
         match sys::set_nonblock(&stderr) {
             Err(e) => return Err(e),
             _ => {},
         }
-        return Ok(PipeReader::from(Io::from_raw_fd(stderr.into_raw_fd())));
+        return Ok(PipeReader::from(unsafe { Io::from_raw_fd(stderr.into_raw_fd()) }));
     }
 }
 
@@ -275,7 +275,7 @@ impl PipeWriter {
             Err(e) => return Err(e),
             _ => {},
         }
-        return Ok(PipeWriter::from(Io::from_raw_fd(stdin.into_raw_fd())));
+        return Ok(PipeWriter::from(unsafe { Io::from_raw_fd(stdin.into_raw_fd()) }));
     }
 }
 

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -21,21 +21,9 @@ pub struct Io {
     fd: RawFd,
 }
 
-impl Io {
-    pub fn from_raw_fd(fd: RawFd) -> Io {
-        Io { fd: fd }
-    }
-}
-
-impl From<RawFd> for Io {
-    fn from(fd: RawFd) -> Io {
-        Io { fd: fd }
-    }
-}
-
 impl FromRawFd for Io {
     unsafe fn from_raw_fd(fd: RawFd) -> Io {
-        From::from(fd)
+        Io { fd: fd }
     }
 }
 

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -29,6 +29,8 @@ pub use self::tcp::{TcpStream, TcpListener};
 pub use self::udp::UdpSocket;
 pub use self::uds::UnixSocket;
 
+use std::os::unix::io::FromRawFd;
+
 pub fn pipe() -> ::io::Result<(Io, Io)> {
     use nix::fcntl::{O_NONBLOCK, O_CLOEXEC};
     use nix::unistd::pipe2;
@@ -36,7 +38,9 @@ pub fn pipe() -> ::io::Result<(Io, Io)> {
     let (rd, wr) = try!(pipe2(O_NONBLOCK | O_CLOEXEC)
         .map_err(from_nix_error));
 
-    Ok((Io::from_raw_fd(rd), Io::from_raw_fd(wr)))
+    unsafe {
+        Ok((Io::from_raw_fd(rd), Io::from_raw_fd(wr)))
+    }
 }
 
 pub fn from_nix_error(err: ::nix::Error) -> ::io::Error {

--- a/src/sys/unix/net.rs
+++ b/src/sys/unix/net.rs
@@ -1,6 +1,6 @@
 use {io};
 use sys::unix::{nix, Io};
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, RawFd, FromRawFd};
 pub use net::tcp::Shutdown;
 
 pub fn socket(family: nix::AddressFamily, ty: nix::SockType, nonblock: bool) -> io::Result<RawFd> {
@@ -53,5 +53,5 @@ pub fn accept(io: &Io, nonblock: bool) -> io::Result<RawFd> {
 pub fn dup(io: &Io) -> io::Result<Io> {
     nix::dup(io.as_raw_fd())
         .map_err(super::from_nix_error)
-        .map(Io::from_raw_fd)
+        .map(|fd| unsafe { Io::from_raw_fd(fd) })
 }

--- a/src/sys/unix/uds.rs
+++ b/src/sys/unix/uds.rs
@@ -19,7 +19,7 @@ impl UnixSocket {
 
     fn new(ty: nix::SockType) -> io::Result<UnixSocket> {
         let fd = try!(net::socket(nix::AddressFamily::Unix, ty, true));
-        Ok(From::from(Io::from_raw_fd(fd)))
+        Ok(From::from(unsafe { Io::from_raw_fd(fd) }))
     }
 
     /// Connect the socket to the specified address
@@ -34,7 +34,7 @@ impl UnixSocket {
 
     pub fn accept(&self) -> io::Result<UnixSocket> {
         net::accept(&self.io, true)
-            .map(|fd| From::from(Io::from_raw_fd(fd)))
+            .map(|fd| From::from(unsafe { Io::from_raw_fd(fd) }))
     }
 
     /// Bind the socket to the specified address

--- a/test/test_unix_pass_fd.rs
+++ b/test/test_unix_pass_fd.rs
@@ -6,7 +6,7 @@ use bytes::{Buf, ByteBuf, SliceBuf};
 use slab;
 use std::path::PathBuf;
 use std::io::{self, Read};
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, FromRawFd};
 use tempdir::TempDir;
 
 const SERVER: Token = Token(10_000_000);
@@ -172,7 +172,7 @@ impl EchoClient {
                 assert_eq!(r, 1);
                 assert_eq!(b'x', buf[0]);
                 debug!("CLIENT : We read {} bytes!", r);
-                pipe = From::<Io>::from(From::from(fd));
+                pipe = From::<Io>::from(unsafe { Io::from_raw_fd(fd) });
             }
             Err(e) => {
                 panic!("not implemented; client err={:?}", e);


### PR DESCRIPTION
As mentioned in https://github.com/carllerche/mio/pull/468. It's kind of a drag to have `unsafe` everywhere, but on the other hand the function _is_ kind of unsafe. Curious for your thoughts.