### PR TITLE
Fixes a race in Registration drop

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -172,12 +172,6 @@ impl Ready {
         Ready(0x008)
     }
 
-    // Private
-    #[inline]
-    fn drop() -> Ready {
-        Ready(0x10)
-    }
-
     #[inline]
     pub fn all() -> Ready {
         Ready::readable() |
@@ -188,7 +182,7 @@ impl Ready {
 
     #[inline]
     pub fn is_none(&self) -> bool {
-        (*self & !Ready::drop()) == Ready::none()
+        *self == Ready::none()
     }
 
     #[inline]
@@ -284,8 +278,7 @@ impl fmt::Debug for Ready {
             (Ready::readable(), "Readable"),
             (Ready::writable(), "Writable"),
             (Ready::error(),    "Error"),
-            (Ready::hup(),      "Hup"),
-            (Ready::drop(),     "Drop")];
+            (Ready::hup(),      "Hup")];
 
         try!(write!(fmt, "Ready {{"));
 
@@ -354,14 +347,6 @@ pub fn from_usize(events: usize) -> Ready {
 /// set.
 pub fn is_empty(events: Ready) -> bool {
     events.0 == 0
-}
-
-pub fn is_drop(events: Ready) -> bool {
-    events.contains(Ready::drop())
-}
-
-pub fn drop() -> Ready {
-    Ready::drop()
 }
 
 // Used internally to mutate an `Event` in place


### PR DESCRIPTION
In certain cases, a race condition caused registration nodes to be
unlinked twice.  # Please enter the commit message for your changes.
Lines starting. Instead of communicating drop via the events atomic. use
the last atomic that will be touched by the SetRegistration half. This
could either be the readiness queue pointer OR the queued flag.

(Hopefully) fixes #532

The test cases provided in the issue does not fail anymore, but this may just means that it only "works for me". @svyatonik would you be able to see if you can reproduce the issue with this PR?

cc @alexcrichton 