### PR TITLE
Fix broken links and an outdated usage in mio's doc.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,8 @@
 //!
 //! # Usage
 //!
-//! Using mio starts by creating an [EventLoop](struct.EventLoop.html), which
-//! handles receiving events from the OS and dispatching them to a supplied
-//! [Handler](handler/trait.Handler.html).
+//! Using mio starts by creating an [Poll](struct.Poll.html), which reads events from the OS and
+//! put them into [Events](struct.Events.html). You can handle IO events from the OS with it.
 //!
 //! # Example
 //!


### PR DESCRIPTION
I found broken links and an outdated usage in mio's documentation.

Since v0.6, EventLoop and Handler are deprecated.
However, top level of mio's documentation still shows v0.5.x's usage instruction in v0.6.4 doc.

So, I fixed in this way.
Please review this!  🙂 