### PR TITLE
POSIX AIO support

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -543,10 +543,10 @@ impl fmt::Debug for PollOpt {
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct Ready(usize);
 
-const READABLE: usize = 0b0001;
-const WRITABLE: usize = 0b0010;
-const ERROR: usize    = 0b0100;
-const HUP: usize      = 0b1000;
+const READABLE: usize = 0b00001;
+const WRITABLE: usize = 0b00010;
+const ERROR: usize    = 0b00100;
+const HUP: usize      = 0b01000;
 
 impl Ready {
     /// Returns the empty `Ready` set.
@@ -860,6 +860,7 @@ impl ops::Not for Ready {
     }
 }
 
+// TODO: impl Debug for UnixReady
 impl fmt::Debug for Ready {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut one = false;

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -1,4 +1,5 @@
 #![allow(deprecated)]
+use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use std::time::Duration;
@@ -182,6 +183,12 @@ fn ioevent_to_epoll(interest: Ready, opts: PollOpt) -> u32 {
     }
 
     kind as u32
+}
+
+impl AsRawFd for Selector {
+    fn as_raw_fd(&self) -> RawFd {
+        self.epfd
+    }
 }
 
 impl Drop for Selector {

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -313,3 +313,14 @@ fn does_not_register_rw() {
     evtloop.register(&kqf, Token(1234), Ready::readable(),
                      PollOpt::edge() | PollOpt::oneshot()).unwrap();
 }
+
+#[cfg(any(target_os = "dragonfly",
+    target_os = "freebsd", target_os = "ios", target_os = "macos"))]
+#[test]
+fn test_coalesce_aio() {
+    let mut events = Events::with_capacity(1);
+    events.sys_events.0.push(kevent!(0x1234, libc::EVFILT_AIO, 0, 42));
+    events.coalesce(Token(0));
+    assert!(events.events[0].readiness() == UnixReady::aio().into());
+    assert!(events.events[0].token() == Token(42));
+}

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -84,10 +84,31 @@ use std::ops;
 #[derive(Debug, Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct UnixReady(Ready);
 
-const ERROR: usize = 0b0100;
-const HUP: usize   = 0b1000;
+const ERROR: usize = 0b00100;
+const HUP: usize   = 0b01000;
+const AIO: usize   = 0b10000;
 
 impl UnixReady {
+    /// Returns a `Ready` representing AIO completion readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::unix::UnixReady;
+    ///
+    /// let ready = UnixReady::aio();
+    ///
+    /// assert!(ready.is_aio());
+    /// ```
+    ///
+    /// [`Poll`]: struct.Poll.html
+    #[inline]
+    pub fn aio() -> UnixReady {
+        UnixReady(ready_from_usize(AIO))
+    }
+
     /// Returns a `Ready` representing error readiness.
     ///
     /// **Note that only readable and writable readiness is guaranteed to be
@@ -141,6 +162,24 @@ impl UnixReady {
     #[inline]
     pub fn hup() -> UnixReady {
         UnixReady(ready_from_usize(HUP))
+    }
+
+    /// Returns true if `Ready` contains AIO readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::unix::UnixReady;
+    ///
+    /// let ready = UnixReady::aio();
+    ///
+    /// assert!(ready.is_aio());
+    /// ```
+    #[inline]
+    pub fn is_aio(&self) -> bool {
+        self.contains(ready_from_usize(AIO))
     }
 
     /// Returns true if the value includes error readiness


### PR DESCRIPTION
On BSD-based operating systems, add low-level support for queuing AIO
operations in the event loop.  This commit adds 3 new public methods:
UnixReady::aio, UnixReady::is_aio, and Poll.as_raw_fd.  Full support
will be added in a separate crate.

This PR is a rebase of and replaces #558 