### PR TITLE
Support SO_REUSEPORT option when feature 'reuse_port' enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ env_logger = "0.3.0"
 tempdir    = "0.3.4"
 bytes      = "0.3.0"
 
+[features]
+default = []
+reuse_port = []
+
 [[test]]
 name = "test"
 path = "test/mod.rs"

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -281,6 +281,13 @@ impl TcpListener {
             try!(sock.reuse_address(true));
         }
 
+        // Set SO_REUSEPORT, but only on Unix
+        // And on Linux, this socket option is only available on kernel 3.9+
+        if cfg!(unix) && cfg!(feature = "reuse_port") {
+            use net2::unix::UnixTcpBuilderExt;
+            try!(sock.reuse_port(true));
+        }
+
         // Bind the socket
         try!(sock.bind(addr));
 

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -267,8 +267,12 @@ fn test_tcp_sockets_are_send() {
 }
 
 #[test]
-fn bind_twice_bad() {
+fn bind_twice() {
     let l1 = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = l1.local_addr().unwrap();
-    assert!(TcpListener::bind(&addr).is_err());
+    if cfg!(feature = "reuse_port") {
+        assert!(TcpListener::bind(&addr).is_ok());
+    } else {
+        assert!(TcpListener::bind(&addr).is_err());
+    }
 }


### PR DESCRIPTION
On Linux, this socket option allows several sockets to be bound to one (address, port) pair, and the incoming requests will be distribute evenly across all sockets, which achieves a simple load balance and solves a kind of bottleneck of the single accepting thread.

But this option is only available on linux kernel 3.9+, so I implement it as an optional feature.

@carllerche @alexcrichton Please review this, thanks.

Signed-off-by: Cholerae Hu <choleraehyq@gmail.com>