### PR TITLE
windows: use SetFileCompletionNotificationModes for TCP sockets (#476)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ libc   = "0.2.19"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.1"
-miow   = "0.1.4"
+miow   = "0.2.0"
 kernel32-sys = "0.2"
 
 [dev-dependencies]

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -176,3 +176,18 @@ unsafe fn cancel(socket: &AsRawSocket,
         Ok(())
     }
 }
+
+unsafe fn no_notify_on_instant_completion(handle: winapi::HANDLE) -> io::Result<()> {
+    // TODO: move those to winapi
+    const FILE_SKIP_COMPLETION_PORT_ON_SUCCESS: winapi::UCHAR = 1;
+    const FILE_SKIP_SET_EVENT_ON_HANDLE: winapi::UCHAR = 2;
+
+    let flags = FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE;
+
+    let r = kernel32::SetFileCompletionNotificationModes(handle, flags);
+    if r == winapi::TRUE {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -69,8 +69,6 @@ impl Selector {
                   events: &mut Events,
                   awakener: Token,
                   timeout: Option<Duration>) -> io::Result<bool> {
-        let timeout = timeout.map(|to| cmp::min(convert::millis(to), u32::MAX as u64) as u32);
-
         trace!("select; timeout={:?}", timeout);
 
         // Clear out the previous list of I/O events and get some more!

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -109,9 +109,8 @@ impl UdpSocket {
         let amt = try!(owned_buf.write(buf));
         try!(unsafe {
             trace!("scheduling a send");
-            let overlapped = miow::Overlapped::from_raw(self.imp.inner.write.as_mut_ptr());
             self.imp.inner.socket.send_to_overlapped(&owned_buf, target,
-                                                     overlapped)
+                                                     self.imp.inner.write.as_mut_ptr())
         });
         me.write = State::Pending(owned_buf);
         mem::forget(self.imp.clone());
@@ -254,9 +253,8 @@ impl Imp {
             trace!("scheduling a read");
             let cap = buf.capacity();
             buf.set_len(cap);
-            let overlapped = miow::Overlapped::from_raw(self.inner.read.as_mut_ptr());
             self.inner.socket.recv_from_overlapped(&mut buf, &mut me.read_buf,
-                                                   overlapped)
+                                                   self.inner.read.as_mut_ptr())
         };
         match res {
             Ok(_) => {


### PR DESCRIPTION
## SetFileCompletionNotificationModes allows us to tell the kernel not to enqueue the completion message, if it returns `SUCCESS` immediately.

This removes the **CPU-overhead** of having to enter the event loop to handle this completion message.

### Less memory overhead
You do not need as much internal (or external) buffering,
which can be quite significant, especially in a context where the event loop is only run after buffering the content in an external buffer (up to 3x less, 512 MB insteadof 1.5GB for my case).
In that regard it also behaves **similar to the POSIX (epoll) implementation**:
You should be able to repeatedly write to the underlying IO, which will still allow it to progress, without requiring any event loop interaction (similar as epoll, which returns `eagain`, miow returns true).

### **general issues**, some of them already mentioned in the original issue:
- The API is not supported on Windows XP **(unsure it this needs additional attention?)**
- We might want to check for [non-IFS LSPs](https://support.microsoft.com/de-de/help/2568167/setfilecompletionnotificationmodes-api-causes-an-i-o-completion-port-not-to-work-correctly-if-a-non-ifs-lsp-is-installed) , since if one of them is installed, **SetFileCompletionNotificationModes will not work properly if such is installed**.
[Golang](https://github.com/golang/go/blob/d0cf0421717a93b705efcbce0770a24361582445/src/net/fd_windows.go#L47) does perform this check, while **libuv** doesn't seem to.
(This is probably because non-IFS LSPs are deprecated for ages)

### some **issues** or rather hurdles using it with **UDP-sockets**:
- There seems to be a bug in the underlying WSARecv implementation (which according to [this blogpost](http://www.lenholgate.com/blog/2010/01/file-skip-completion-port-on-success-and-datagram-socket-read-errors.html) which is a summary of the issue and links to the [original MSDN post](https://blogs.technet.microsoft.com/winserverperformance/2008/06/25/designing-applications-for-high-performance-part-iii/), where Microsoft confirmed the issue in the comment section.
[Golang](https://github.com/golang/go/blob/d0cf0421717a93b705efcbce0770a24361582445/src/net/fd_windows.go#L299) disables UDP because of this, while [LIBUV](https://github.com/libuv/libuv/blob/v1.x/src/win/winsock.c#L271) uses a (slightly limited) workaround.
[.NET Core](https://github.com/dotnet/corefx/pull/15141/files#diff-6c4b087518282ebcba0a74cb9bd073c3R22) disables it for <= Windows 7.
- Also the MIO api seems slightly different, which should not be any issue, but for the sake of completeness I still list it here.

This is the main reason this implements this for TCP sockets first.