### PR TITLE
Rewrite the readiness queue

### DIFF
--- a/benches/bench_poll.rs
+++ b/benches/bench_poll.rs
@@ -1,0 +1,52 @@
+#![feature(test)]
+
+extern crate mio;
+extern crate test;
+
+use mio::*;
+use test::Bencher;
+use std::sync::Arc;
+use std::thread;
+
+#[bench]
+fn bench_poll(bench: &mut Bencher) {
+    const NUM: usize = 10_000;
+    const THREADS: usize = 4;
+
+    let poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(1024);
+
+    let mut registrations = vec![];
+    let mut set_readiness = vec![];
+
+    for i in 0..NUM {
+        let (r, s) = Registration::new(
+            &poll,
+            Token(i),
+            Ready::readable(),
+            PollOpt::edge());
+
+        registrations.push(r);
+        set_readiness.push(s);
+    }
+
+    let set_readiness = Arc::new(set_readiness);
+
+    bench.iter(move || {
+        for mut i in 0..THREADS {
+            let set_readiness = set_readiness.clone();
+            thread::spawn(move || {
+                while i < NUM {
+                    set_readiness[i].set_readiness(Ready::readable()).unwrap();
+                    i += THREADS;
+                }
+            });
+        }
+
+        let mut n = 0;
+
+        while n < NUM {
+            n += poll.poll(&mut events, None).unwrap();
+        }
+    })
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,28 +7,28 @@ pub struct PollOpt(usize);
 
 impl PollOpt {
     #[inline]
-    pub fn edge() -> PollOpt {
-        PollOpt(0x020)
-    }
-
-    #[inline]
     pub fn empty() -> PollOpt {
         PollOpt(0)
     }
 
     #[inline]
+    pub fn edge() -> PollOpt {
+        PollOpt(0b0001)
+    }
+
+    #[inline]
     pub fn level() -> PollOpt {
-        PollOpt(0x040)
+        PollOpt(0b0010)
     }
 
     #[inline]
     pub fn oneshot() -> PollOpt {
-        PollOpt(0x080)
+        PollOpt(0b0100)
     }
 
     #[inline]
     pub fn urgent() -> PollOpt {
-        PollOpt(0x100)
+        PollOpt(0b1000)
     }
 
     #[inline]
@@ -154,28 +154,22 @@ impl Ready {
 
     #[inline]
     pub fn readable() -> Ready {
-        Ready(0x001)
+        Ready(0b0001)
     }
 
     #[inline]
     pub fn writable() -> Ready {
-        Ready(0x002)
+        Ready(0b0010)
     }
 
     #[inline]
     pub fn error() -> Ready {
-        Ready(0x004)
+        Ready(0b0100)
     }
 
     #[inline]
     pub fn hup() -> Ready {
-        Ready(0x008)
-    }
-
-    // Private
-    #[inline]
-    fn drop() -> Ready {
-        Ready(0x10)
+        Ready(0b1000)
     }
 
     #[inline]
@@ -188,7 +182,12 @@ impl Ready {
 
     #[inline]
     pub fn is_none(&self) -> bool {
-        (*self & !Ready::drop()) == Ready::none()
+        *self == Ready::none()
+    }
+
+    #[inline]
+    pub fn is_some(&self) -> bool {
+        !self.is_none()
     }
 
     #[inline]
@@ -284,8 +283,7 @@ impl fmt::Debug for Ready {
             (Ready::readable(), "Readable"),
             (Ready::writable(), "Writable"),
             (Ready::error(),    "Error"),
-            (Ready::hup(),      "Hup"),
-            (Ready::drop(),     "Drop")];
+            (Ready::hup(),      "Hup")];
 
         try!(write!(fmt, "Ready {{"));
 
@@ -342,26 +340,20 @@ impl Event {
  *
  */
 
-pub fn as_usize(events: Ready) -> usize {
+pub fn ready_as_usize(events: Ready) -> usize {
     events.0
 }
 
-pub fn from_usize(events: usize) -> Ready {
+pub fn opt_as_usize(opt: PollOpt) -> usize {
+    opt.0
+}
+
+pub fn ready_from_usize(events: usize) -> Ready {
     Ready(events)
 }
 
-/// Returns true if the `Ready` does not have any public OR private flags
-/// set.
-pub fn is_empty(events: Ready) -> bool {
-    events.0 == 0
-}
-
-pub fn is_drop(events: Ready) -> bool {
-    events.contains(Ready::drop())
-}
-
-pub fn drop() -> Ready {
-    Ready::drop()
+pub fn opt_from_usize(opt: usize) -> PollOpt {
+    PollOpt(opt)
 }
 
 // Used internally to mutate an `Event` in place

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,14 +1,62 @@
 use {sys, Evented, Token};
 use event::{self, Ready, Event, PollOpt};
-use std::{fmt, io, mem, ptr, usize};
-use std::cell::{UnsafeCell, Cell};
-use std::isize;
-use std::marker;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, AtomicPtr, Ordering};
-use std::time::Duration;
+use std::{fmt, io, ptr, usize};
+use std::cell::UnsafeCell;
+use std::{ops, isize};
+use std::sync::{Arc, Mutex, Condvar};
+use std::sync::atomic::{self, AtomicUsize, AtomicPtr, AtomicBool};
+use std::sync::atomic::Ordering::{self, Acquire, Release, AcqRel, Relaxed, SeqCst};
+use std::time::{Duration, Instant};
 
-const MAX_REFCOUNT: usize = (isize::MAX) as usize;
+// Poll is backed by two readiness queues. The first is a system readiness queue
+// represented by `sys::Selector`. The system readiness queue handles
+// notifications provided by the system, such as TCP and UDP. The second
+// readiness queue is implemented in user space by `ReadinessQueue`. It provides
+// a way to implement purely userspace `Evented` types.
+//
+// `ReadinessQueue` is is backed by a MPSC queue that supports reuse of linked
+// list nodes. This significantly reduces the number of required allocations.
+// Each `Registration` / `SetReadiness` pair allocates a single readiness node
+// that is used for the lifetime of the registration.
+//
+// The readiness node also includes a single atomic variable, `state` that
+// tracks most of the state associated with the registration. This includes the
+// current readiness, interest, poll options, and internal state. When the node
+// state is mutated, it is queued in the MPSC channel. A call to
+// `ReadinessQueue::poll` will dequeue and process nodes. The node state can
+// still be mutated while it is queued in the channel for processing.
+// Intermediate state values do not matter as long as the final state is
+// included in the call to `poll`. This is the eventually consistent nature of
+// the readiness queue.
+//
+// The readiness node is ref counted using the `ref_count` field. On creation,
+// the ref_count is initialized to 3: one `Registration` handle, one
+// `SetReadiness` handle, and for the readiness queue. Since the readiness queue
+// doesn't *always* hold a handle to the node, we don't use the Arc type for
+// managing ref counts (this is to avoid constantly incrementing and
+// decrementing the ref count when pushing & popping from the queue). When the
+// `Registration` handle is dropped, the `dropped` flag is set on the node, then
+// the node is pushed into the registration queue. When Poll::poll pops the
+// node, it sees the drop flag is set, and decrements it's ref count.
+//
+// The MPSC queue is a modified version of the intrusive MPSC node based queue
+// described by 1024cores [1].
+//
+// The first modification is that two markers are used instead of a single
+// `stub`. The second marker is a `sleep_marker` which is used to signal to
+// producers that the consumer is going to sleep. This sleep_marker is only used
+// when the queue is empty, implying that the only node in the queue is
+// `end_marker`.
+//
+// The second modification is an `until` argument passed to the dequeue
+// function. When `poll` encounters a level-triggered node, the node will be
+// immediately pushed back into the queue. In order to avoid an infinite loop,
+// `poll` before pushing the node, the pointer is saved off and then passed
+// again as the `until` argument. If the next node to pop is `until`, then
+// `Dequeue::Empty` is returned.
+//
+// [1] http://www.1024cores.net/home/lock-free-algorithms/queues/intrusive-mpsc-node-based-queue
+
 
 /// Polls for readiness events on all registered values.
 ///
@@ -52,14 +100,21 @@ const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 /// poll.poll(&mut events, None).unwrap();
 /// ```
 pub struct Poll {
-    // This type is `Send`, but not `Sync`, so ensure it's exposed as such.
-    _marker: marker::PhantomData<Cell<()>>,
-
     // Platform specific IO selector
     selector: sys::Selector,
 
     // Custom readiness queue
     readiness_queue: ReadinessQueue,
+
+    // Use an atomic to first check if a full lock will be required. This is a
+    // fast-path check for single threaded cases avoiding the extra syscall
+    lock_state: AtomicUsize,
+
+    // Sequences concurrent calls to `Poll::poll`
+    lock: Mutex<()>,
+
+    // Wakeup the next waiter
+    condvar: Condvar,
 }
 
 /// Handle to a Poll registration. Used for registering custom types for event
@@ -68,6 +123,9 @@ pub struct Registration {
     inner: RegistrationInner,
 }
 
+unsafe impl Send for Registration {}
+unsafe impl Sync for Registration {}
+
 /// Used to update readiness for an associated `Registration`. `SetReadiness`
 /// is `Sync` which allows it to be updated across threads.
 #[derive(Clone)]
@@ -75,88 +133,142 @@ pub struct SetReadiness {
     inner: RegistrationInner,
 }
 
+unsafe impl Send for SetReadiness {}
+unsafe impl Sync for SetReadiness {}
+
 struct RegistrationInner {
     // ARC pointer to the Poll's readiness queue
     queue: ReadinessQueue,
 
-    // Unsafe pointer to the registration's node. The node is owned by the
-    // registration queue.
-    node: ReadyRef,
+    // Unsafe pointer to the registration's node. The node is ref counted. This
+    // cannot "simply" be tracked by an Arc because `Poll::poll` has an implicit
+    // handle though it isn't stored anywhere. In other words, `Poll::poll`
+    // needs to decrement the ref count before the node is freed.
+    node: *mut ReadinessNode,
 }
 
 #[derive(Clone)]
 struct ReadinessQueue {
-    inner: Arc<UnsafeCell<ReadinessQueueInner>>,
+    inner: Arc<ReadinessQueueInner>,
 }
+
+unsafe impl Send for ReadinessQueue {}
+unsafe impl Sync for ReadinessQueue {}
 
 struct ReadinessQueueInner {
     // Used to wake up `Poll` when readiness is set in another thread.
     awakener: sys::Awakener,
 
-    // All readiness nodes are owned by the `Poll` instance and live either in
-    // this linked list or in a `readiness_wheel` linked list.
-    head_all_nodes: Option<Box<ReadinessNode>>,
-
-    // linked list of nodes that are pending some processing
+    // Head of the MPSC queue used to signal readiness to `Poll::poll`.
     head_readiness: AtomicPtr<ReadinessNode>,
 
-    // A fake readiness node used to indicate that `Poll::poll` will block.
-    sleep_token: Box<ReadinessNode>,
+    // Tail of the readiness queue.
+    //
+    // Only accessed by Poll::poll. Coordination will be handled by the poll fn
+    tail_readiness: UnsafeCell<*mut ReadinessNode>,
+
+    // Fake readiness node used to punctuate the end of the readiness queue.
+    // Before attempting to read from the queue, this node is inserted in order
+    // to partition the queue between nodes that are "owned" by the dequeue end
+    // and nodes that will be pushed on by producers.
+    end_marker: Box<ReadinessNode>,
+
+    // Similar to `end_marker`, but this node signals to producers that `Poll`
+    // has gone to sleep and must be woken up.
+    sleep_marker: Box<ReadinessNode>,
 }
 
-struct ReadyList {
-    head: ReadyRef,
-}
-
-struct ReadyRef {
-    ptr: *mut ReadinessNode,
-}
-
+/// Node shared by a `Registration` / `SetReadiness` pair as well as the node
+/// queued into the MPSC channel.
 struct ReadinessNode {
-    // ===== Fields only accessed by Poll =====
+    // Node state, see struct docs for `ReadinessState`
     //
-    // Next node in ownership tracking queue
-    next_all_nodes: Option<Box<ReadinessNode>>,
+    // This variable is the primary point of coordination between all the
+    // various threads concurrently accessing the node.
+    state: AtomicState,
 
-    // Previous node in the owned list
-    prev_all_nodes: ReadyRef,
-
-    // Data set in register / reregister functions and read in `Poll`. This
-    // field should only be accessed from the thread that owns the `Poll`
-    // instance.
-    registration_data: UnsafeCell<RegistrationData>,
-
-    // ===== Fields accessed by any thread ====
+    // The registration token cannot fit into the `state` variable, so it is
+    // broken out here. In order to atomically update both the state and token
+    // we have to jump through a few hoops.
     //
+    // First, `state` includes `token_read_pos` and `token_write_pos`. These can
+    // either be 0, 1, or 2 which represent a token slot. `token_write_pos` is
+    // the token slot that contains the most up to date registration token.
+    // `token_read_pos` is the token slot that `poll` is currently reading from.
+    //
+    // When a call to `update` includes a different token than the one currently
+    // associated with the registration (token_write_pos), first an unused token
+    // slot is found. The unused slot is the one not represented by
+    // `token_read_pos` OR `token_write_pos`. The new token is written to this
+    // slot, then `state` is updated with the new `token_write_pos` value. This
+    // requires that there is only a *single* concurrent call to `update`.
+    //
+    // When `poll` reads a node state, it checks that `token_read_pos` matches
+    // `token_write_pos`. If they do not match, then it atomically updates
+    // `state` such that `token_read_pos` is set to `token_write_pos`. It will
+    // then read the token at the newly updated `token_read_pos`.
+    token_0: UnsafeCell<Token>,
+    token_1: UnsafeCell<Token>,
+    token_2: UnsafeCell<Token>,
+
     // Used when the node is queued in the readiness linked list. Accessing
     // this field requires winning the "queue" lock
-    next_readiness: ReadyRef,
+    next_readiness: AtomicPtr<ReadinessNode>,
 
-    // The set of events to include in the notification on next poll
-    events: AtomicUsize,
-
-    // Tracks if the node is queued for readiness using the MSB, the
-    // rest of the usize is the readiness delay.
-    queued: AtomicUsize,
+    // Ensures that there is only one concurrent call to `update`.
+    //
+    // Each call to `update` will attempt to swap `update_lock` from `false` to
+    // `true`. If the CAS succeeds, the thread has obtained the update lock. If
+    // the CAS fails, then the `update` call returns immediately and the update
+    // is discarded.
+    update_lock: AtomicBool,
 
     // Tracks the number of `ReadyRef` pointers
     ref_count: AtomicUsize,
 }
 
-struct RegistrationData {
-    // The Token used to register the `Evented` with`Poll`
-    token: Token,
-
-    // The registration interest
-    interest: Ready,
-
-    // Poll opts
-    opts: PollOpt,
+/// Stores the ReadinessNode state in an AtomicUsize. This wrapper around the
+/// atomic variable handles encoding / decoding `ReadinessState` values.
+struct AtomicState {
+    inner: AtomicUsize,
 }
 
-const NODE_QUEUED_FLAG: usize = 1;
+const MASK_2: usize = 4 - 1;
+const MASK_4: usize = 16 - 1;
+const QUEUED_MASK: usize = 1 << QUEUED_SHIFT;
+const DROPPED_MASK: usize = 1 << DROPPED_SHIFT;
+
+const READINESS_SHIFT: usize = 0;
+const INTEREST_SHIFT: usize = 4;
+const POLL_OPT_SHIFT: usize = 8;
+const TOKEN_RD_SHIFT: usize = 12;
+const TOKEN_WR_SHIFT: usize = 14;
+const QUEUED_SHIFT: usize = 16;
+const DROPPED_SHIFT: usize = 17;
+
+/// Tracks all state for a single `ReadinessNode`. The state is packed into a
+/// `usize` variable from low to high bit as follows:
+///
+/// 4 bits: Registration current readiness
+/// 4 bits: Registration interest
+/// 4 bits: Poll options
+/// 2 bits: Token position currently being read from by `poll`
+/// 2 bits: Token position last written to by `update`
+/// 1 bit:  Queued flag, set when node is being pushed into MPSC queue.
+/// 1 bit:  Dropped flag, set when all `Registration` handles have been dropped.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+struct ReadinessState(usize);
+
+/// Returned by `dequeue_node`. Represents the different states as described by
+/// the queue documentation on 1024cores.net.
+enum Dequeue {
+    Data(*mut ReadinessNode),
+    Empty,
+    Inconsistent,
+}
 
 const AWAKEN: Token = Token(usize::MAX);
+const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 
 /*
  *
@@ -167,14 +279,19 @@ const AWAKEN: Token = Token(usize::MAX);
 impl Poll {
     /// Return a new `Poll` handle using a default configuration.
     pub fn new() -> io::Result<Poll> {
+        is_send::<Poll>();
+        is_sync::<Poll>();
+
         let poll = Poll {
             selector: try!(sys::Selector::new()),
             readiness_queue: try!(ReadinessQueue::new()),
-            _marker: marker::PhantomData,
+            lock_state: AtomicUsize::new(0),
+            lock: Mutex::new(()),
+            condvar: Condvar::new(),
         };
 
         // Register the notification wakeup FD with the IO poller
-        try!(poll.readiness_queue.inner().awakener.register(&poll, AWAKEN, Ready::readable(), PollOpt::edge()));
+        try!(poll.readiness_queue.inner.awakener.register(&poll, AWAKEN, Ready::readable(), PollOpt::edge()));
 
         Ok(poll)
     }
@@ -226,25 +343,180 @@ impl Poll {
 
     /// Block the current thread and wait until any `Evented` values registered
     /// with the `Poll` instance are ready or the given timeout has elapsed.
-    pub fn poll(&self,
-                events: &mut Events,
-                timeout: Option<Duration>) -> io::Result<usize> {
-        let timeout = if !self.readiness_queue.is_empty() {
-            trace!("custom readiness queue has pending events");
-            // Never block if the readiness queue has pending events
-            Some(Duration::from_millis(0))
-        } else if !self.readiness_queue.prepare_for_sleep() {
-            Some(Duration::from_millis(0))
-        } else {
+    pub fn poll(&self, events: &mut Events, mut timeout: Option<Duration>) -> io::Result<usize> {
+        let zero = Some(Duration::from_millis(0));
+
+        // At a high level, the synchronization strategy is to acquire access to
+        // the critical section by transitioning the atomic from unlocked ->
+        // locked. If the attempt fails, the thread will wait on the condition
+        // variable.
+        //
+        // # Some more detail
+        //
+        // The `lock_state` atomic usize combines:
+        //
+        // - locked flag, stored in the least significant bit
+        // - number of waiting threads, stored in the rest of the bits.
+        //
+        // When a thread transitions the locked flag from 0 -> 1, it has
+        // obtained access to the critical section.
+        //
+        // When entering `poll`, a compare-and-swap from 0 -> 1 is attempted.
+        // This is a fast path for the case when there are no concurrent calls
+        // to poll, which is very common.
+        //
+        // On failure, the mutex is locked, and the thread attempts to increment
+        // the number of waiting threads component of `lock_state`. If this is
+        // successfully done while the locked flag is set, then the thread can
+        // wait on the condition variable.
+        //
+        // When a thread exits the critical section, it unsets the locked flag.
+        // If there are any waiters, which is atomically determined while
+        // unsetting the locked flag, then the condvar is notified.
+
+        let mut curr = self.lock_state.compare_and_swap(0, 1, SeqCst);
+
+        if 0 != curr {
+            // Enter slower path
+            let mut lock = self.lock.lock().unwrap();
+            let mut inc = false;
+
+            loop {
+                if curr & 1 == 0 {
+                    // The lock is currently free, attempt to grab it
+                    let mut next = curr | 1;
+
+                    if inc {
+                        // The waiter count has previously been incremented, so
+                        // decrement it here
+                        next -= 2;
+                    }
+
+                    let actual = self.lock_state.compare_and_swap(curr, next, SeqCst);
+
+                    if actual != curr {
+                        curr = actual;
+                        continue;
+                    }
+
+                    // Lock acquired, break from the loop
+                    break;
+                }
+
+                if timeout == zero {
+                    if inc {
+                        self.lock_state.fetch_sub(2, SeqCst);
+                    }
+
+                    return Ok(0);
+                }
+
+                // The lock is currently held, so wait for it to become
+                // free. If the waiter count hasn't been incremented yet, do
+                // so now
+                if !inc {
+                    let next = curr.checked_add(2).expect("overflow");
+                    let actual = self.lock_state.compare_and_swap(curr, next, SeqCst);
+
+                    if actual != curr {
+                        curr = actual;
+                        continue;
+                    }
+
+                    // Track that the waiter count has been incremented for
+                    // this thread and fall through to the condvar waiting
+                    inc = true;
+                }
+
+                lock = match timeout {
+                    Some(to) => {
+                        let now = Instant::now();
+
+                        // Wait to be notified
+                        let (l, _) = self.condvar.wait_timeout(lock, to).unwrap();
+
+                        // See how much time was elapsed in the wait
+                        let elapsed = now.elapsed();
+
+                        // Update `timeout` to reflect how much time is left to
+                        // wait.
+                        if elapsed >= to {
+                            timeout = zero;
+                        } else {
+                            // Update the timeout
+                            timeout = Some(to - elapsed);
+                        }
+
+                        l
+                    }
+                    None => {
+                        self.condvar.wait(lock).unwrap()
+                    }
+                };
+
+                // Reload the state
+                curr = self.lock_state.load(SeqCst);
+
+                // Try to lock again...
+            }
+        }
+
+        let ret = self.poll2(events, timeout);
+
+        // Release the lock
+        if 1 != self.lock_state.fetch_and(!1, Release) {
+            // Acquire the mutex
+            let _lock = self.lock.lock().unwrap();
+
+            // There is at least one waiting thread, so notify one
+            self.condvar.notify_one();
+        }
+
+        ret
+    }
+
+    #[inline]
+    fn poll2(&self, events: &mut Events, timeout: Option<Duration>) -> io::Result<usize> {
+        let mut sleep = false;
+
+        // Compute the timeout value passed to the system selector. If the
+        // readiness queue has pending nodes, we still want to poll the system
+        // selector for new events, but we don't want to block the thread to
+        // wait for new events.
+        let timeout = if timeout == Some(Duration::from_millis(0)) {
+            // If blocking is not requested, then there is no need to prepare
+            // the queue for sleep
             timeout
+        } else if self.readiness_queue.prepare_for_sleep() {
+            // The readiness queue is empty. The call to `prepare_for_sleep`
+            // inserts `sleep_marker` into the queue. This signals to any
+            // threads setting readiness that the `Poll::poll` is going to
+            // sleep, so the awakener should be used.
+            sleep = true;
+            timeout
+        } else {
+            // The readiness queue is not empty, so do not block the thread.
+            Some(Duration::from_millis(0))
         };
 
         // First get selector events
-        let awoken = try!(self.selector.select(&mut events.inner, AWAKEN,
-                                               timeout));
+        let res = self.selector.select(&mut events.inner, AWAKEN, timeout);
 
-        if awoken {
-            self.readiness_queue.inner().awakener.cleanup();
+        if sleep {
+            // Cleanup the sleep marker. Removing `sleep_marker` avoids
+            // unnecessary syscalls to the awakener. It also needs to be removed
+            // from the queue before it can be inserted again.
+            //
+            // Note, that this won't *guarantee* that the sleep marker is
+            // removed. If the sleep marker cannot be removed, it is no longer
+            // at the head of the queue, which still achieves the goal of
+            // avoiding extra awakener syscalls.
+            self.readiness_queue.try_remove_sleep_marker();
+        }
+
+        if try!(res) {
+            // Some awakeners require reading from a FD.
+            self.readiness_queue.inner.awakener.cleanup();
         }
 
         // Poll custom event queue
@@ -360,20 +632,59 @@ pub fn selector(poll: &Poll) -> &sys::Selector {
 
 impl Registration {
     /// Create a new `Registration` associated with the given `Poll` instance.
+    ///
     /// The returned `Registration` will be associated with this `Poll` for its
-    /// entire lifetime.
-    pub fn new(poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> (Registration, SetReadiness) {
-        let inner = RegistrationInner::new(poll, token, interest, opts);
-        let registration = Registration { inner: inner.clone() };
-        let set_readiness = SetReadiness { inner: inner.clone() };
+    /// entire lifetime. Dropping the `Registration` will prevent any further
+    /// notifications to be polled.
+    pub fn new(poll: &Poll, token: Token, interest: Ready, opt: PollOpt) -> (Registration, SetReadiness) {
+        is_send::<Registration>();
+        is_sync::<Registration>();
+        is_send::<SetReadiness>();
+        is_sync::<SetReadiness>();
+
+        // Clone handle to the readiness queue, this bumps the ref count
+        let queue = poll.readiness_queue.clone();
+
+        // Allocate the registration node. The new node will have `ref_count`
+        // set to 3: one SetReadiness, one Registration, and one Poll handle.
+        let node = Box::into_raw(Box::new(ReadinessNode::new(token, interest, opt)));
+
+        let registration = Registration {
+            inner: RegistrationInner {
+                node: node,
+                queue: queue.clone(),
+            },
+        };
+
+        let set_readiness = SetReadiness {
+            inner: RegistrationInner {
+                node: node,
+                queue: queue.clone(),
+            },
+        };
 
         (registration, set_readiness)
     }
 
+    /// Update the registration details
+    ///
+    /// # Note
+    ///
+    /// `update` does not guarantee to establish any memory ordering. Any
+    /// concurrent data access must be synchronized using another strategy.
     pub fn update(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
         self.inner.update(poll, token, interest, opts)
     }
 
+    /// Disable the registration.
+    ///
+    /// No further notifcations for this registration will be polled until the
+    /// registration details are updated with `update`.
+    ///
+    /// # Note
+    ///
+    /// `deregister` does not guarantee to establish any memory ordering. Any
+    /// concurrent data access must be synchronized using another strategy.
     pub fn deregister(&self, poll: &Poll) -> io::Result<()> {
         self.inner.update(poll, Token(0), Ready::none(), PollOpt::empty())
     }
@@ -381,8 +692,13 @@ impl Registration {
 
 impl Drop for Registration {
     fn drop(&mut self) {
-        let inner = &self.inner;
-        inner.registration_data_mut(&inner.queue).unwrap().disable();
+        // `flag_as_dropped` toggles the `dropped` flag and notifies
+        // `Poll::poll` to release its handle (which is just decrementing
+        // the ref count).
+        if self.inner.state.flag_as_dropped() {
+            // Can't do anything if the queuing fails
+            let _ = self.inner.queue.enqueue_node_with_wakeup(&self.inner);
+        }
     }
 }
 
@@ -393,115 +709,194 @@ impl fmt::Debug for Registration {
     }
 }
 
-unsafe impl Send for Registration { }
-
 impl SetReadiness {
+    /// Returns the registration's current readiness.
+    ///
+    /// # Note
+    ///
+    /// `readiness` does not guarantee to establish any memory ordering. Any
+    /// concurrent data access must be synchronized using another strategy.
     pub fn readiness(&self) -> Ready {
         self.inner.readiness()
     }
 
+    /// Update the registration's readiness
+    ///
+    /// # Note
+    ///
+    /// `set_readiness` does not guarantee to establish any memory ordering. Any
+    /// concurrent data access must be synchronized using another strategy.
     pub fn set_readiness(&self, ready: Ready) -> io::Result<()> {
         self.inner.set_readiness(ready)
     }
 }
 
-unsafe impl Send for SetReadiness { }
-unsafe impl Sync for SetReadiness { }
-
 impl RegistrationInner {
-    fn new(poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> RegistrationInner {
-        let queue = poll.readiness_queue.clone();
-        let node = queue.new_readiness_node(token, interest, opts, 1);
-
-        RegistrationInner {
-            node: node,
-            queue: queue,
-        }
-    }
-
-    fn update(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        // Update the registration data
-        try!(self.registration_data_mut(&poll.readiness_queue)).update(token, interest, opts);
-
-        // If the node is currently ready, re-queue?
-        if !event::is_empty(self.readiness()) {
-            // The releaxed ordering of `self.readiness()` is sufficient here.
-            // All mutations to readiness will immediately attempt to queue the
-            // node for processing. This means that this call to
-            // `queue_for_processing` is only intended to handle cases where
-            // the node was dequeued in `poll` and then has the interest
-            // changed, which means that the "newest" readiness value is
-            // already known by the current thread.
-            let needs_wakeup = self.queue_for_processing();
-            debug_assert!(!needs_wakeup, "something funky is going on");
-        }
-
-        Ok(())
-    }
-
+    /// Get the registration's readiness.
     fn readiness(&self) -> Ready {
-        // A relaxed ordering is sufficient here as a call to `readiness` is
-        // only meant as a hint to what the current value is. It should not be
-        // used for any synchronization.
-        event::from_usize(self.node().events.load(Ordering::Relaxed))
+        self.state.load(Relaxed).readiness()
     }
 
+    /// Set the registration's readiness.
+    ///
+    /// This function can be called concurrently by an arbitrary number of
+    /// SetReadiness handles.
     fn set_readiness(&self, ready: Ready) -> io::Result<()> {
-        // First store in the new readiness using relaxed as this operation is
-        // permitted to be visible ad-hoc. The `queue_for_processing` function
-        // will set a `Release` barrier ensuring eventual consistency.
-        self.node().events.store(event::as_usize(ready), Ordering::Relaxed);
+        // Load the current atomic state.
+        let mut state = self.state.load(Acquire);
+        let mut next;
 
-        trace!("set_readiness event {:?} {:?}", ready, self.node().token());
+        loop {
+            next = state;
 
-        // Setting readiness to none doesn't require any processing by the poll
-        // instance, so there is no need to enqueue the node. No barrier is
-        // needed in this case since it doesn't really matter when the value
-        // becomes visible to other threads.
-        if event::is_empty(ready) {
-            return Ok(());
+            if state.is_dropped() {
+                // Node is dropped, no more notifications
+                return Ok(());
+            }
+
+            // Update the readiness
+            next.set_readiness(ready);
+
+            // If the readiness is not blank, try to obtain permission to
+            // push the node into the readiness queue.
+            if next.effective_readiness().is_some() {
+                next.set_queued();
+            }
+
+            let actual = self.state.compare_and_swap(state, next, AcqRel);
+
+            if state == actual {
+                break;
+            }
+
+            state = actual;
         }
 
-        if self.queue_for_processing() {
-            try!(self.queue.wakeup());
+        if !state.is_queued() && next.is_queued() {
+            // We toggled the queued flag, making us responsible for queuing the
+            // node in the MPSC readiness queue.
+            try!(self.queue.enqueue_node_with_wakeup(self));
         }
 
         Ok(())
     }
 
-    /// Returns true if `Poll` needs to be woken up
-    fn queue_for_processing(&self) -> bool {
-        // `Release` ensures that the `events` mutation is visible if this
-        // mutation is visible.
-        //
-        // `Acquire` ensures that a change to `head_readiness` made in the
-        // poll thread is visible if `queued` has been reset to zero.
-        let prev = self.node().queued.compare_and_swap(0, NODE_QUEUED_FLAG, Ordering::AcqRel);
-
-        // If the queued flag was not initially set, then the current thread
-        // is assigned the responsibility of enqueuing the node for processing.
-        if prev == 0 {
-            self.queue.prepend_readiness_node(self.node.clone())
-        } else {
-            false
-        }
-    }
-
-    fn node(&self) -> &ReadinessNode {
-        self.node.as_ref().unwrap()
-    }
-
-    fn registration_data_mut(&self, readiness_queue: &ReadinessQueue) -> io::Result<&mut RegistrationData> {
-        // `&Poll` is passed in here in order to ensure that this function is
-        // only called from the thread that owns the `Poll` value. This is
-        // required because the function will mutate variables that are read
-        // from a call to `Poll::poll`.
-
-        if !self.queue.identical(readiness_queue) {
+    /// Update the registration details associated with the node
+    fn update(&self, poll: &Poll, token: Token, interest: Ready, opt: PollOpt) -> io::Result<()> {
+        // Ensure poll instances match
+        if !self.queue.identical(&poll.readiness_queue) {
             return Err(io::Error::new(io::ErrorKind::Other, "registration registered with another instance of Poll"));
         }
 
-        Ok(self.node().registration_data_mut())
+        // The `update_lock` atomic is used as a flag ensuring only a single
+        // thread concurrently enters the `update` critical section. Any
+        // concurrent calls to update are discarded. If coordinated updates are
+        // required, the Mio user is responsible for handling that.
+        //
+        // Acquire / Release ordering is used on `update_lock` to ensure that
+        // data access to the `token_*` variables are scoped to the critical
+        // section.
+
+        // Acquire the update lock.
+        if self.update_lock.compare_and_swap(false, true, Acquire) {
+            // The lock is already held. Discard the update
+            return Ok(());
+        }
+
+        // Relaxed ordering is acceptable here as the only memory that needs to
+        // be visible as part of the update are the `token_*` variables, and
+        // ordering has already been handled by the `update_lock` access.
+        let mut state = self.state.load(Relaxed);
+        let mut next;
+
+        // Read the current token, again this memory has been ordered by the
+        // acquire on `update_lock`.
+        let curr_token_pos = state.token_write_pos();
+        let curr_token = unsafe { self::token(self, curr_token_pos) };
+
+        let mut next_token_pos = curr_token_pos;
+
+        // If the `update` call is changing the token, then compute the next
+        // available token slot and write the token there.
+        //
+        // Note that this computation is happening *outside* of the
+        // compare-and-swap loop. The update lock ensures that only a single
+        // thread could be mutating the write_token_position, so the
+        // `next_token_pos` will never need to be recomputed even if
+        // `token_read_pos` concurrently changes. This is because
+        // `token_read_pos` can ONLY concurrently change to the current value of
+        // `token_write_pos`, so `next_token_pos` will always remain valid.
+        if token != curr_token {
+            next_token_pos = state.next_token_pos();
+
+            // Update the token
+            match next_token_pos {
+                0 => unsafe { *self.token_0.get() = token },
+                1 => unsafe { *self.token_1.get() = token },
+                2 => unsafe { *self.token_2.get() = token },
+                _ => unreachable!(),
+            }
+        }
+
+        // Now enter the compare-and-swap loop
+        loop {
+            next = state;
+
+            // The node is only dropped once all `Registration` handles are
+            // dropped. Only `Registration` can call `update`.
+            debug_assert!(!state.is_dropped());
+
+            // Update the write token position, this will also release the token
+            // to Poll::poll.
+            next.set_token_write_pos(next_token_pos);
+
+            // Update readiness and poll opts
+            next.set_interest(interest);
+            next.set_poll_opt(opt);
+
+            // If there is effective readiness, the node will need to be queued
+            // for processing. This exact behavior is still TBD, so we are
+            // conservative for now and always fire.
+            //
+            // See https://github.com/carllerche/mio/issues/535.
+            if next.effective_readiness().is_some() {
+                next.set_queued();
+            }
+
+            // compare-and-swap the state values. Only `Release` is needed here.
+            // The `Release` ensures that `Poll::poll` will see the token
+            // update and the update function doesn't care about any other
+            // memory visibility.
+            let actual = self.state.compare_and_swap(state, next, Release);
+
+            if actual == state {
+                break;
+            }
+
+            // CAS failed, but `curr_token_pos` should not have changed given
+            // that we still hold the update lock.
+            debug_assert_eq!(curr_token_pos, actual.token_write_pos());
+
+            state = actual;
+        }
+
+        // Release the lock
+        self.update_lock.store(false, Release);
+
+        if !state.is_queued() && next.is_queued() {
+            // We are responsible for enqueing the node.
+            try!(self.queue.enqueue_node_with_wakeup(self));
+        }
+
+        Ok(())
+    }
+}
+
+impl ops::Deref for RegistrationInner {
+    type Target = ReadinessNode;
+
+    fn deref(&self) -> &ReadinessNode {
+        unsafe { &*self.node }
     }
 }
 
@@ -518,7 +913,7 @@ impl Clone for RegistrationInner {
         // another must already provide any required synchronization.
         //
         // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
-        let old_size = self.node().ref_count.fetch_add(1, Ordering::Relaxed);
+        let old_size = self.ref_count.fetch_add(1, Relaxed);
 
         // However we need to guard against massive refcounts in case someone
         // is `mem::forget`ing Arcs. If we don't do this the count can overflow
@@ -530,7 +925,8 @@ impl Clone for RegistrationInner {
         // We abort because such a program is incredibly degenerate, and we
         // don't care to support it.
         if old_size & !MAX_REFCOUNT != 0 {
-            panic!("too many outstanding refs");
+            // TODO: This should really abort the process
+            panic!();
         }
 
         RegistrationInner {
@@ -542,18 +938,9 @@ impl Clone for RegistrationInner {
 
 impl Drop for RegistrationInner {
     fn drop(&mut self) {
-        // Because `fetch_sub` is already atomic, we do not need to synchronize
-        // with other threads unless we are going to delete the object. This
-        // same logic applies to the below `fetch_sub` to the `weak` count.
-        let old_size = self.node().ref_count.fetch_sub(1, Ordering::Release);
-
-        if old_size != 1 {
-            return;
-        }
-
-        // Signal to the queue that the node is not referenced anymore and can
-        // be released / reused
-        let _ = self.set_readiness(event::drop());
+        // Only handles releasing from `Registration` and `SetReadiness`
+        // handles. Poll has to call this itself.
+        release_node(self.node);
     }
 }
 
@@ -564,398 +951,566 @@ impl Drop for RegistrationInner {
  */
 
 impl ReadinessQueue {
+    /// Create a new `ReadinessQueue`.
     fn new() -> io::Result<ReadinessQueue> {
-        let sleep_token = Box::new(ReadinessNode::new(Token(0), Ready::none(), PollOpt::empty(), 0));
+        is_send::<Self>();
+        is_sync::<Self>();
+
+        let end_marker = Box::new(ReadinessNode::marker());
+        let sleep_marker = Box::new(ReadinessNode::marker());
+
+        let ptr = &*end_marker as *const _ as *mut _;
 
         Ok(ReadinessQueue {
-            inner: Arc::new(UnsafeCell::new(ReadinessQueueInner {
+            inner: Arc::new(ReadinessQueueInner {
                 awakener: try!(sys::Awakener::new()),
-                head_all_nodes: None,
-                head_readiness: AtomicPtr::new(ptr::null_mut()),
-                // Arguments here don't matter, the node is only used for the
-                // pointer value.
-                sleep_token: sleep_token,
-            }))
+                head_readiness: AtomicPtr::new(ptr),
+                tail_readiness: UnsafeCell::new(ptr),
+                end_marker: end_marker,
+                sleep_marker: sleep_marker,
+            })
         })
     }
 
+    /// Poll the queue for new events
     fn poll(&self, dst: &mut sys::Events) {
-        let ready = self.take_ready();
+        // `until` is set with the first node that gets re-enqueued due to being
+        // set to have level-triggered notifications. This prevents an infinite
+        // loop where `Poll::poll` will keep dequeuing nodes it enqueues.
+        let mut until = ptr::null_mut();
 
-        // TODO: Cap number of nodes processed
-        for node in ready {
-            let mut events;
-            let opts;
+        'outer:
+        while dst.len() < dst.capacity() {
+            // Dequeue a node. If the queue is in an inconsistent state, then
+            // stop polling. `Poll::poll` will be called again shortly and enter
+            // a syscall, which should be enough to enable the other thread to
+            // finish the queuing process.
+            let ptr = match unsafe { self.inner.dequeue_node(until) } {
+                Dequeue::Empty | Dequeue::Inconsistent => break,
+                Dequeue::Data(ptr) => ptr,
+            };
 
-            {
-                let node_ref = node.as_ref().unwrap();
-                opts = node_ref.poll_opts();
+            let node = unsafe { &*ptr };
 
-                // Atomically read queued. Use Acquire ordering to set a
-                // barrier before reading events, which will be read using
-                // `Relaxed` ordering. Reading events w/ `Relaxed` is OK thanks to
-                // the acquire / release hand off on `queued`.
-                let mut queued = node_ref.queued.load(Ordering::Acquire);
-                events = node_ref.poll_events();
+            // Read the node state with Acquire ordering. This allows reading
+            // the token variables.
+            let mut state = node.state.load(Acquire);
+            let mut next;
+            let mut readiness;
+            let mut opt;
 
-                // Enter a loop attempting to unset the "queued" bit or requeuing
-                // the node.
-                loop {
-                    // In the following conditions, the registration is removed from
-                    // the readiness queue:
-                    //
-                    // - The registration is edge triggered.
-                    // - The event set contains no events
-                    // - There is a requested delay that has not already expired.
-                    //
-                    // If the drop flag is set though, the node is never queued
-                    // again.
-                    if event::is_drop(events) {
-                        // dropped nodes are always processed immediately. There is
-                        // also no need to unset the queued bit as the node should
-                        // not change anymore.
-                        break;
-                    } else if opts.is_edge() || event::is_empty(events) {
-                        // An acquire barrier is set in order to re-read the
-                        // `events field. `Release` is not needed as we have not
-                        // mutated any field that we need to expose to the producer
-                        // thread.
-                        let next = node_ref.queued.compare_and_swap(queued, 0, Ordering::Acquire);
+            loop {
+                // Build up any changes to the readiness node's state and
+                // attempt the CAS at the end
+                next = state;
 
-                        // Re-read in order to ensure we have the latest value
-                        // after having marked the registration has dequeued from
-                        // the readiness queue. Again, `Relaxed` is OK since we set
-                        // the barrier above.
-                        events = node_ref.poll_events();
+                // Given that the node was just read from the queue, the
+                // `queued` flag should still be set.
+                debug_assert!(state.is_queued());
 
-                        if queued == next {
-                            break;
-                        }
-
-                        queued = next;
-                    } else {
-                        // The node needs to stay queued for readiness, so it gets
-                        // pushed back onto the queue.
-                        //
-                        // TODO: It would be better to build up a batch list that
-                        // requires a single CAS. Also, `Relaxed` ordering would be
-                        // OK here as the prepend only needs to be visible by the
-                        // current thread.
-                        let needs_wakeup = self.prepend_readiness_node(node.clone());
-                        debug_assert!(!needs_wakeup, "something funky is going on");
-                        break;
-                    }
+                // The dropped flag means we need to release the node and
+                // perform no further processing on it.
+                if state.is_dropped() {
+                    // Release the node and continue
+                    release_node(ptr);
+                    continue 'outer;
                 }
+
+                // Process the node
+                readiness = state.effective_readiness();
+                opt = state.poll_opt();
+
+                if opt.is_edge() {
+                    // Mark the node as dequeued
+                    next.set_dequeued();
+
+                    if opt.is_oneshot() && readiness.is_some() {
+                        next.disarm();
+                    }
+                } else if readiness.is_none() {
+                    next.set_dequeued();
+                }
+
+                // Ensure `token_read_pos` is set to `token_write_pos` so that
+                // we read the most up to date token value.
+                next.update_token_read_pos();
+
+                if state == next {
+                    break;
+                }
+
+                let actual = node.state.compare_and_swap(state, next, AcqRel);
+
+                if actual == state {
+                    break;
+                }
+
+                state = actual;
             }
 
-            // Process the node.
-            if event::is_drop(events) {
-                // Release the node
-                let _ = self.unlink_node(node);
-            } else if !events.is_none() {
-                let node_ref = node.as_ref().unwrap();
-
-                // TODO: Don't push the event if the capacity of `dst` has
-                // been reached
-                trace!("returning readiness event {:?} {:?}", events,
-                       node_ref.token());
-                dst.push_event(Event::new(events, node_ref.token()));
-
-                // If one-shot, disarm the node
-                if opts.is_oneshot() {
-                    node_ref.registration_data_mut().disable();
+            // If the queued flag is still set, then the node must be requeued.
+            // This typically happens when using level-triggered notifications.
+            if next.is_queued() {
+                if until.is_null() {
+                    // We never want to see the node again
+                    until = ptr;
                 }
+
+                // Requeue the node
+                self.inner.enqueue_node(node);
+            }
+
+            if readiness.is_some() {
+                // Get the token
+                let token = unsafe { token(node, next.token_read_pos()) };
+
+                // Push the event
+                dst.push_event(Event::new(readiness, token));
             }
         }
     }
 
     fn wakeup(&self) -> io::Result<()> {
-        self.inner().awakener.wakeup()
-    }
-
-    // Attempts to state to sleeping. This involves changing `head_readiness`
-    // to `sleep_token`. Returns true if `poll` can sleep.
-    fn prepare_for_sleep(&self) -> bool {
-        // Use relaxed as no memory besides the pointer is being sent across
-        // threads. Ordering doesn't matter, only the current value of
-        // `head_readiness`.
-        ptr::null_mut() == self.inner().head_readiness
-            .compare_and_swap(ptr::null_mut(), self.sleep_token(), Ordering::Relaxed)
-    }
-
-    fn take_ready(&self) -> ReadyList {
-        // Use `Acquire` ordering to ensure being able to read the latest
-        // values of all other atomic mutations.
-        let mut head = self.inner().head_readiness.swap(ptr::null_mut(), Ordering::Acquire);
-
-        if head == self.sleep_token() {
-            head = ptr::null_mut();
-        }
-
-        ReadyList { head: ReadyRef::new(head) }
-    }
-
-    fn new_readiness_node(&self, token: Token, interest: Ready, opts: PollOpt, ref_count: usize) -> ReadyRef {
-        let mut node = Box::new(ReadinessNode::new(token, interest, opts, ref_count));
-        let ret = ReadyRef::new(&mut *node as *mut ReadinessNode);
-
-        node.next_all_nodes = self.inner_mut().head_all_nodes.take();
-
-        let ptr = &*node as *const ReadinessNode as *mut ReadinessNode;
-
-        if let Some(ref mut next) = node.next_all_nodes {
-            next.prev_all_nodes = ReadyRef::new(ptr);
-        }
-
-        self.inner_mut().head_all_nodes = Some(node);
-
-        ret
+        self.inner.awakener.wakeup()
     }
 
     /// Prepend the given node to the head of the readiness queue. This is done
     /// with relaxed ordering. Returns true if `Poll` needs to be woken up.
-    fn prepend_readiness_node(&self, mut node: ReadyRef) -> bool {
-        let mut curr_head = self.inner().head_readiness.load(Ordering::Relaxed);
-
-        loop {
-            let node_next = if curr_head == self.sleep_token() {
-                ptr::null_mut()
-            } else {
-                curr_head
-            };
-
-            // Update next pointer
-            node.as_mut().unwrap().next_readiness = ReadyRef::new(node_next);
-
-            // Update the ref, use release ordering to ensure that mutations to
-            // previous atomics are visible if the mutation to the head pointer
-            // is.
-            let next_head = self.inner().head_readiness.compare_and_swap(curr_head, node.ptr, Ordering::Release);
-
-            if curr_head == next_head {
-                return curr_head == self.sleep_token();
-            }
-
-            curr_head = next_head;
+    fn enqueue_node_with_wakeup(&self, node: &ReadinessNode) -> io::Result<()> {
+        if self.inner.enqueue_node(node) {
+            try!(self.wakeup());
         }
+
+        Ok(())
     }
 
-    fn unlink_node(&self, mut node: ReadyRef) -> Box<ReadinessNode> {
-        node.as_mut().unwrap().unlink(&mut self.inner_mut().head_all_nodes)
+    /// Prepare the queue for the `Poll::poll` thread to block in the system
+    /// selector. This involves changing `head_readiness` to `sleep_marker`.
+    /// Returns true if successfull and `poll` can block.
+    fn prepare_for_sleep(&self) -> bool {
+        let end_marker = self.inner.end_marker();
+        let sleep_marker = self.inner.sleep_marker();
+
+        self.inner.sleep_marker.next_readiness.store(ptr::null_mut(), Relaxed);
+
+        let actual = self.inner.head_readiness.compare_and_swap(
+            end_marker, sleep_marker, AcqRel);
+
+        debug_assert!(actual != sleep_marker);
+
+        if actual != end_marker {
+            // The readiness queue is not empty
+            return false;
+        }
+
+        // The current tail should be pointing to `end_marker`
+        debug_assert!(unsafe { *self.inner.tail_readiness.get() == end_marker });
+        // The `end_marker` next pointer should be null
+        debug_assert!(self.inner.end_marker.next_readiness.load(Relaxed).is_null());
+
+        // Update tail pointer.
+        unsafe { *self.inner.tail_readiness.get() = sleep_marker; }
+        true
     }
 
-    fn is_empty(&self) -> bool {
-        self.inner().head_readiness.load(Ordering::Relaxed).is_null()
-    }
+    fn try_remove_sleep_marker(&self) {
+        let end_marker = self.inner.end_marker();
+        let sleep_marker = self.inner.sleep_marker();
 
-    fn sleep_token(&self) -> *mut ReadinessNode {
-        &*self.inner().sleep_token as *const ReadinessNode as *mut ReadinessNode
+        // Set the next ptr to null
+        self.inner.end_marker.next_readiness.store(ptr::null_mut(), Relaxed);
+
+        let actual = self.inner.head_readiness.compare_and_swap(
+            sleep_marker, end_marker, AcqRel);
+
+        // If the swap is successful, then the queue is still empty.
+        if actual != sleep_marker {
+            return;
+        }
+
+        unsafe { *self.inner.tail_readiness.get() = end_marker; }
     }
 
     fn identical(&self, other: &ReadinessQueue) -> bool {
-        self.inner.get() == other.inner.get()
-    }
+        let a = &*self.inner as *const ReadinessQueueInner;
+        let b = &*other.inner as *const ReadinessQueueInner;
 
-    fn inner(&self) -> &ReadinessQueueInner {
-        unsafe { mem::transmute(self.inner.get()) }
-    }
-
-    fn inner_mut(&self) -> &mut ReadinessQueueInner {
-        unsafe { mem::transmute(self.inner.get()) }
+        a == b
     }
 }
 
-unsafe impl Send for ReadinessQueue { }
+impl ReadinessQueueInner {
+    /// Push the node into the readiness queue
+    fn enqueue_node(&self, node: &ReadinessNode) -> bool {
+        // This is the 1024cores.net intrusive MPSC queue [1] "push" function.
+
+        let node_ptr = node as *const _ as *mut _;
+
+        // Relaxed used as the ordering is "released" when swapping
+        // `head_readiness`
+        node.next_readiness.store(ptr::null_mut(), Relaxed);
+
+        unsafe {
+            let prev = self.head_readiness.swap(node_ptr, AcqRel);
+
+            debug_assert!((*prev).next_readiness.load(Relaxed).is_null());
+
+            (*prev).next_readiness.store(node_ptr, Release);
+
+            prev == self.sleep_marker()
+        }
+    }
+
+    /// Must only be called in `poll` or `drop`
+    unsafe fn dequeue_node(&self, until: *mut ReadinessNode) -> Dequeue {
+        // This is the 1024cores.net intrusive MPSC queue [1] "pop" function
+        // with the modifications mentioned at the top of the file.
+        let mut tail = *self.tail_readiness.get();
+        let mut next = (*tail).next_readiness.load(Acquire);
+
+        if tail == self.end_marker() || tail == self.sleep_marker() {
+            if next.is_null() {
+                return Dequeue::Empty;
+            }
+
+            *self.tail_readiness.get() = next;
+            tail = next;
+            next = (*next).next_readiness.load(Acquire);
+        }
+
+        // Only need to check `until` at this point. `until` is either null,
+        // which will never match tail OR it is a node that was pushed by
+        // the current thread. This means that either:
+        //
+        // 1) The queue is inconsistent, which is handled explicitly
+        // 2) We encounter `until` at this point in dequeue
+        // 3) we will pop a different node
+        if tail == until {
+            return Dequeue::Empty;
+        }
+
+        if !next.is_null() {
+            *self.tail_readiness.get() = next;
+            return Dequeue::Data(tail);
+        }
+
+        if self.head_readiness.load(Acquire) != tail {
+            return Dequeue::Inconsistent;
+        }
+
+        // Push the stub node
+        self.enqueue_node(&*self.end_marker);
+
+        next = (*tail).next_readiness.load(Acquire);
+
+        if !next.is_null() {
+            *self.tail_readiness.get() = next;
+            return Dequeue::Data(tail);
+        }
+
+        Dequeue::Inconsistent
+    }
+
+    fn end_marker(&self) -> *mut ReadinessNode {
+        &*self.end_marker as *const ReadinessNode as *mut ReadinessNode
+    }
+
+    fn sleep_marker(&self) -> *mut ReadinessNode {
+        &*self.sleep_marker as *const ReadinessNode as *mut ReadinessNode
+    }
+}
+
+impl Drop for ReadinessQueueInner {
+    fn drop(&mut self) {
+        loop {
+            // Free any nodes that happen to be left in the readiness queue
+            let ptr = match unsafe { self.dequeue_node(ptr::null_mut()) } {
+                Dequeue::Empty => break,
+                Dequeue::Inconsistent => {
+                    // This really shouldn't be possible as all other handles to
+                    // `ReadinessQueueInner` are dropped, but handle this by
+                    // spinning I guess?
+                    continue;
+                }
+                Dequeue::Data(ptr) => ptr,
+            };
+
+            let node = unsafe { &*ptr };
+
+            let state = node.state.load(Acquire);
+
+            debug_assert!(state.is_queued());
+            debug_assert!(state.is_dropped());
+
+            release_node(ptr);
+        }
+    }
+}
 
 impl ReadinessNode {
-    fn new(token: Token, interest: Ready, opts: PollOpt, ref_count: usize) -> ReadinessNode {
+    /// Return a new `ReadinessNode`, initialized with a ref_count of 3.
+    fn new(token: Token, interest: Ready, opt: PollOpt) -> ReadinessNode {
         ReadinessNode {
-            next_all_nodes: None,
-            prev_all_nodes: ReadyRef::none(),
-            registration_data: UnsafeCell::new(RegistrationData::new(token, interest, opts)),
-            next_readiness: ReadyRef::none(),
-            events: AtomicUsize::new(0),
-            queued: AtomicUsize::new(0),
-            ref_count: AtomicUsize::new(ref_count),
+            state: AtomicState::new(interest, opt),
+            // Only the first token is set, the others are initialized to 0
+            token_0: UnsafeCell::new(token),
+            token_1: UnsafeCell::new(Token(0)),
+            token_2: UnsafeCell::new(Token(0)),
+            next_readiness: AtomicPtr::new(ptr::null_mut()),
+            update_lock: AtomicBool::new(false),
+            ref_count: AtomicUsize::new(3),
         }
     }
 
-    fn poll_events(&self) -> Ready {
-        (self.interest() | event::drop()) & event::from_usize(self.events.load(Ordering::Relaxed))
+    fn marker() -> ReadinessNode {
+        ReadinessNode {
+            state: AtomicState::new(Ready::none(), PollOpt::empty()),
+            token_0: UnsafeCell::new(Token(0)),
+            token_1: UnsafeCell::new(Token(0)),
+            token_2: UnsafeCell::new(Token(0)),
+            next_readiness: AtomicPtr::new(ptr::null_mut()),
+            update_lock: AtomicBool::new(false),
+            ref_count: AtomicUsize::new(0),
+        }
+    }
+}
+
+unsafe fn token(node: &ReadinessNode, pos: usize) -> Token {
+    match pos {
+        0 => *node.token_0.get(),
+        1 => *node.token_1.get(),
+        2 => *node.token_2.get(),
+        _ => unreachable!(),
+    }
+}
+
+fn release_node(ptr: *mut ReadinessNode) {
+    unsafe {
+        // Because `fetch_sub` is already atomic, we do not need to synchronize
+        // with other threads unless we are going to delete the object. This
+        // same logic applies to the below `fetch_sub` to the `weak` count.
+        if (*ptr).ref_count.fetch_sub(1, Release) != 1 {
+            return;
+        }
+
+        // This fence is needed to prevent reordering of use of the data and
+        // deletion of the data.  Because it is marked `Release`, the decreasing
+        // of the reference count synchronizes with this `Acquire` fence. This
+        // means that use of the data happens before decreasing the reference
+        // count, which happens before this fence, which happens before the
+        // deletion of the data.
+        //
+        // As explained in the [Boost documentation][1],
+        //
+        // > It is important to enforce any possible access to the object in one
+        // > thread (through an existing reference) to *happen before* deleting
+        // > the object in a different thread. This is achieved by a "release"
+        // > operation after dropping a reference (any access to the object
+        // > through this reference must obviously happened before), and an
+        // > "acquire" operation before deleting the object.
+        //
+        // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
+        atomic::fence(Acquire);
+
+        let _ = Box::from_raw(ptr);
+    }
+}
+
+impl AtomicState {
+    fn new(interest: Ready, opt: PollOpt) -> AtomicState {
+        let state = ReadinessState::new(interest, opt);
+
+        AtomicState {
+            inner: AtomicUsize::new(state.into()),
+        }
     }
 
-    fn token(&self) -> Token {
-        unsafe { &*self.registration_data.get() }.token
+    /// Loads the current `ReadinessState`
+    fn load(&self, order: Ordering) -> ReadinessState {
+        self.inner.load(order).into()
     }
 
+    /// Stores a state if the current state is the same as `current`.
+    fn compare_and_swap(&self, current: ReadinessState, new: ReadinessState, order: Ordering) -> ReadinessState {
+        self.inner.compare_and_swap(current.into(), new.into(), order).into()
+    }
+
+    // Returns `true` if the node should be queued
+    fn flag_as_dropped(&self) -> bool {
+        let prev: ReadinessState = self.inner.fetch_or(DROPPED_MASK | QUEUED_MASK, Release).into();
+        // The flag should not have been previously set
+        debug_assert!(!prev.is_dropped());
+
+        !prev.is_queued()
+    }
+}
+
+impl ReadinessState {
+    // Create a `ReadinessState` initialized with the provided arguments
+    #[inline]
+    fn new(interest: Ready, opt: PollOpt) -> ReadinessState {
+        let interest = event::ready_as_usize(interest);
+        let opt = event::opt_as_usize(opt);
+
+        debug_assert!(interest <= MASK_4);
+        debug_assert!(opt <= MASK_4);
+
+        let mut val = interest << INTEREST_SHIFT;
+        val |= opt << POLL_OPT_SHIFT;
+
+        ReadinessState(val)
+    }
+
+    #[inline]
+    fn get(&self, mask: usize, shift: usize) -> usize{
+        (self.0 >> shift) & mask
+    }
+
+    #[inline]
+    fn set(&mut self, val: usize, mask: usize, shift: usize) {
+        self.0 = (self.0 & !(mask << shift)) | (val << shift)
+    }
+
+    /// Get the readiness
+    #[inline]
+    fn readiness(&self) -> Ready {
+        let v = self.get(MASK_4, READINESS_SHIFT);
+        event::ready_from_usize(v)
+    }
+
+    #[inline]
+    fn effective_readiness(&self) -> Ready {
+        self.readiness() & self.interest()
+    }
+
+    /// Set the readiness
+    #[inline]
+    fn set_readiness(&mut self, v: Ready) {
+        self.set(event::ready_as_usize(v), MASK_4, READINESS_SHIFT);
+    }
+
+    /// Get the interest
+    #[inline]
     fn interest(&self) -> Ready {
-        unsafe { &*self.registration_data.get() }.interest
+        let v = self.get(MASK_4, INTEREST_SHIFT);
+        event::ready_from_usize(v)
     }
 
-    fn poll_opts(&self) -> PollOpt {
-        unsafe { &*self.registration_data.get() }.opts
+    /// Set the interest
+    #[inline]
+    fn set_interest(&mut self, v: Ready) {
+        self.set(event::ready_as_usize(v), MASK_4, INTEREST_SHIFT);
     }
 
-    fn registration_data_mut(&self) -> &mut RegistrationData {
-        unsafe { &mut *self.registration_data.get() }
+    #[inline]
+    fn disarm(&mut self) {
+        self.set_interest(Ready::none());
     }
 
-    fn unlink(&mut self, head: &mut Option<Box<ReadinessNode>>) -> Box<ReadinessNode> {
-        if let Some(ref mut next) = self.next_all_nodes {
-            next.prev_all_nodes = self.prev_all_nodes.clone();
-        }
+    /// Get the poll options
+    #[inline]
+    fn poll_opt(&self) -> PollOpt {
+        let v = self.get(MASK_4, POLL_OPT_SHIFT);
+        event::opt_from_usize(v)
+    }
 
-        let node;
+    /// Set the poll options
+    #[inline]
+    fn set_poll_opt(&mut self, v: PollOpt) {
+        self.set(event::opt_as_usize(v), MASK_4, POLL_OPT_SHIFT);
+    }
 
-        match self.prev_all_nodes.take().as_mut() {
-            Some(prev) => {
-                node = prev.next_all_nodes.take().unwrap();
-                prev.next_all_nodes = self.next_all_nodes.take();
+    #[inline]
+    fn is_queued(&self) -> bool {
+        self.0 & QUEUED_MASK == QUEUED_MASK
+    }
+
+    /// Set the queued flag
+    #[inline]
+    fn set_queued(&mut self) {
+        // Dropped nodes should never be queued
+        debug_assert!(!self.is_dropped());
+        self.0 |= QUEUED_MASK;
+    }
+
+    #[inline]
+    fn set_dequeued(&mut self) {
+        debug_assert!(self.is_queued());
+        self.0 &= !QUEUED_MASK
+    }
+
+    #[inline]
+    fn is_dropped(&self) -> bool {
+        self.0 & DROPPED_MASK == DROPPED_MASK
+    }
+
+    #[inline]
+    fn token_read_pos(&self) -> usize {
+        self.get(MASK_2, TOKEN_RD_SHIFT)
+    }
+
+    #[inline]
+    fn token_write_pos(&self) -> usize {
+        self.get(MASK_2, TOKEN_WR_SHIFT)
+    }
+
+    #[inline]
+    fn next_token_pos(&self) -> usize {
+        let rd = self.token_read_pos();
+        let wr = self.token_write_pos();
+
+        match wr {
+            0 => {
+                match rd {
+                    1 => 2,
+                    2 => 1,
+                    0 => 1,
+                    _ => unreachable!(),
+                }
             }
-            None => {
-                node = head.take().unwrap();
-                *head = self.next_all_nodes.take();
+            1 => {
+                match rd {
+                    0 => 2,
+                    2 => 0,
+                    1 => 2,
+                    _ => unreachable!(),
+                }
             }
+            2 => {
+                match rd {
+                    0 => 1,
+                    1 => 0,
+                    2 => 0,
+                    _ => unreachable!(),
+                }
+            }
+            _ => unreachable!(),
         }
+    }
 
-        node
+    #[inline]
+    fn set_token_write_pos(&mut self, val: usize) {
+        self.set(val, MASK_2, TOKEN_WR_SHIFT);
+    }
+
+    #[inline]
+    fn update_token_read_pos(&mut self) {
+        let val = self.token_write_pos();
+        self.set(val, MASK_2, TOKEN_WR_SHIFT);
     }
 }
 
-impl RegistrationData {
-    fn new(token: Token, interest: Ready, opts: PollOpt) -> RegistrationData {
-        RegistrationData {
-            token: token,
-            interest: interest,
-            opts: opts,
-        }
-    }
-
-    fn update(&mut self, token: Token, interest: Ready, opts: PollOpt) {
-        self.token = token;
-        self.interest = interest;
-        self.opts = opts;
-    }
-
-    fn disable(&mut self) {
-        self.interest = Ready::none();
-        self.opts = PollOpt::empty();
+impl From<ReadinessState> for usize {
+    fn from(src: ReadinessState) -> usize {
+        src.0
     }
 }
 
-impl Iterator for ReadyList {
-    type Item = ReadyRef;
-
-    fn next(&mut self) -> Option<ReadyRef> {
-        let mut next = self.head.take();
-
-        if next.is_some() {
-            next.as_mut().map(|n| self.head = n.next_readiness.take());
-            Some(next)
-        } else {
-            None
-        }
+impl From<usize> for ReadinessState {
+    fn from(src: usize) -> ReadinessState {
+        ReadinessState(src)
     }
 }
 
-impl ReadyRef {
-    fn new(ptr: *mut ReadinessNode) -> ReadyRef {
-        ReadyRef { ptr: ptr }
-    }
-
-    fn none() -> ReadyRef {
-        ReadyRef { ptr: ptr::null_mut() }
-    }
-
-    fn take(&mut self) -> ReadyRef {
-        let ret = ReadyRef { ptr: self.ptr };
-        self.ptr = ptr::null_mut();
-        ret
-    }
-
-    fn is_some(&self) -> bool {
-        !self.is_none()
-    }
-
-    fn is_none(&self) -> bool {
-        self.ptr.is_null()
-    }
-
-    fn as_ref(&self) -> Option<&ReadinessNode> {
-        if self.ptr.is_null() {
-            return None;
-        }
-
-        unsafe { Some(&*self.ptr) }
-    }
-
-    fn as_mut(&mut self) -> Option<&mut ReadinessNode> {
-        if self.ptr.is_null() {
-            return None;
-        }
-
-        unsafe { Some(&mut *self.ptr) }
-    }
-}
-
-impl Clone for ReadyRef {
-    fn clone(&self) -> ReadyRef {
-        ReadyRef::new(self.ptr)
-    }
-}
-
-impl fmt::Pointer for ReadyRef {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self.as_ref() {
-            Some(r) => fmt::Pointer::fmt(&r, fmt),
-            None => fmt::Pointer::fmt(&ptr::null::<ReadinessNode>(), fmt),
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use {Ready, Poll, PollOpt, Registration, SetReadiness, Token, Events};
-    use std::time::Duration;
-
-    fn ensure_send<T: Send>(_: &T) {}
-    fn ensure_sync<T: Sync>(_: &T) {}
-
-    #[allow(dead_code)]
-    fn ensure_type_bounds(r: &Registration, s: &SetReadiness) {
-        ensure_send(r);
-        ensure_send(s);
-        ensure_sync(s);
-    }
-
-    fn readiness_node_count(poll: &Poll) -> usize {
-        let mut cur = poll.readiness_queue.inner().head_all_nodes.as_ref();
-        let mut cnt = 0;
-
-        while let Some(node) = cur {
-            cnt += 1;
-            cur = node.next_all_nodes.as_ref();
-        }
-
-        cnt
-    }
-
-    #[test]
-    pub fn test_nodes_do_not_leak() {
-        let mut poll = Poll::new().unwrap();
-        let mut events = Events::with_capacity(1024);
-        let mut registrations = Vec::with_capacity(1_000);
-
-        for _ in 0..3 {
-            registrations.push(Registration::new(&mut poll, Token(0), Ready::readable(), PollOpt::edge()));
-        }
-
-        drop(registrations);
-
-        // Poll
-        let num = poll.poll(&mut events, Some(Duration::from_millis(300))).unwrap();
-
-        assert_eq!(0, num);
-        assert_eq!(0, readiness_node_count(&poll));
-    }
-}
+fn is_send<T: Send>() {}
+fn is_sync<T: Sync>() {}

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -197,6 +197,11 @@ impl Events {
     }
 
     #[inline]
+    pub fn capacity(&self) -> usize {
+        self.events.capacity()
+    }
+
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.events.is_empty()
     }

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -182,6 +182,11 @@ impl Events {
     }
 
     #[inline]
+    pub fn capacity(&self) -> usize {
+        self.events.capacity()
+    }
+
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.events.is_empty()
     }

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -447,6 +447,10 @@ impl Events {
         self.events.len()
     }
 
+    pub fn capacity(&self) -> usize {
+        self.events.capacity()
+    }
+
     pub fn get(&self, idx: usize) -> Option<Event> {
         self.events.get(idx).map(|e| *e)
     }

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -10,6 +10,7 @@ extern crate tempdir;
 
 pub use ports::localhost;
 
+mod test_custom_evented;
 mod test_close_on_drop;
 mod test_double_register;
 mod test_echo_server;

--- a/test/test_custom_evented.rs
+++ b/test/test_custom_evented.rs
@@ -1,0 +1,271 @@
+use mio::*;
+use std::time::Duration;
+
+#[test]
+fn smoke() {
+    let poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(128);
+
+    let (_r, set) = Registration::new(&poll, Token(0), Ready::readable(), PollOpt::edge());
+
+    let n = poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
+    assert_eq!(n, 0);
+
+    set.set_readiness(Ready::readable()).unwrap();
+
+    let n = poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
+    assert_eq!(n, 1);
+
+    assert_eq!(events.get(0).unwrap().token(), Token(0));
+}
+
+#[test]
+fn stress_single_threaded_poll() {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering::{Acquire, Release};
+    use std::thread;
+
+    const NUM_ATTEMPTS: usize = 30;
+    const NUM_ITERS: usize = 500;
+    const NUM_THREADS: usize = 4;
+    const NUM_REGISTRATIONS: usize = 128;
+
+    for _ in 0..NUM_ATTEMPTS {
+        let poll = Poll::new().unwrap();
+        let mut events = Events::with_capacity(128);
+
+        let registrations: Vec<_> = (0..NUM_REGISTRATIONS).map(|i| {
+            Registration::new(&poll, Token(i), Ready::readable(), PollOpt::edge())
+        }).collect();
+
+        let mut ready: Vec<_> = (0..NUM_REGISTRATIONS).map(|_| Ready::none()).collect();
+
+        let remaining = Arc::new(AtomicUsize::new(NUM_THREADS));
+
+        for _ in 0..NUM_THREADS {
+            let remaining = remaining.clone();
+
+            let set_readiness: Vec<SetReadiness> =
+                registrations.iter().map(|r| r.1.clone()).collect();
+
+            thread::spawn(move || {
+                for _ in 0..NUM_ITERS {
+                    for i in 0..NUM_REGISTRATIONS {
+                        set_readiness[i].set_readiness(Ready::readable()).unwrap();
+                        set_readiness[i].set_readiness(Ready::none()).unwrap();
+                        set_readiness[i].set_readiness(Ready::writable()).unwrap();
+                        set_readiness[i].set_readiness(Ready::readable() | Ready::writable()).unwrap();
+                        set_readiness[i].set_readiness(Ready::none()).unwrap();
+                    }
+                }
+
+                for i in 0..NUM_REGISTRATIONS {
+                    set_readiness[i].set_readiness(Ready::readable()).unwrap();
+                }
+
+                remaining.fetch_sub(1, Release);
+            });
+        }
+
+        while remaining.load(Acquire) > 0 {
+            // Set interest
+            for (i, &(ref r, _)) in registrations.iter().enumerate() {
+                r.update(&poll, Token(i), Ready::writable(), PollOpt::edge()).unwrap();
+            }
+
+            poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
+
+            for event in &events {
+                ready[event.token().0] = event.kind();
+            }
+
+            // Update registration
+            // Set interest
+            for (i, &(ref r, _)) in registrations.iter().enumerate() {
+                r.update(&poll, Token(i), Ready::readable(), PollOpt::edge()).unwrap();
+            }
+        }
+
+        // One final poll
+        poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
+
+        for event in &events {
+            ready[event.token().0] = event.kind();
+        }
+
+        // Everything should be flagged as readable
+        for ready in ready {
+            assert_eq!(ready, Ready::readable());
+        }
+    }
+}
+
+#[test]
+fn stress_multi_threaded_poll() {
+    use std::sync::{Arc, Barrier};
+    use std::sync::atomic::{AtomicUsize};
+    use std::sync::atomic::Ordering::{Relaxed, SeqCst};
+    use std::thread;
+
+    const ENTRIES: usize = 10_000;
+    const PER_ENTRY: usize = 16;
+    const THREADS: usize = 4;
+    const NUM: usize = ENTRIES * PER_ENTRY;
+
+    struct Entry {
+        #[allow(dead_code)]
+        registration: Registration,
+        set_readiness: SetReadiness,
+        num: AtomicUsize,
+    }
+
+    impl Entry {
+        fn fire(&self) {
+            self.set_readiness.set_readiness(Ready::readable()).unwrap();
+        }
+    }
+
+    let poll = Arc::new(Poll::new().unwrap());
+    let mut entries = vec![];
+
+    // Create entries
+    for i in 0..ENTRIES {
+        let (registration, set_readiness) =
+            Registration::new(&poll, Token(i), Ready::readable(), PollOpt::edge());
+
+        entries.push(Entry {
+            registration: registration,
+            set_readiness: set_readiness,
+            num: AtomicUsize::new(0),
+        });
+    }
+
+    let total = Arc::new(AtomicUsize::new(0));
+    let entries = Arc::new(entries);
+    let barrier = Arc::new(Barrier::new(THREADS));
+
+    let mut threads = vec![];
+
+    for th in 0..THREADS {
+        let poll = poll.clone();
+        let total = total.clone();
+        let entries = entries.clone();
+        let barrier = barrier.clone();
+
+        threads.push(thread::spawn(move || {
+            let mut events = Events::with_capacity(128);
+
+            barrier.wait();
+
+            // Prime all the registrations
+            let mut i = th;
+            while i < ENTRIES {
+                entries[i].fire();
+                i += THREADS;
+            }
+
+            let mut n = 0;
+
+
+            while total.load(SeqCst) < NUM {
+                // A poll timeout is necessary here because there may be more
+                // than one threads blocked in `poll` when the final wakeup
+                // notification arrives (and only notifies one thread).
+                n += poll.poll(&mut events, Some(Duration::from_millis(100))).unwrap();
+
+                let mut num_this_tick = 0;
+
+                for event in &events {
+                    let e = &entries[event.token().0];
+
+                    let mut num = e.num.load(Relaxed);
+
+                    loop {
+                        if num < PER_ENTRY {
+                            let actual = e.num.compare_and_swap(num, num + 1, Relaxed);
+
+                            if actual == num {
+                                num_this_tick += 1;
+                                e.fire();
+                                break;
+                            }
+
+                            num = actual;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+
+                total.fetch_add(num_this_tick, SeqCst);
+            }
+
+            n
+        }));
+    }
+
+    let per_thread: Vec<_> = threads.into_iter()
+        .map(|th| th.join().unwrap())
+        .collect();
+
+    for entry in entries.iter() {
+        assert_eq!(PER_ENTRY, entry.num.load(Relaxed));
+    }
+
+    for th in per_thread {
+        // Kind of annoying that we can't really test anything better than this,
+        // but CI tends to be very non deterministic when it comes to multi
+        // threading.
+        assert!(th > 0, "actual={:?}", th);
+    }
+}
+
+#[test]
+fn drop_registration_from_non_main_thread() {
+    use std::thread;
+    use std::sync::mpsc::channel;
+
+    const THREADS: usize = 8;
+    const ITERS: usize = 50_000;
+
+    let mut poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(1024);
+    let mut senders = Vec::with_capacity(THREADS);
+    let mut token_index = 0;
+
+    // spawn threads, which will send messages to single receiver
+    for _ in 0..THREADS {
+        let (tx, rx) = channel::<(Registration, SetReadiness)>();
+        senders.push(tx);
+
+        thread::spawn(move || {
+            for (registration, set_readiness) in rx {
+                let _ = set_readiness.set_readiness(Ready::readable());
+                drop(registration);
+                drop(set_readiness);
+            }
+        });
+    }
+
+    let mut index: usize = 0;
+    for _ in 0..ITERS {
+        let (registration, set_readiness) = Registration::new(&mut poll, Token(token_index), Ready::readable(), PollOpt::edge());
+        let _ = senders[index].send((registration, set_readiness));
+
+        token_index += 1;
+        index += 1;
+        if index == THREADS {
+            index = 0;
+
+            let (registration, set_readiness) = Registration::new(&mut poll, Token(token_index), Ready::readable(), PollOpt::edge());
+            let _ = set_readiness.set_readiness(Ready::readable());
+            drop(registration);
+            drop(set_readiness);
+            token_index += 1;
+
+            thread::park_timeout(Duration::from_millis(0));
+            let _ = poll.poll(&mut events, None).unwrap();
+        }
+    }
+}


### PR DESCRIPTION
The current readiness queue implementation has some concurrency bugs. So,
instead of fixing the bug, let's rewrite everything! :)

But more seriously, the current implementation has some problems (besides
having bugs):

* It's complicated
* It is not fair when using level-triggered notifications
* It is !Sync

This implementation will hopefully resolve the bugs, as well as simplifying
the implementation by reducing all the critical concurrent state for a
given node to a single atomic variable. It also changes the queueing
strategy from a stack to an actual queue based on the 1024cores MPSC
queue. However, this queue is able to reuse the nodes.

# TODO

* [x] Rewrite queue
* [x] Synchronize call to `poll`
* [x] Get tests to pass
* [x] Add custom evented tests
* [x] Check for performance regression.
* [x] Add multi-threaded poll tests
* [x] Code review

Fixes #532