### PR TITLE
Fix a use-after-free in the readiness queue 

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1647,7 +1647,6 @@ impl RegistrationInner {
         let other: &*mut () = unsafe { mem::transmute(&poll.readiness_queue) };
         let other = *other;
 
-        debug_assert_eq!(other as usize, unsafe { mem::transmute(poll.readiness_queue.inner.clone()) });
         debug_assert!(mem::size_of::<ReadinessQueue>() == mem::size_of::<*mut ()>());
 
         if queue.is_null() {
@@ -1687,7 +1686,10 @@ impl RegistrationInner {
             return Err(io::Error::new(io::ErrorKind::Other, "registration handle associated with another `Poll` instance"));
         }
 
-        debug_assert_eq!(queue as usize, unsafe { mem::transmute(poll.readiness_queue.inner.clone()) });
+        unsafe {
+            let actual = &poll.readiness_queue.inner as *const _ as *const usize;
+            debug_assert_eq!(queue as usize, *actual);
+        }
 
         // The `update_lock` atomic is used as a flag ensuring only a single
         // thread concurrently enters the `update` critical section. Any


### PR DESCRIPTION
It looks like registrations created with `new2` can end up causing segfaults due
to a use-after-free, and after tracking it down it looks like it's because a
`RegistrationInner` expects to have an owning reference to the underlying
readiness queue, but when we lazily initialize the `readiness_queue` field the
`new2` branch forgot to create an owning reference (unlike the `new` constructor
which does this).

This commit adds an appropriate `mem::forget` to transfer ownership of the
reference count.