### PR TITLE
Move TCP & UDP types into `net` module.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,8 @@ pub use iovec::IoVec;
 #[cfg(feature = "with-deprecated")]
 #[doc(hidden)]
 pub mod tcp {
-    pub use net::{TcpListener, TcpStream, Shutdown};
+    pub use net::{TcpListener, TcpStream};
+    pub use std::net::Shutdown;
 }
 
 #[deprecated(since = "0.6.6", note = "use net module instead")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,10 +105,11 @@ extern crate env_logger;
 
 mod event_imp;
 mod io;
-mod net;
 mod poll;
 mod sys;
 mod token;
+
+pub mod net;
 
 #[deprecated(since = "0.6.5", note = "use mio-more instead")]
 #[cfg(feature = "with-deprecated")]
@@ -130,10 +131,18 @@ pub mod deprecated;
 #[doc(hidden)]
 pub use iovec::IoVec;
 
-pub use net::{
-    tcp,
-    udp,
-};
+#[deprecated(since = "0.6.6", note = "use net module instead")]
+#[cfg(feature = "with-deprecated")]
+#[doc(hidden)]
+pub mod tcp {
+    pub use net::{TcpListener, TcpStream, Shutdown};
+}
+
+#[deprecated(since = "0.6.6", note = "use net module instead")]
+#[cfg(feature = "with-deprecated")]
+#[doc(hidden)]
+pub mod udp;
+
 pub use poll::{
     Poll,
     Registration,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -10,5 +10,5 @@
 mod tcp;
 mod udp;
 
-pub use self::tcp::{TcpListener, TcpStream, Shutdown};
+pub use self::tcp::{TcpListener, TcpStream};
 pub use self::udp::UdpSocket;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,41 +1,14 @@
 //! Networking primitives
 //!
-pub mod tcp;
-pub mod udp;
+//! The types provided in this module are non-blocking by default and are
+//! designed to be portable across all supported Mio platforms. As long as the
+//! [portability guidelines] are followed, the behavior should be identical no
+//! matter the target platform.
+//!
+//! [portability guidelines]: ../struct.Poll.html#portability
 
-use {poll, Poll};
-use std::io;
-use std::sync::atomic::{AtomicUsize, Ordering};
+mod tcp;
+mod udp;
 
-/// Used to associate an IO type with a Selector
-#[derive(Debug)]
-struct SelectorId {
-    id: AtomicUsize,
-}
-
-impl SelectorId {
-    fn new() -> SelectorId {
-        SelectorId {
-            id: AtomicUsize::new(0),
-        }
-    }
-
-    fn associate_selector(&self, poll: &Poll) -> io::Result<()> {
-        let selector_id = self.id.load(Ordering::SeqCst);
-
-        if selector_id != 0 && selector_id != poll::selector(poll).id() {
-            Err(io::Error::new(io::ErrorKind::Other, "socket already registered"))
-        } else {
-            self.id.store(poll::selector(poll).id(), Ordering::SeqCst);
-            Ok(())
-        }
-    }
-}
-
-impl Clone for SelectorId {
-    fn clone(&self) -> SelectorId {
-        SelectorId {
-            id: AtomicUsize::new(self.id.load(Ordering::SeqCst)),
-        }
-    }
-}
+pub use self::tcp::{TcpListener, TcpStream, Shutdown};
+pub use self::udp::UdpSocket;

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -16,7 +16,7 @@ use iovec::IoVec;
 
 use {io, sys, Ready, Poll, PollOpt, Token};
 use event::Evented;
-use super::SelectorId;
+use poll::SelectorId;
 
 /*
  *

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -56,7 +56,7 @@ pub struct TcpStream {
     selector_id: SelectorId,
 }
 
-pub use std::net::Shutdown;
+use std::net::Shutdown;
 
 impl TcpStream {
     /// Create a new TCP stream and issue a non-blocking connect to the

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,6 +1,5 @@
 use {io, Ready, Poll, PollOpt, Token};
 use event::Evented;
-use io::MapNonBlock;
 use unix::EventedFd;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::io::{RawFd, IntoRawFd, AsRawFd, FromRawFd};
@@ -33,31 +32,23 @@ impl UdpSocket {
         })
     }
 
-    pub fn send_to(&self, buf: &[u8], target: &SocketAddr)
-                   -> io::Result<Option<usize>> {
+    pub fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
         self.io.send_to(buf, target)
-            .map_non_block()
     }
 
-    pub fn recv_from(&self, buf: &mut [u8])
-                     -> io::Result<Option<(usize, SocketAddr)>> {
+    pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.io.recv_from(buf)
-            .map_non_block()
     }
 
-    pub fn send(&self, buf: &[u8])
-                   -> io::Result<Option<usize>> {
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
         self.io.send(buf)
-            .map_non_block()
     }
 
-    pub fn recv(&self, buf: &mut [u8])
-                     -> io::Result<Option<usize>> {
+    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.io.recv(buf)
-            .map_non_block()
     }
 
-    pub fn connect(&self, addr: SocketAddr) 
+    pub fn connect(&self, addr: SocketAddr)
                      -> io::Result<()> {
         self.io.connect(addr)
     }

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -1,14 +1,13 @@
 use std::fmt;
 use std::io::{self, Read, ErrorKind};
 use std::mem;
-use std::net::{self, SocketAddr};
+use std::net::{self, SocketAddr, Shutdown};
 use std::os::windows::prelude::*;
 use std::sync::{Mutex, MutexGuard};
 
 use miow::iocp::CompletionStatus;
 use miow::net::*;
 use net2::{TcpBuilder, TcpStreamExt as Net2TcpExt};
-use net::tcp::Shutdown;
 use winapi::*;
 use iovec::IoVec;
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -7,6 +7,8 @@
 //!
 /// [portability guidelines]: ../struct.Poll.html#portability
 
+#![allow(deprecated)]
+
 use {sys, Ready, Poll, PollOpt, Token};
 use io::{self, MapNonBlock};
 use event::Evented;

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -5,7 +5,7 @@
 //! [portability guidelines] are followed, the behavior should be identical no
 //! matter the target platform.
 //!
-/// [portability guidelines]: ../struct.Poll.html#portability
+//! [portability guidelines]: ../struct.Poll.html#portability
 
 #![allow(deprecated)]
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -7,7 +7,8 @@
 //!
 /// [portability guidelines]: ../struct.Poll.html#portability
 
-use {io, sys, Ready, Poll, PollOpt, Token};
+use {sys, Ready, Poll, PollOpt, Token};
+use io::{self, MapNonBlock};
 use event::Evented;
 use poll::SelectorId;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -72,14 +73,16 @@ impl UdpSocket {
     ///
     /// Address type can be any implementor of `ToSocketAddrs` trait. See its
     /// documentation for concrete examples.
-    pub fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
-        self.sys.send_to(buf, target)
+    pub fn send_to(&self, buf: &[u8], target: &SocketAddr)
+                   -> io::Result<Option<usize>> {
+        self.sys.send_to(buf, target).map_non_block()
     }
 
     /// Receives data from the socket. On success, returns the number of bytes
     /// read and the address from whence the data came.
-    pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
-        self.sys.recv_from(buf)
+    pub fn recv_from(&self, buf: &mut [u8])
+                     -> io::Result<Option<(usize, SocketAddr)>> {
+        self.sys.recv_from(buf).map_non_block()
     }
 
     /// Sends data on the socket to the address previously bound via connect(). On success,
@@ -87,20 +90,23 @@ impl UdpSocket {
     ///
     /// Address type can be any implementor of `ToSocketAddrs` trait. See its
     /// documentation for concrete examples.
-    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        self.sys.send(buf)
+    pub fn send(&self, buf: &[u8])
+                   -> io::Result<Option<usize>> {
+        self.sys.send(buf).map_non_block()
     }
 
     /// Receives data from the socket previously bound with connect(). On success, returns
     /// the number of bytes read and the address from whence the data came.
-    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.sys.recv(buf)
+    pub fn recv(&self, buf: &mut [u8])
+                     -> io::Result<Option<usize>> {
+        self.sys.recv(buf).map_non_block()
     }
 
-    /// Connects the UDP socket setting the default destination for `send()`
+    /// Connects the UDP socket setting the default destination for `send()` 
     /// and limiting packets that are read via `recv` from the address specified
     /// in `addr`.
-    pub fn connect(&self, addr: SocketAddr) -> io::Result<()> {
+    pub fn connect(&self, addr: SocketAddr)
+                 -> io::Result<()> {
         self.sys.connect(addr)
     }
 
@@ -301,4 +307,3 @@ impl FromRawFd for UdpSocket {
         }
     }
 }
-


### PR DESCRIPTION
Motivation for this is twofold.

1) Mirror the layout in `std`
2) Fix UDP API without breaking backwards compatibility.