### PR TITLE
Fix handling of failed TCP connections on windows

### DIFF
--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -538,5 +538,5 @@ fn connection_reset_by_peer() {
          }
      }
 
-     assert!(l.take_error().unwrap().is_some());
+     assert_eq!(l.take_error().unwrap().unwrap().kind(), io::ErrorKind::ConnectionRefused);
  }


### PR DESCRIPTION
Previously, mio unconditionally called setsockopt after a TCP connection attempt completed. If the connection had failed, this resulted in a WSAENOTCONN error being yielded in place of the actual error.

~~This PR depends on https://github.com/alexcrichton/miow/pull/10.~~