### PR TITLE
Doc: typo: an Poll => a Poll

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! # Usage
 //!
-//! Using mio starts by creating an [Poll], which reads events from the OS and
+//! Using mio starts by creating a [Poll], which reads events from the OS and
 //! put them into [`Events`]. You can handle IO events from the OS with it.
 //!
 //! For more detail, see [`Poll`].
@@ -36,7 +36,7 @@
 //! // Setup the server socket
 //! let server = TcpListener::bind(&addr).unwrap();
 //!
-//! // Create an poll instance
+//! // Create a poll instance
 //! let poll = Poll::new().unwrap();
 //!
 //! // Start listening for incoming connections

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -155,7 +155,7 @@ impl Binding {
     /// Creates a new blank binding ready to be inserted into an I/O
     /// object.
     ///
-    /// Won't actually do anything until associated with an `Poll` loop.
+    /// Won't actually do anything until associated with a `Poll` loop.
     pub fn new() -> Binding {
         Binding { selector: AtomicLazyCell::new() }
     }


### PR DESCRIPTION
Hi,

This fixes a typo, I don't know if there are others but this is the only one that came up to me while reading the main page of the doc (english being not my native language).

:-)