### PR TITLE
Implement readv/writev support for TcpStream

### DIFF
--- a/src/iovec.rs
+++ b/src/iovec.rs
@@ -1,0 +1,33 @@
+use std::mem;
+
+use sys;
+
+pub struct IoVec {
+    data: sys::IoVec,
+}
+
+impl<'a> From<&'a [u8]> for &'a IoVec {
+    fn from(bytes: &'a [u8]) -> &'a IoVec {
+        unsafe {
+            mem::transmute(<&sys::IoVec>::from(bytes))
+        }
+    }
+}
+
+impl<'a> From<&'a mut [u8]> for &'a mut IoVec {
+    fn from(bytes: &'a mut [u8]) -> &'a mut IoVec {
+        unsafe {
+            mem::transmute(<&mut sys::IoVec>::from(bytes))
+        }
+    }
+}
+
+impl IoVec {
+    pub fn as_bytes(&self) -> &[u8] {
+        self.data.as_bytes()
+    }
+
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
+        self.data.as_mut_bytes()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ extern crate env_logger;
 
 mod event;
 mod io;
+mod iovec;
 mod net;
 mod poll;
 mod sys;
@@ -122,6 +123,7 @@ pub use io::{
     Evented,
     would_block,
 };
+pub use iovec::IoVec;
 pub use net::{
     tcp,
     udp,

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -5,7 +5,7 @@ use std::net::{self, SocketAddr, SocketAddrV4, SocketAddrV6, Ipv4Addr, Ipv6Addr}
 
 use net2::TcpBuilder;
 
-use {io, sys, Evented, Ready, Poll, PollOpt, Token};
+use {io, sys, Evented, Ready, Poll, PollOpt, Token, IoVec};
 use super::SelectorId;
 
 /*
@@ -175,6 +175,42 @@ impl TcpStream {
     /// calls.
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         self.sys.take_error()
+    }
+
+    /// Read in a list of buffers all at once.
+    ///
+    /// This operation will attempt to read bytes from this socket and place
+    /// them into the list of buffers provided. Note that each buffer is an
+    /// `IoVec` which can be created from a byte slice.
+    ///
+    /// The buffers provided will be filled in sequentially. A buffer will be
+    /// entirely filled up before the next is written to.
+    ///
+    /// The number of bytes read is returned, if successful, or an error is
+    /// returned otherwise. If no bytes are available to be read yet then
+    /// a "would block" error is returned. This operation does not block.
+    ///
+    /// On Unix this corresponds to the `readv` syscall.
+    pub fn read_bufs(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
+        self.sys.readv(bufs)
+    }
+
+    /// Write a list of buffers all at once.
+    ///
+    /// This operation will attempt to write a list of byte buffers to this
+    /// socket. Note that each buffer is an `IoVec` which can be created from a
+    /// byte slice.
+    ///
+    /// The buffers provided will be written sequentially. A buffer will be
+    /// entirely written before the next is written.
+    ///
+    /// The number of bytes written is returned, if successful, or an error is
+    /// returned otherwise. If the socket is not currently writable then a
+    /// "would block" error is returned. This operation does not block.
+    ///
+    /// On Unix this corresponds to the `writev` syscall.
+    pub fn write_bufs(&self, bufs: &[&IoVec]) -> io::Result<usize> {
+        self.sys.writev(bufs)
     }
 }
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -11,6 +11,7 @@ pub use self::unix::{
     UnixSocket,
     pipe,
     set_nonblock,
+    IoVec,
 };
 
 
@@ -27,6 +28,7 @@ pub use self::windows::{
     UdpSocket,
     Overlapped,
     Binding,
+    IoVec,
 };
 
 #[cfg(windows)]

--- a/src/sys/unix/iovec.rs
+++ b/src/sys/unix/iovec.rs
@@ -1,0 +1,58 @@
+use std::mem;
+use std::slice;
+
+use libc;
+
+pub struct IoVec {
+    inner: [u8],
+}
+
+pub unsafe fn as_iovec_slice<'a>(iov: &'a [&::IoVec]) -> &'a [libc::iovec] {
+    mem::transmute(iov)
+}
+
+pub unsafe fn as_iovec_slice_mut<'a>(iov: &'a mut [&mut ::IoVec]) -> &'a mut [libc::iovec] {
+    mem::transmute(iov)
+}
+
+impl IoVec {
+    pub fn as_bytes(&self) -> &[u8] {
+        let vec = self.iovec();
+        unsafe {
+            slice::from_raw_parts(vec.iov_base as *const u8, vec.iov_len)
+        }
+    }
+
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
+        let vec = self.iovec();
+        unsafe {
+            slice::from_raw_parts_mut(vec.iov_base as *mut u8, vec.iov_len)
+        }
+    }
+
+    pub fn iovec(&self) -> libc::iovec {
+        unsafe { mem::transmute(&self.inner) }
+    }
+}
+
+impl<'a> From<&'a [u8]> for &'a IoVec {
+    fn from(bytes: &'a [u8]) -> &'a IoVec {
+        unsafe {
+            mem::transmute(libc::iovec {
+                iov_base: bytes.as_ptr() as *mut _,
+                iov_len: bytes.len(),
+            })
+        }
+    }
+}
+
+impl<'a> From<&'a mut [u8]> for &'a mut IoVec {
+    fn from(bytes: &'a mut [u8]) -> &'a mut IoVec {
+        unsafe {
+            mem::transmute(libc::iovec {
+                iov_base: bytes.as_ptr() as *mut _,
+                iov_len: bytes.len(),
+            })
+        }
+    }
+}

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -21,10 +21,12 @@ mod net;
 mod tcp;
 mod udp;
 mod uds;
+mod iovec;
 
 pub use self::awakener::Awakener;
 pub use self::eventedfd::EventedFd;
 pub use self::io::{Io, set_nonblock};
+pub use self::iovec::IoVec;
 pub use self::tcp::{TcpStream, TcpListener};
 pub use self::udp::UdpSocket;
 pub use self::uds::UnixSocket;

--- a/src/sys/windows/iovec.rs
+++ b/src/sys/windows/iovec.rs
@@ -1,0 +1,53 @@
+use std::cmp;
+use std::mem;
+use std::slice;
+
+use winapi::{WSABUF, DWORD};
+
+pub struct IoVec {
+    inner: [u8],
+}
+
+impl IoVec {
+    pub fn as_bytes(&self) -> &[u8] {
+        let vec = self.wsabuf();
+        unsafe {
+            slice::from_raw_parts(vec.buf as *const u8, vec.len as usize)
+        }
+    }
+
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
+        let vec = self.wsabuf();
+        unsafe {
+            slice::from_raw_parts_mut(vec.buf as *mut u8, vec.len as usize)
+        }
+    }
+
+    pub fn wsabuf(&self) -> WSABUF {
+        unsafe { mem::transmute(&self.inner) }
+    }
+}
+
+impl<'a> From<&'a [u8]> for &'a IoVec {
+    fn from(bytes: &'a [u8]) -> &'a IoVec {
+        let len = cmp::min(<DWORD>::max_value() as usize, bytes.len());
+        unsafe {
+            mem::transmute(WSABUF {
+                buf: bytes.as_ptr() as *mut _,
+                len: len as DWORD,
+            })
+        }
+    }
+}
+
+impl<'a> From<&'a mut [u8]> for &'a mut IoVec {
+    fn from(bytes: &'a mut [u8]) -> &'a mut IoVec {
+        let len = cmp::min(<DWORD>::max_value() as usize, bytes.len());
+        unsafe {
+            mem::transmute(WSABUF {
+                buf: bytes.as_ptr() as *mut _,
+                len: len as DWORD,
+            })
+        }
+    }
+}

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -149,11 +149,13 @@ mod tcp;
 mod udp;
 mod from_raw_arc;
 mod buffer_pool;
+mod iovec;
 
 pub use self::awakener::Awakener;
 pub use self::selector::{Events, Selector, Overlapped, Binding};
 pub use self::tcp::{TcpStream, TcpListener};
 pub use self::udp::UdpSocket;
+pub use self::iovec::IoVec;
 
 #[derive(Copy, Clone)]
 enum Family {

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -1,15 +1,16 @@
 extern crate mio;
 extern crate env_logger;
 
-use std::io;
+use std::cmp;
 use std::io::prelude::*;
+use std::io;
 use std::net;
 use std::sync::mpsc::channel;
 use std::thread;
 use std::time::Duration;
 
 use {TryRead, TryWrite};
-use mio::{Token, Ready, PollOpt};
+use mio::{Token, Ready, PollOpt, Poll, Events, IoVec};
 use mio::deprecated::{EventLoop, Handler};
 use mio::tcp::{TcpListener, TcpStream};
 
@@ -147,6 +148,78 @@ fn read() {
 }
 
 #[test]
+fn read_bufs() {
+    const N: usize = 16 * 1024 * 1024;
+
+    let l = net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = l.local_addr().unwrap();
+
+    let t = thread::spawn(move || {
+        let mut s = l.accept().unwrap().0;
+        let b = [1; 1024];
+        let mut amt = 0;
+        while amt < N {
+            amt += s.write(&b).unwrap();
+        }
+    });
+
+    let poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(128);
+
+    let s = TcpStream::connect(&addr).unwrap();
+
+    poll.register(&s, Token(1), Ready::readable(), PollOpt::level()).unwrap();
+
+    let mut b1 = &mut [0; 10][..];
+    let mut b2 = &mut [0; 383][..];
+    let mut b3 = &mut [0; 28][..];
+    let mut b4 = &mut [0; 8][..];
+    let mut b5 = &mut [0; 128][..];
+    let mut b: [&mut IoVec; 5] = [
+        b1.into(),
+        b2.into(),
+        b3.into(),
+        b4.into(),
+        b5.into(),
+    ];
+
+    let mut so_far = 0;
+    loop {
+        for buf in b.iter_mut() {
+            for byte in buf.as_mut_bytes() {
+                *byte = 0;
+            }
+        }
+
+        poll.poll(&mut events, None).unwrap();
+
+        match s.read_bufs(&mut b) {
+            Ok(0) => {
+                assert_eq!(so_far, N);
+                break
+            }
+            Ok(mut n) => {
+                so_far += n;
+                for buf in b.iter() {
+                    let buf = buf.as_bytes();
+                    for byte in buf[..cmp::min(n, buf.len())].iter() {
+                        assert_eq!(*byte, 1);
+                    }
+                    n = n.saturating_sub(buf.len());
+                    if n == 0 {
+                        break
+                    }
+                }
+                assert_eq!(n, 0);
+            }
+            Err(e) => assert_eq!(e.kind(), io::ErrorKind::WouldBlock),
+        }
+    }
+
+    t.join().unwrap();
+}
+
+#[test]
 fn write() {
     const N: usize = 16 * 1024 * 1024;
     struct H { amt: usize, socket: TcpStream }
@@ -192,6 +265,60 @@ fn write() {
 
     let mut h = H { amt: 0, socket: s };
     e.run(&mut h).unwrap();
+    t.join().unwrap();
+}
+
+#[test]
+fn write_bufs() {
+    const N: usize = 16 * 1024 * 1024;
+
+    let l = net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = l.local_addr().unwrap();
+
+    let t = thread::spawn(move || {
+        let mut s = l.accept().unwrap().0;
+        let mut b = [0; 1024];
+        let mut amt = 0;
+        while amt < N {
+            for byte in b.iter_mut() {
+                *byte = 0;
+            }
+            let n = s.read(&mut b).unwrap();
+            amt += n;
+            for byte in b[..n].iter() {
+                assert_eq!(*byte, 1);
+            }
+        }
+    });
+
+    let poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(128);
+    let s = TcpStream::connect(&addr).unwrap();
+    poll.register(&s, Token(1), Ready::writable(), PollOpt::level()).unwrap();
+
+    let b1 = &[1; 10][..];
+    let b2 = &[1; 383][..];
+    let b3 = &[1; 28][..];
+    let b4 = &[1; 8][..];
+    let b5 = &[1; 128][..];
+    let b: [&IoVec; 5] = [
+        b1.into(),
+        b2.into(),
+        b3.into(),
+        b4.into(),
+        b5.into(),
+    ];
+
+    let mut so_far = 0;
+    while so_far < N {
+        poll.poll(&mut events, None).unwrap();
+
+        match s.write_bufs(&b) {
+            Ok(n) => so_far += n,
+            Err(e) => assert_eq!(e.kind(), io::ErrorKind::WouldBlock),
+        }
+    }
+
     t.join().unwrap();
 }
 


### PR DESCRIPTION
This commit implements `readv` and `writev` support for TCP sockets in mio. This
corresponds to the `readv` and `writev` syscalls on Unix and a bit of custom
logic on Windows. On Windows writes are just concatenated into one buffer and
then handed off to IOCP, and each buffer to read into incurs a `recv` syscall
(currently). This may be optimizable in the future for Windows.

The other major factor in this commit is that a new `IoVec` type is added to
this library to represent a buffer passed to these functions. This type is a
dynamically sized type to allow `&IoVec` to represent `&[u8]` and `&mut IoVec`
to represent `&mut [u8]`, allowing the same type to be used in the read/write
versions of these functions. The in-memory representation of `IoVec` is
equivalent to `libc::iovec` on Unix and `winapi::WSABUF` on Windows, asserted
with various transmutes. This all allows us to build up 0-cost abstractions for
readv/writev.