### PR TITLE
WIP: Vectored IO interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub use poll::{
 pub use token::{
     Token,
 };
+pub use sys::IoVec;
 
 #[cfg(unix)]
 pub mod unix {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,6 +1,6 @@
 //! Primitives for working with UDP
 
-use {io, sys, Evented, Ready, Poll, PollOpt, Token};
+use {io, sys, Evented, Ready, Poll, PollOpt, Token, IoVec};
 use super::SelectorId;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 
@@ -56,10 +56,7 @@ impl UdpSocket {
 
     /// Sends data on the socket to the given address. On success, returns the
     /// number of bytes written.
-    ///
-    /// Address type can be any implementor of `ToSocketAddrs` trait. See its
-    /// documentation for concrete examples.
-    pub fn send_to(&self, buf: &[u8], target: &SocketAddr)
+    pub fn send_to(&self, buf: &[IoVec<&[u8]>], target: &SocketAddr)
                    -> io::Result<Option<usize>> {
         self.sys.send_to(buf, target)
     }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -9,6 +9,7 @@ pub use self::unix::{
     TcpListener,
     UdpSocket,
     UnixSocket,
+    IoVec,
     pipe,
     set_nonblock,
 };
@@ -25,6 +26,7 @@ pub use self::windows::{
     TcpStream,
     TcpListener,
     UdpSocket,
+    IoVec,
 };
 
 #[cfg(windows)]

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -95,3 +95,17 @@ mod nix {
         dup,
     };
 }
+
+pub struct IoVec<T>(nix::IoVec<T>);
+
+impl<'a> IoVec<&'a [u8]> {
+    pub fn from_slice(buf: &'a [u8]) -> IoVec<&'a [u8]> {
+        IoVec(nix::IoVec::from_slice(buf))
+    }
+}
+
+impl<'a> IoVec<&'a mut [u8]> {
+    pub fn from_mut(buf: &'a mut [u8]) -> IoVec<&'a mut [u8]> {
+        IoVec(nix::IoVec::from_mut_slice(buf))
+    }
+}

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -50,7 +50,7 @@ impl UdpHandler {
         match token {
             SENDER => {
                 let addr = self.rx.local_addr().unwrap();
-                let cnt = self.tx.send_to(self.buf.bytes(), &addr)
+                let cnt = self.tx.send_to(&[IoVec::from_slice(self.buf.bytes())], &addr)
                                  .unwrap().unwrap();
                 self.buf.advance(cnt);
             },

--- a/test/test_udp_level.rs
+++ b/test/test_udp_level.rs
@@ -29,7 +29,7 @@ pub fn test_udp_level_triggered() {
         assert_eq!(rx_events[0], Event::new(Ready::writable(), Token(1)));
     }
 
-    tx.send_to(b"hello world!", &rx.local_addr().unwrap()).unwrap();
+    tx.send_to(&[IoVec::from_slice(b"hello world!")], &rx.local_addr().unwrap()).unwrap();
 
     sleep_ms(250);
 
@@ -51,7 +51,7 @@ pub fn test_udp_level_triggered() {
         assert_eq!(rx_events[0], Event::new(Ready::writable(), Token(1)));
     }
 
-    tx.send_to(b"hello world!", &rx.local_addr().unwrap()).unwrap();
+    tx.send_to(&[IoVec::from_slice(b"hello world!")], &rx.local_addr().unwrap()).unwrap();
     sleep_ms(250);
 
     poll.poll(&mut events, Some(Duration::from_millis(MS))).unwrap();

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -54,7 +54,7 @@ impl Handler for UdpHandler {
             match token {
                 SENDER => {
                     let addr = self.rx.local_addr().unwrap();
-                    let cnt = self.tx.send_to(self.buf.bytes(), &addr).unwrap()
+                    let cnt = self.tx.send_to(&[IoVec::from_slice(self.buf.bytes())], &addr).unwrap()
                                                                       .unwrap();
                     self.buf.advance(cnt);
                 },


### PR DESCRIPTION
This PR demonstrates a possible approach to exposing a portable interface to vectored IO. To guarantee binary compatibility with the syscalls without requiring copying and either dynamic allocation or a low limit on the number of buffers, the syscalls' native slice types (e.g. `iovec` or `WSABUF`) must be exposed publicly, so I defined a portable wrapper for Unix and Windows. I modified the *nix definition `UdpSocket::send_to` and its tests to demonstrate employment of this wrapper.

If this approach is deemed acceptable, the PR should be fleshed out with implementations of vectored IO for all network IO functions on all platforms. Due to the ugliness of the interface, these implementations should probably be provided alongside, rather than in place of, the existing slice-based functions.
