### PR TITLE
windows: Don't allocate buffers for TCP reads

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -454,7 +454,7 @@ impl RegistrationInner {
         // will set a `Release` barrier ensuring eventual consistency.
         self.node().events.store(event::as_usize(ready), Ordering::Relaxed);
 
-        trace!("readiness event {:?} {:?}", ready, self.node().token());
+        trace!("set_readiness event {:?} {:?}", ready, self.node().token());
 
         // Setting readiness to none doesn't require any processing by the poll
         // instance, so there is no need to enqueue the node. No barrier is
@@ -659,7 +659,8 @@ impl ReadinessQueue {
 
                 // TODO: Don't push the event if the capacity of `dst` has
                 // been reached
-                trace!("readiness event {:?} {:?}", events, node_ref.token());
+                trace!("returning readiness event {:?} {:?}", events,
+                       node_ref.token());
                 dst.push_event(Event::new(events, node_ref.token()));
 
                 // If one-shot, disarm the node

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -37,7 +37,7 @@ impl UdpHandler {
                         unsafe { MutBuf::advance(&mut self.rx_buf, cnt); }
                         assert_eq!(*addr.ip(), Ipv4Addr::new(127, 0, 0, 1));
                     }
-                    _ => panic!("unexpected result"),
+                    res => panic!("unexpected result: {:?}", res),
                 }
                 assert!(str::from_utf8(self.rx_buf.bytes()).unwrap() == self.msg);
                 event_loop.shutdown();
@@ -76,6 +76,7 @@ impl Handler for UdpHandler {
 
 #[test]
 pub fn test_multicast() {
+    drop(::env_logger::init());
     debug!("Starting TEST_UDP_CONNECTIONLESS");
     let mut event_loop = EventLoop::new().unwrap();
 

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -62,7 +62,7 @@ fn connect() {
             assert_eq!(token, Token(1));
             match self.hit {
                 0 => assert!(events.is_writable()),
-                1 => assert!(events.is_hup()),
+                1 => assert!(events.is_readable()),
                 _ => panic!(),
             }
             self.hit += 1;

--- a/test/test_timer.rs
+++ b/test/test_timer.rs
@@ -8,7 +8,7 @@ use bytes::{Buf, ByteBuf, SliceBuf};
 use localhost;
 use std::time::Duration;
 
-use self::TestState::{Initial, AfterRead, AfterHup};
+use self::TestState::{Initial, AfterRead};
 
 #[test]
 fn test_basic_timer_without_poll() {
@@ -274,7 +274,6 @@ const CONN: Token = Token(2);
 enum TestState {
     Initial,
     AfterRead,
-    AfterHup
 }
 
 struct TestHandler {
@@ -293,7 +292,7 @@ impl TestHandler {
     }
 
     fn handle_read(&mut self, event_loop: &mut EventLoop<TestHandler>,
-                   tok: Token, events: Ready) {
+                   tok: Token, _events: Ready) {
         match tok {
             SERVER => {
                 debug!("server connection ready for accept");
@@ -309,30 +308,14 @@ impl TestHandler {
                 debug!("client readable");
 
                 match self.state {
-                    Initial => {
-                        // Whether or not Hup is included with actual data is
-                        // platform specific
-                        if events.is_hup() {
-                            self.state = AfterHup;
-                        } else {
-                            self.state = AfterRead;
-                        }
-                    }
-                    AfterRead => {
-                        assert_eq!(events, Ready::readable() | Ready::hup());
-                        self.state = AfterHup;
-                    }
-                    AfterHup => panic!("Shouldn't get here"),
-                }
-
-                if self.state == AfterHup {
-                    event_loop.shutdown();
-                    return;
+                    Initial => self.state = AfterRead,
+                    AfterRead => {}
                 }
 
                 let mut buf = ByteBuf::mut_with_capacity(2048);
 
                 match self.cli.try_read_buf(&mut buf) {
+                    Ok(Some(0)) => return event_loop.shutdown(),
                     Ok(n) => {
                         debug!("read {:?} bytes", n);
                         assert!(b"zomg" == buf.flip().bytes());
@@ -410,5 +393,5 @@ pub fn test_old_timer() {
     // Start the event loop
     event_loop.run(&mut handler).unwrap();
 
-    assert!(handler.state == AfterHup, "actual={:?}", handler.state);
+    assert!(handler.state == AfterRead, "actual={:?}", handler.state);
 }


### PR DESCRIPTION
This commit employs a trick [1](https://github.com/carllerche/mio/issues/439#issuecomment-246602046) for avoiding allocation of an intermediate
buffer for in-flight calls to `TcpStream::read`. Previously this was done to
receive data, but apparently it works out to pass a 0-length buffer to the
kernel and get a notification back when there's internally buffered data.

This in turn allows us to avoid allocation any buffers while getting an
epoll-style readiness notification for TCP streams. Once a 0-byte read has
completed we just call the normal `TcpStream::read` function and wait for
`WouldBlock` to get returned. Note that this involves putting the socket into
nonblocking mode (which we managed to avoid before).

cc #439
