### PR TITLE
kqueue: Ignore EPIPE coming out of `kevent`

### DIFF
--- a/test/test_broken_pipe.rs
+++ b/test/test_broken_pipe.rs
@@ -19,8 +19,8 @@ pub fn broken_pipe() {
     let mut event_loop: EventLoop<BrokenPipeHandler> = EventLoop::new().unwrap();
     let (reader, _) = unix::pipe().unwrap();
 
-    // On Darwin this returns a "broken pipe" error.
-    let _ = event_loop.register(&reader, Token(1), Ready::all(), PollOpt::edge());
+    event_loop.register(&reader, Token(1), Ready::all(), PollOpt::edge())
+              .unwrap();
 
     let mut handler = BrokenPipeHandler;
     drop(reader);


### PR DESCRIPTION
This commit updates mio to ignore `EPIPE` coming out of `kevent`. It
turns out that older versions of OSX (10.10 and 10.11 have been
confirmed) will return an `EPIPE` when registering one half of a pipe
where the other half has been closed. On other platforms this is an ok
operation which just returns that the pipe is readable/writable (to
return an error/eof), so this brings the OSX behavior in line by
ignoring the error and moving to the next event.

Closes #582

This is a dup of #583... but appveyor is stuck, so I have no idea what else to do :(