### PR TITLE
Update nix api for version 0.7.1 and later

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ slab     = "0.3.0"
 net2     = "0.2.19"
 
 [target.'cfg(unix)'.dependencies]
-nix    = "0.6.0"
+nix    = { git = "https://github.com/nix-rust/nix" }
 libc   = "0.2.14"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Git rev 45c82235a3b91939ea9a656c6afcf71be15411f3, to be released in
Nix 0.7.1 or later, changes the API of KEvent.

https://github.com/nix-rust/nix/pull/442 must be merged before this PR will build.
