### PR TITLE
Split Ready into Ready and UnixReady

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,6 +1,6 @@
 //! Thread safe communication channel implementing `Evented`
 
-#![allow(unused_imports, deprecated)]
+#![allow(unused_imports, deprecated, missing_debug_implementations)]
 
 use {io, Evented, Ready, Poll, PollOpt, Registration, SetReadiness, Token};
 use lazycell::{LazyCell, AtomicLazyCell};

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -266,7 +266,8 @@ impl PollOpt {
         PollOpt(0b0100)
     }
 
-    // TODO: Figure out if this should be deprecated or not
+    #[deprecated(since = "0.6.5", note = "removed")]
+    #[cfg(feature = "with-deprecated")]
     #[doc(hidden)]
     #[inline]
     pub fn urgent() -> PollOpt {
@@ -341,8 +342,10 @@ impl PollOpt {
         self.contains(PollOpt::oneshot())
     }
 
-    // TODO: Should this be deprecated?
+    #[deprecated(since = "0.6.5", note = "removed")]
+    #[cfg(feature = "with-deprecated")]
     #[doc(hidden)]
+    #[allow(deprecated)]
     #[inline]
     pub fn is_urgent(&self) -> bool {
         self.contains(PollOpt::urgent())
@@ -512,10 +515,11 @@ impl fmt::Debug for PollOpt {
 /// indicates that the associated `Evented` handle is ready to perform a
 /// `read` operation.
 ///
-/// **Note that only readable and writable readiness is guaranteed to be
-/// supported on all platforms**. This means that `error` and `hup` readiness
-/// should be treated as hints. For more details, see [readiness] in the poll
-/// documentation.
+/// This struct only represents portable event kinds. Since only readable and
+/// writable events are guaranteed to be raised on all systems, those are the
+/// only ones available via the `Ready` struct. There are also platform specific
+/// extensions to `Ready`, i.e. `UnixReady`, which provide additional readiness
+/// event kinds only available on unix platforms.
 ///
 /// `Ready` values can be combined together using the various bitwise operators.
 ///
@@ -543,7 +547,6 @@ const READABLE: usize = 0b0001;
 const WRITABLE: usize = 0b0010;
 const ERROR: usize    = 0b0100;
 const HUP: usize      = 0b1000;
-const READY_ALL: usize = READABLE | WRITABLE | ERROR | HUP;
 
 impl Ready {
     /// Returns the empty `Ready` set.
@@ -612,56 +615,17 @@ impl Ready {
         Ready(WRITABLE)
     }
 
-    /// Returns a `Ready` representing error readiness.
-    ///
-    /// **Note that only readable and writable readiness is guaranteed to be
-    /// supported on all platforms**. This means that `error` readiness
-    /// should be treated as a hint. For more details, see [readiness] in the
-    /// poll documentation.
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::error();
-    ///
-    /// assert!(ready.is_error());
-    /// ```
-    ///
-    /// [`Poll`]: struct.Poll.html
-    /// [readiness]: struct.Poll.html#readiness-operations
+    #[deprecated(since = "0.6.5", note = "use UnixReady instead")]
+    #[cfg(feature = "with-deprecated")]
+    #[doc(hidden)]
     #[inline]
     pub fn error() -> Ready {
         Ready(ERROR)
     }
 
-    /// Returns a `Ready` representing HUP readiness.
-    ///
-    /// A HUP (or hang-up) signifies that a stream socket **peer** closed the
-    /// connection, or shut down the writing half of the connection.
-    ///
-    /// **Note that only readable and writable readiness is guaranteed to be
-    /// supported on all platforms**. This means that `hup` readiness
-    /// should be treated as a hint. For more details, see [readiness] in the
-    /// poll documentation.
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::hup();
-    ///
-    /// assert!(ready.is_hup());
-    /// ```
-    ///
-    /// [`Poll`]: struct.Poll.html
-    /// [readiness]: struct.Poll.html#readiness-operations
+    #[deprecated(since = "0.6.5", note = "use UnixReady instead")]
+    #[cfg(feature = "with-deprecated")]
+    #[doc(hidden)]
     #[inline]
     pub fn hup() -> Ready {
         Ready(HUP)
@@ -741,54 +705,17 @@ impl Ready {
         self.contains(Ready::writable())
     }
 
-    /// Returns true if the value includes error readiness
-    ///
-    /// **Note that only readable and writable readiness is guaranteed to be
-    /// supported on all platforms**. This means that `error` readiness should
-    /// be treated as a hint. For more details, see [readiness] in the poll
-    /// documentation.
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::error();
-    ///
-    /// assert!(ready.is_error());
-    /// ```
-    ///
-    /// [`Poll`]: struct.Poll.html
+    #[deprecated(since = "0.6.5", note = "use UnixReady instead")]
+    #[cfg(feature = "with-deprecated")]
+    #[doc(hidden)]
     #[inline]
     pub fn is_error(&self) -> bool {
         self.contains(Ready(ERROR))
     }
 
-    /// Returns true if the value includes HUP readiness
-    ///
-    /// A HUP (or hang-up) signifies that a stream socket **peer** closed the
-    /// connection, or shut down the writing half of the connection.
-    ///
-    /// **Note that only readable and writable readiness is guaranteed to be
-    /// supported on all platforms**. This means that `hup` readiness
-    /// should be treated as a hint. For more details, see [readiness] in the
-    /// poll documentation.
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::Ready;
-    ///
-    /// let ready = Ready::hup();
-    ///
-    /// assert!(ready.is_hup());
-    /// ```
-    ///
-    /// [`Poll`]: struct.Poll.html
+    #[deprecated(since = "0.6.5", note = "use UnixReady instead")]
+    #[cfg(feature = "with-deprecated")]
+    #[doc(hidden)]
     #[inline]
     pub fn is_hup(&self) -> bool {
         self.contains(Ready(HUP))
@@ -809,7 +736,8 @@ impl Ready {
     /// assert!(readiness.is_readable());
     /// ```
     #[inline]
-    pub fn insert(&mut self, other: Ready) {
+    pub fn insert<T: Into<Self>>(&mut self, other: T) {
+        let other = other.into();
         self.0 |= other.0;
     }
 
@@ -828,7 +756,8 @@ impl Ready {
     /// assert!(!readiness.is_readable());
     /// ```
     #[inline]
-    pub fn remove(&mut self, other: Ready) {
+    pub fn remove<T: Into<Self>>(&mut self, other: T) {
+        let other = other.into();
         self.0 &= !other.0;
     }
 
@@ -880,44 +809,45 @@ impl Ready {
     ///
     /// [`Poll`]: struct.Poll.html
     #[inline]
-    pub fn contains(&self, other: Ready) -> bool {
+    pub fn contains<T: Into<Self>>(&self, other: T) -> bool {
+        let other = other.into();
         (*self & other) == other
     }
 }
 
-impl ops::BitOr for Ready {
+impl<T: Into<Ready>> ops::BitOr<T> for Ready {
     type Output = Ready;
 
     #[inline]
-    fn bitor(self, other: Ready) -> Ready {
-        Ready(self.0 | other.0)
+    fn bitor(self, other: T) -> Ready {
+        Ready(self.0 | other.into().0)
     }
 }
 
-impl ops::BitXor for Ready {
+impl<T: Into<Ready>> ops::BitXor<T> for Ready {
     type Output = Ready;
 
     #[inline]
-    fn bitxor(self, other: Ready) -> Ready {
-        Ready(self.0 ^ other.0)
+    fn bitxor(self, other: T) -> Ready {
+        Ready(self.0 ^ other.into().0)
     }
 }
 
-impl ops::BitAnd for Ready {
+impl<T: Into<Ready>> ops::BitAnd<T> for Ready {
     type Output = Ready;
 
     #[inline]
-    fn bitand(self, other: Ready) -> Ready {
-        Ready(self.0 & other.0)
+    fn bitand(self, other: T) -> Ready {
+        Ready(self.0 & other.into().0)
     }
 }
 
-impl ops::Sub for Ready {
+impl<T: Into<Ready>> ops::Sub<T> for Ready {
     type Output = Ready;
 
     #[inline]
-    fn sub(self, other: Ready) -> Ready {
-        Ready(self.0 & !other.0)
+    fn sub(self, other: T) -> Ready {
+        Ready(self.0 & !other.into().0)
     }
 }
 
@@ -926,7 +856,7 @@ impl ops::Not for Ready {
 
     #[inline]
     fn not(self) -> Ready {
-        Ready(!self.0 & READY_ALL)
+        Ready(!self.0)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,7 @@ pub mod unix {
     pub use sys::{
         EventedFd,
     };
+    pub use sys::unix::UnixReady;
 }
 
 /// Windows-only extensions to the mio crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 #![doc(html_root_url = "https://docs.rs/mio/0.6.1")]
 #![crate_name = "mio"]
 
-#![deny(warnings, missing_docs)]
+#![deny(warnings, missing_docs, missing_debug_implementations)]
 
 extern crate lazycell;
 extern crate net2;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1185,6 +1185,7 @@ pub struct Events {
 ///
 /// [`Events`]: struct.Events.html
 /// [`iter`]: struct.Events.html#method.iter
+#[derive(Debug)]
 pub struct Iter<'a> {
     inner: &'a Events,
     pos: usize,
@@ -1318,6 +1319,15 @@ impl<'a> Iterator for Iter<'a> {
         let ret = self.inner.get(self.pos);
         self.pos += 1;
         ret
+    }
+}
+
+impl fmt::Debug for Events {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Events")
+            .field("len", &self.len())
+            .field("capacity", &self.capacity())
+            .finish()
     }
 }
 
@@ -1583,6 +1593,12 @@ impl SetReadiness {
     /// [`poll`]: struct.Poll.html#method.poll
     pub fn set_readiness(&self, ready: Ready) -> io::Result<()> {
         self.inner.set_readiness(ready)
+    }
+}
+
+impl fmt::Debug for SetReadiness {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SetReadiness")
     }
 }
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -17,7 +17,7 @@ pub use self::unix::{
 pub use self::unix::UnixSocket;
 
 #[cfg(unix)]
-mod unix;
+pub mod unix;
 
 #[cfg(windows)]
 pub use self::windows::{

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -9,7 +9,7 @@ use libc::{self, time_t};
 
 use {io, Ready, PollOpt, Token};
 use event_imp::{self as event, Event};
-use sys::unix::cvt;
+use sys::unix::{cvt, UnixReady};
 use sys::unix::io::set_cloexec;
 
 /// Each Selector has a globally unique(ish) ID associated with it. This ID
@@ -221,7 +221,7 @@ impl Events {
             }
 
             if e.flags & libc::EV_ERROR != 0 {
-                event::kind_mut(&mut self.events[idx]).insert(Ready::error());
+                event::kind_mut(&mut self.events[idx]).insert(*UnixReady::error());
             }
 
             if e.filter == libc::EVFILT_READ {
@@ -231,12 +231,12 @@ impl Events {
             }
 
             if e.flags & libc::EV_EOF != 0 {
-                event::kind_mut(&mut self.events[idx]).insert(Ready::hup());
+                event::kind_mut(&mut self.events[idx]).insert(UnixReady::hup());
 
                 // When the read end of the socket is closed, EV_EOF is set on
                 // flags, and fflags contains the error if there is one.
                 if e.fflags != 0 {
-                    event::kind_mut(&mut self.events[idx]).insert(Ready::error());
+                    event::kind_mut(&mut self.events[idx]).insert(UnixReady::error());
                 }
             }
         }

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -22,6 +22,7 @@ pub use self::kqueue::{Events, Selector};
 mod awakener;
 mod eventedfd;
 mod io;
+mod ready;
 mod tcp;
 mod udp;
 
@@ -31,6 +32,7 @@ mod uds;
 pub use self::awakener::Awakener;
 pub use self::eventedfd::EventedFd;
 pub use self::io::{Io, set_nonblock};
+pub use self::ready::UnixReady;
 pub use self::tcp::{TcpStream, TcpListener};
 pub use self::udp::UdpSocket;
 

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -1,0 +1,269 @@
+use event_imp::{Ready, ready_from_usize};
+
+use std::ops;
+
+/// Unix specific extensions to `Ready`
+///
+/// Provides additional readiness event kinds that are available on unix
+/// platforms. Unix platforms are able to provide readiness events for
+/// additional socket events, such as HUP and error.
+///
+/// HUP events occur when the remote end of a socket hangs up. In the TCP case,
+/// this occurs when the remote end of a TCP socket shuts down writes.
+///
+/// Error events occur when the socket enters an error state. In this case, the
+/// socket will also receive a readable or writable event. Reading or writing to
+/// the socket will result in an error.
+///
+/// Conversion traits are implemented between `Ready` and `UnixReady`. See the
+/// examples.
+///
+/// For high level documentation on polling and readiness, see [`Poll`].
+///
+/// # Examples
+///
+/// Most of the time, all that is needed is using bit operations
+///
+/// ```
+/// use mio::Ready;
+/// use mio::unix::UnixReady;
+///
+/// let ready = Ready::readable() | UnixReady::hup();
+///
+/// assert!(ready.is_readable());
+/// assert!(UnixReady::from(ready).is_hup());
+/// ```
+///
+/// Basic conversion between ready types.
+///
+/// ```
+/// use mio::Ready;
+/// use mio::unix::UnixReady;
+///
+/// // Start with a portable ready
+/// let ready = Ready::readable();
+///
+/// // Convert to a unix ready, adding HUP
+/// let mut unix_ready = UnixReady::from(ready) | UnixReady::hup();
+///
+/// unix_ready.insert(UnixReady::error());
+///
+/// // `unix_ready` maintains readable interest
+/// assert!(unix_ready.is_readable());
+/// assert!(unix_ready.is_hup());
+/// assert!(unix_ready.is_error());
+///
+/// // Convert back to `Ready`
+/// let ready = Ready::from(unix_ready);
+///
+/// // Readable is maintained
+/// assert!(ready.is_readable());
+/// ```
+///
+/// Registering readable and error interest on a socket
+///
+/// ```
+/// use mio::{Ready, Poll, PollOpt, Token};
+/// use mio::tcp::TcpStream;
+/// use mio::unix::UnixReady;
+///
+/// let addr = "216.58.193.68:80".parse().unwrap();
+/// let socket = TcpStream::connect(&addr).unwrap();
+///
+/// let poll = Poll::new().unwrap();
+///
+/// poll.register(&socket,
+///               Token(0),
+///               Ready::readable() | UnixReady::error(),
+///               PollOpt::edge()).unwrap();
+///
+/// ```
+///
+/// [`Poll`]: struct.Poll.html
+/// [readiness]: struct.Poll.html#readiness-operations
+#[derive(Debug, Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
+pub struct UnixReady(Ready);
+
+const ERROR: usize = 0b0100;
+const HUP: usize   = 0b1000;
+
+impl UnixReady {
+    /// Returns a `Ready` representing error readiness.
+    ///
+    /// **Note that only readable and writable readiness is guaranteed to be
+    /// supported on all platforms**. This means that `error` readiness
+    /// should be treated as a hint. For more details, see [readiness] in the
+    /// poll documentation.
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::Ready;
+    ///
+    /// let ready = Ready::error();
+    ///
+    /// assert!(ready.is_error());
+    /// ```
+    ///
+    /// [`Poll`]: struct.Poll.html
+    /// [readiness]: struct.Poll.html#readiness-operations
+    #[inline]
+    pub fn error() -> UnixReady {
+        UnixReady(ready_from_usize(ERROR))
+    }
+
+    /// Returns a `Ready` representing HUP readiness.
+    ///
+    /// A HUP (or hang-up) signifies that a stream socket **peer** closed the
+    /// connection, or shut down the writing half of the connection.
+    ///
+    /// **Note that only readable and writable readiness is guaranteed to be
+    /// supported on all platforms**. This means that `hup` readiness
+    /// should be treated as a hint. For more details, see [readiness] in the
+    /// poll documentation.
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::Ready;
+    ///
+    /// let ready = Ready::hup();
+    ///
+    /// assert!(ready.is_hup());
+    /// ```
+    ///
+    /// [`Poll`]: struct.Poll.html
+    /// [readiness]: struct.Poll.html#readiness-operations
+    #[inline]
+    pub fn hup() -> UnixReady {
+        UnixReady(ready_from_usize(HUP))
+    }
+
+    /// Returns true if the value includes error readiness
+    ///
+    /// **Note that only readable and writable readiness is guaranteed to be
+    /// supported on all platforms**. This means that `error` readiness should
+    /// be treated as a hint. For more details, see [readiness] in the poll
+    /// documentation.
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::Ready;
+    ///
+    /// let ready = Ready::error();
+    ///
+    /// assert!(ready.is_error());
+    /// ```
+    ///
+    /// [`Poll`]: struct.Poll.html
+    #[inline]
+    pub fn is_error(&self) -> bool {
+        self.contains(ready_from_usize(ERROR))
+    }
+
+    /// Returns true if the value includes HUP readiness
+    ///
+    /// A HUP (or hang-up) signifies that a stream socket **peer** closed the
+    /// connection, or shut down the writing half of the connection.
+    ///
+    /// **Note that only readable and writable readiness is guaranteed to be
+    /// supported on all platforms**. This means that `hup` readiness
+    /// should be treated as a hint. For more details, see [readiness] in the
+    /// poll documentation.
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::Ready;
+    ///
+    /// let ready = Ready::hup();
+    ///
+    /// assert!(ready.is_hup());
+    /// ```
+    ///
+    /// [`Poll`]: struct.Poll.html
+    #[inline]
+    pub fn is_hup(&self) -> bool {
+        self.contains(ready_from_usize(HUP))
+    }
+}
+
+impl From<Ready> for UnixReady {
+    fn from(src: Ready) -> UnixReady {
+        UnixReady(src)
+    }
+}
+
+impl From<UnixReady> for Ready {
+    fn from(src: UnixReady) -> Ready {
+        src.0
+    }
+}
+
+impl ops::Deref for UnixReady {
+    type Target = Ready;
+
+    fn deref(&self) -> &Ready {
+        &self.0
+    }
+}
+
+impl ops::DerefMut for UnixReady {
+    fn deref_mut(&mut self) -> &mut Ready {
+        &mut self.0
+    }
+}
+
+impl ops::BitOr for UnixReady {
+    type Output = UnixReady;
+
+    #[inline]
+    fn bitor(self, other: UnixReady) -> UnixReady {
+        (self.0 | other.0).into()
+    }
+}
+
+impl ops::BitXor for UnixReady {
+    type Output = UnixReady;
+
+    #[inline]
+    fn bitxor(self, other: UnixReady) -> UnixReady {
+        (self.0 ^ other.0).into()
+    }
+}
+
+impl ops::BitAnd for UnixReady {
+    type Output = UnixReady;
+
+    #[inline]
+    fn bitand(self, other: UnixReady) -> UnixReady {
+        (self.0 & other.0).into()
+    }
+}
+
+impl ops::Sub for UnixReady {
+    type Output = UnixReady;
+
+    #[inline]
+    fn sub(self, other: UnixReady) -> UnixReady {
+        (self.0 & !other.0).into()
+    }
+}
+
+impl ops::Not for UnixReady {
+    type Output = UnixReady;
+
+    #[inline]
+    fn not(self) -> UnixReady {
+        (!self.0).into()
+    }
+}

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -360,13 +360,6 @@ impl ReadyBinding {
             try!(self.binding.register_socket(socket, token, poll));
         }
 
-        // To keep the same semantics as epoll, if I/O objects are interested in
-        // being readable then they're also interested in listening for hup
-        let events = if events.is_readable() {
-            events | Ready::hup()
-        }  else {
-            events
-        };
         let (r, s) = poll::new_registration(poll, token, events, opts);
         self.readiness = Some(s);
         *registration.lock().unwrap() = Some(r);
@@ -387,13 +380,6 @@ impl ReadyBinding {
             try!(self.binding.reregister_socket(socket, token, poll));
         }
 
-        // To keep the same semantics as epoll, if I/O objects are interested in
-        // being readable then they're also interested in listening for hup
-        let events = if events.is_readable() {
-            events | Ready::hup()
-        }  else {
-            events
-        };
         registration.lock().unwrap()
                     .as_mut().unwrap()
                     .reregister(poll, token, events, opts)

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)]
 
-use std::{io, u32};
+use std::{fmt, io, u32};
 use std::cell::UnsafeCell;
 use std::os::windows::prelude::*;
 use std::sync::{Arc, Mutex};
@@ -268,6 +268,12 @@ impl Binding {
     }
 }
 
+impl fmt::Debug for Binding {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Binding")
+    }
+}
+
 /// Helper struct used for TCP and UDP which bundles a `binding` with a
 /// `SetReadiness` handle.
 pub struct ReadyBinding {
@@ -520,6 +526,12 @@ impl Overlapped {
         unsafe {
             (*self.inner.get()).raw()
         }
+    }
+}
+
+impl fmt::Debug for Overlapped {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Overlapped")
     }
 }
 

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -395,15 +395,8 @@ impl StreamImp {
                 mem::forget(self.clone());
             }
             Err(e) => {
-                // Like above, be sure to indicate that hup has happened
-                // whenever we get `ECONNRESET`
-                let mut set = Ready::readable();
-                if e.raw_os_error() == Some(WSAECONNRESET as i32) {
-                    trace!("tcp stream at hup: econnreset");
-                    set = set | Ready::hup();
-                }
                 me.read = State::Error(e);
-                self.add_readiness(me, set);
+                self.add_readiness(me, Ready::readable());
             }
         }
     }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,6 +1,6 @@
 //! Timer optimized for I/O related operations
 
-#![allow(deprecated)]
+#![allow(deprecated, missing_debug_implementations)]
 
 use {convert, io, Evented, Ready, Poll, PollOpt, Registration, SetReadiness, Token};
 use lazycell::LazyCell;


### PR DESCRIPTION
Move HUP and error event kinds to a unix specific readiness type.