### PR TITLE
POSIX AIO support

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -538,13 +538,34 @@ impl fmt::Debug for PollOpt {
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct Ready(usize);
 
-const READABLE: usize = 0b0001;
-const WRITABLE: usize = 0b0010;
-const ERROR: usize    = 0b0100;
-const HUP: usize      = 0b1000;
-const READY_ALL: usize = READABLE | WRITABLE | ERROR | HUP;
+const READABLE: usize = 0b00001;
+const WRITABLE: usize = 0b00010;
+const ERROR: usize    = 0b00100;
+const HUP: usize      = 0b01000;
+const AIO: usize      = 0b10000;
+const READY_ALL: usize = READABLE | WRITABLE | ERROR | HUP | AIO;
 
 impl Ready {
+    /// Returns a `Ready` representing AIO completion readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::Ready;
+    ///
+    /// let ready = Ready::aio();
+    ///
+    /// assert!(ready.is_aio());
+    /// ```
+    ///
+    /// [`Poll`]: struct.Poll.html
+    #[inline]
+    pub fn aio() -> Ready {
+        Ready(AIO)
+    }
+
     /// Returns the empty `Ready` set.
     ///
     /// See [`Poll`] for more documentation on polling.
@@ -673,6 +694,24 @@ impl Ready {
     pub fn all() -> Ready {
         Ready::readable() |
             Ready::writable()
+    }
+
+    /// Returns true if `Ready` contains AIO readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::Ready;
+    ///
+    /// let ready = Ready::aio();
+    ///
+    /// assert!(ready.is_aio());
+    /// ```
+    #[inline]
+    pub fn is_aio(&self) -> bool {
+        self.contains(Ready::aio())
     }
 
     /// Returns true if `Ready` is the empty set
@@ -936,7 +975,8 @@ impl fmt::Debug for Ready {
             (Ready::readable(), "Readable"),
             (Ready::writable(), "Writable"),
             (Ready(ERROR), "Error"),
-            (Ready(HUP), "Hup")];
+            (Ready(HUP), "Hup"),
+            (Ready::aio(), "AIO")];
 
         try!(write!(fmt, "Ready {{"));
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -3,6 +3,10 @@ use event_imp::{self as event, Ready, Event, Evented, PollOpt};
 use std::{fmt, io, ptr, usize};
 use std::cell::UnsafeCell;
 use std::{mem, ops, isize};
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+#[cfg(unix)]
+use std::os::unix::io::RawFd;
 use std::sync::{Arc, Mutex, Condvar};
 use std::sync::atomic::{AtomicUsize, AtomicPtr, AtomicBool};
 use std::sync::atomic::Ordering::{self, Acquire, Release, AcqRel, Relaxed, SeqCst};
@@ -531,22 +535,23 @@ struct AtomicState {
 
 const MASK_2: usize = 4 - 1;
 const MASK_4: usize = 16 - 1;
+const MASK_8: usize = 256 - 1;
 const QUEUED_MASK: usize = 1 << QUEUED_SHIFT;
 const DROPPED_MASK: usize = 1 << DROPPED_SHIFT;
 
 const READINESS_SHIFT: usize = 0;
-const INTEREST_SHIFT: usize = 4;
-const POLL_OPT_SHIFT: usize = 8;
-const TOKEN_RD_SHIFT: usize = 12;
-const TOKEN_WR_SHIFT: usize = 14;
-const QUEUED_SHIFT: usize = 16;
-const DROPPED_SHIFT: usize = 17;
+const INTEREST_SHIFT: usize = 8;
+const POLL_OPT_SHIFT: usize = 16;
+const TOKEN_RD_SHIFT: usize = 20;
+const TOKEN_WR_SHIFT: usize = 22;
+const QUEUED_SHIFT: usize = 24;
+const DROPPED_SHIFT: usize = 25;
 
 /// Tracks all state for a single `ReadinessNode`. The state is packed into a
 /// `usize` variable from low to high bit as follows:
 ///
-/// 4 bits: Registration current readiness
-/// 4 bits: Registration interest
+/// 8 bits: Registration current readiness
+/// 8 bits: Registration interest
 /// 4 bits: Poll options
 /// 2 bits: Token position currently being read from by `poll`
 /// 2 bits: Token position last written to by `update`
@@ -1112,8 +1117,8 @@ fn validate_args(token: Token, interest: Ready) -> io::Result<()> {
         return Err(io::Error::new(io::ErrorKind::Other, "invalid token"));
     }
 
-    if !interest.is_readable() && !interest.is_writable() {
-        return Err(io::Error::new(io::ErrorKind::Other, "interest must include readable or writable"));
+    if !interest.is_readable() && !interest.is_writable() && !interest.is_aio() {
+        return Err(io::Error::new(io::ErrorKind::Other, "interest must include readable or writable or aio"));
     }
 
     Ok(())
@@ -1122,6 +1127,13 @@ fn validate_args(token: Token, interest: Ready) -> io::Result<()> {
 impl fmt::Debug for Poll {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "Poll")
+    }
+}
+
+#[cfg(unix)]
+impl AsRawFd for Poll {
+    fn as_raw_fd(&self) -> RawFd {
+        self.selector.as_raw_fd()
     }
 }
 
@@ -2248,7 +2260,7 @@ impl ReadinessState {
         let interest = event::ready_as_usize(interest);
         let opt = event::opt_as_usize(opt);
 
-        debug_assert!(interest <= MASK_4);
+        debug_assert!(interest <= MASK_8);
         debug_assert!(opt <= MASK_4);
 
         let mut val = interest << INTEREST_SHIFT;
@@ -2270,7 +2282,7 @@ impl ReadinessState {
     /// Get the readiness
     #[inline]
     fn readiness(&self) -> Ready {
-        let v = self.get(MASK_4, READINESS_SHIFT);
+        let v = self.get(MASK_8, READINESS_SHIFT);
         event::ready_from_usize(v)
     }
 
@@ -2282,20 +2294,20 @@ impl ReadinessState {
     /// Set the readiness
     #[inline]
     fn set_readiness(&mut self, v: Ready) {
-        self.set(event::ready_as_usize(v), MASK_4, READINESS_SHIFT);
+        self.set(event::ready_as_usize(v), MASK_8, READINESS_SHIFT);
     }
 
     /// Get the interest
     #[inline]
     fn interest(&self) -> Ready {
-        let v = self.get(MASK_4, INTEREST_SHIFT);
+        let v = self.get(MASK_8, INTEREST_SHIFT);
         event::ready_from_usize(v)
     }
 
     /// Set the interest
     #[inline]
     fn set_interest(&mut self, v: Ready) {
-        self.set(event::ready_as_usize(v), MASK_4, INTEREST_SHIFT);
+        self.set(event::ready_as_usize(v), MASK_8, INTEREST_SHIFT);
     }
 
     #[inline]

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -1,4 +1,5 @@
 #![allow(deprecated)]
+use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use std::time::Duration;
@@ -171,6 +172,12 @@ fn ioevent_to_epoll(interest: Ready, opts: PollOpt) -> u32 {
     }
 
     kind as u32
+}
+
+impl AsRawFd for Selector {
+    fn as_raw_fd(&self) -> RawFd {
+        self.epfd
+    }
 }
 
 impl Drop for Selector {

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -1,5 +1,6 @@
 use std::{cmp, fmt, ptr};
 use std::os::raw::c_int;
+use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
@@ -148,6 +149,12 @@ impl fmt::Debug for Selector {
     }
 }
 
+impl AsRawFd for Selector {
+    fn as_raw_fd(&self) -> RawFd {
+        self.kq
+    }
+}
+
 impl Drop for Selector {
     fn drop(&mut self) {
         unsafe {
@@ -228,6 +235,13 @@ impl Events {
                 event::kind_mut(&mut self.events[idx]).insert(Ready::readable());
             } else if e.filter == libc::EVFILT_WRITE {
                 event::kind_mut(&mut self.events[idx]).insert(Ready::writable());
+            }
+#[cfg(any(target_os = "dragonfly",
+    target_os = "freebsd", target_os = "ios", target_os = "macos"))]
+            {
+                if e.filter == libc::EVFILT_AIO {
+                    event::kind_mut(&mut self.events[idx]).insert(Ready::aio());
+                }
             }
 
             if e.flags & libc::EV_EOF != 0 {


### PR DESCRIPTION
On BSD-based operating systems, add low-level support for queuing AIO
operations in the event loop.  This commit adds 2 new public methods:
Ready::aio and Ready::is_aio.  Full support will be added in a separate
crate.