### PR TITLE
Fix usage of O_CLOEXEC in SETFL

### DIFF
--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -18,7 +18,7 @@ pub fn set_nonblock(fd: libc::c_int) -> io::Result<()> {
 
 pub fn set_cloexec(fd: libc::c_int) -> io::Result<()> {
     unsafe {
-        let flags = libc::fcntl(fd, libc::F_GETFL);
+        let flags = libc::fcntl(fd, libc::F_GETFD);
         cvt(libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC)).map(|_| ())
     }
 }

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -19,7 +19,7 @@ pub fn set_nonblock(fd: libc::c_int) -> io::Result<()> {
 pub fn set_cloexec(fd: libc::c_int) -> io::Result<()> {
     unsafe {
         let flags = libc::fcntl(fd, libc::F_GETFL);
-        cvt(libc::fcntl(fd, libc::F_SETFL, flags | libc::O_CLOEXEC)).map(|_| ())
+        cvt(libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC)).map(|_| ())
     }
 }
 


### PR DESCRIPTION
Fixes potential bug introduced in previous PR [#595](https://github.com/carllerche/mio/pull/595).

From SETFL man page: "On Linux this command  can  change  only  the  O_APPEND,  O_ASYNC, O_DIRECT, O_NOATIME, and O_NONBLOCK flags"

Sorry for this :)

@raphlinus knows more about our mio effort