### PR TITLE
Tweak documentation of Ready

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -505,11 +505,12 @@ impl fmt::Debug for PollOpt {
     }
 }
 
-/// A set of readiness events
+/// A set of readiness event kinds
 ///
-/// `Ready` is a set of operation descriptors indicating that an operation is
-/// ready to be performed. For example, `Ready::readable()` indicates that the
-/// associated `Evented` handle is ready to perform a `read` operation.
+/// `Ready` is a set of operation descriptors indicating which kind of an
+/// operation is ready to be performed. For example, `Ready::readable()`
+/// indicates that the associated `Evented` handle is ready to perform a
+/// `read` operation.
 ///
 /// **Note that only readable and writable readiness is guaranteed to be
 /// supported on all platforms**. This means that `error` and `hup` readiness


### PR DESCRIPTION
Current master is much better than https://docs.rs/mio/0.6.4/mio/struct.Ready.html, which confused me into thinking of e.g. an event on a specific connection until I looked at the source. Feel free to just close this PR if you don't think this improves the wording.