### PR TITLE
Correct a couple of typos in documentation

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -23,11 +23,11 @@ pub struct TcpStream {
 pub use std::net::Shutdown;
 
 impl TcpStream {
-    /// Create a new TCP stream an issue a non-blocking connect to the specified
-    /// address.
+    /// Create a new TCP stream and issue a non-blocking connect to the
+    /// specified address.
     ///
     /// This convenience method is available and uses the system's default
-    /// options when creating a socket which is then conntected. If fine-grained
+    /// options when creating a socket which is then connected. If fine-grained
     /// control over the creation of the socket is desired, you can use
     /// `net2::TcpBuilder` to configure a socket and then pass its socket to
     /// `TcpStream::connect_stream` to transfer ownership into mio and schedule


### PR DESCRIPTION
Just noticed a couple of minor typo's, thought it would be nice to correct these
