### PR TITLE
Initial Emscripten websocket support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ iovec    = "0.1.0"
 [target.'cfg(unix)'.dependencies]
 libc   = "0.2.19"
 
+[target.'cfg(target_os="emscripten")'.dependencies]
+lazy_static = "0.2"
+
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.1"
 miow   = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ default = ["with-deprecated"]
 lazycell = "0.4.0"
 log      = "0.3.1"
 slab     = "0.3.0"
-net2     = "0.2.29"
+net2 = { git = "https://github.com/rust-lang-nursery/net2-rs.git", rev="80f1bd17" }
 iovec    = "0.1.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,10 @@ extern crate iovec;
 #[cfg(unix)]
 extern crate libc;
 
+#[cfg(target_os="emscripten")]
+#[macro_use]
+extern crate lazy_static;
+
 #[cfg(windows)]
 extern crate miow;
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -12,7 +12,10 @@ mod tcp;
 #[cfg(not(target_os="emscripten"))]
 mod udp;
 
-pub use self::tcp::{TcpListener, TcpStream};
+#[cfg(not(target_os="emscripten"))]
+pub use self::tcp::TcpListener;
+
+pub use self::tcp::TcpStream;
 
 #[cfg(not(target_os="emscripten"))]
 pub use self::udp::UdpSocket;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -8,7 +8,11 @@
 //! [portability guidelines]: ../struct.Poll.html#portability
 
 mod tcp;
+
+#[cfg(not(target_os="emscripten"))]
 mod udp;
 
 pub use self::tcp::{TcpListener, TcpStream};
+
+#[cfg(not(target_os="emscripten"))]
 pub use self::udp::UdpSocket;

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -445,12 +445,14 @@ impl Evented for TcpStream {
 ///
 /// // There may be a socket ready to be accepted
 /// ```
+#[cfg(not(target_os="emscripten"))]
 #[derive(Debug)]
 pub struct TcpListener {
     sys: sys::TcpListener,
     selector_id: SelectorId,
 }
 
+#[cfg(not(target_os="emscripten"))]
 impl TcpListener {
     /// Convenience method to bind a new TCP listener to the specified address
     /// to receive new connections.
@@ -595,6 +597,7 @@ impl TcpListener {
     }
 }
 
+#[cfg(not(target_os="emscripten"))]
 impl Evented for TcpListener {
     fn register(&self, poll: &Poll, token: Token,
                 interest: Ready, opts: PollOpt) -> io::Result<()> {
@@ -645,21 +648,21 @@ impl FromRawFd for TcpStream {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os="emscripten")))]
 impl IntoRawFd for TcpListener {
     fn into_raw_fd(self) -> RawFd {
         self.sys.into_raw_fd()
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os="emscripten")))]
 impl AsRawFd for TcpListener {
     fn as_raw_fd(&self) -> RawFd {
         self.sys.as_raw_fd()
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os="emscripten")))]
 impl FromRawFd for TcpListener {
     unsafe fn from_raw_fd(fd: RawFd) -> TcpListener {
         TcpListener {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -3,9 +3,9 @@ use event_imp::{self as event, Ready, Event, Evented, PollOpt};
 use std::{fmt, io, ptr, usize};
 use std::cell::UnsafeCell;
 use std::{mem, ops, isize};
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os="emscripten")))]
 use std::os::unix::io::AsRawFd;
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os="emscripten")))]
 use std::os::unix::io::RawFd;
 use std::sync::{Arc, Mutex, Condvar};
 use std::sync::atomic::{AtomicUsize, AtomicPtr, AtomicBool};
@@ -1138,7 +1138,7 @@ impl fmt::Debug for Poll {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os="emscripten")))]
 impl AsRawFd for Poll {
     fn as_raw_fd(&self) -> RawFd {
         self.selector.as_raw_fd()
@@ -2519,7 +2519,7 @@ impl Clone for SelectorId {
 }
 
 #[test]
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os="emscripten")))]
 pub fn as_raw_fd() {
     let poll = Poll::new().unwrap();
     assert!(poll.as_raw_fd() > 0);

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -7,13 +7,13 @@ pub use self::unix::{
     Selector,
     TcpStream,
     TcpListener,
-    UdpSocket,
     set_nonblock,
 };
 
 #[cfg(all(unix, not(target_os="emscripten")))]
 pub use self::unix::{
     pipe,
+    UdpSocket,
 };
 
 #[cfg(unix)]

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -6,13 +6,13 @@ pub use self::unix::{
     Io,
     Selector,
     TcpStream,
-    TcpListener,
     set_nonblock,
 };
 
 #[cfg(all(unix, not(target_os="emscripten")))]
 pub use self::unix::{
     pipe,
+    TcpListener,
     UdpSocket,
 };
 

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -8,8 +8,12 @@ pub use self::unix::{
     TcpStream,
     TcpListener,
     UdpSocket,
-    pipe,
     set_nonblock,
+};
+
+#[cfg(all(unix, not(target_os="emscripten")))]
+pub use self::unix::{
+    pipe,
 };
 
 #[cfg(unix)]

--- a/src/sys/unix/awakener.rs
+++ b/src/sys/unix/awakener.rs
@@ -1,6 +1,8 @@
+#[cfg(not(target_os="emscripten"))]
 pub use self::pipe::Awakener;
 
 /// Default awakener backed by a pipe
+#[cfg(not(target_os="emscripten"))]
 mod pipe {
     use sys::unix;
     use {io, Ready, Poll, PollOpt, Token};
@@ -69,6 +71,44 @@ mod pipe {
 
         fn deregister(&self, poll: &Poll) -> io::Result<()> {
             self.reader().deregister(poll)
+        }
+    }
+}
+
+#[cfg(target_os="emscripten")]
+pub use self::stub::Awakener;
+
+#[cfg(target_os="emscripten")]
+mod stub {
+    use {io, Ready, Poll, PollOpt, Token};
+    use event::Evented;
+
+    pub struct Awakener {}
+
+    impl Awakener {
+        pub fn new() -> io::Result<Awakener> {
+            Ok(Awakener{})
+        }
+
+        pub fn wakeup(&self) -> io::Result<()> {
+            Ok(())
+        }
+
+        pub fn cleanup(&self) {
+        }
+    }
+
+    impl Evented for Awakener {
+        fn register(&self, _poll: &Poll, _token: Token, _interest: Ready, _opts: PollOpt) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn reregister(&self, _poll: &Poll, _token: Token, _interest: Ready, _opts: PollOpt) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn deregister(&self, _poll: &Poll) -> io::Result<()> {
+            Ok(())
         }
     }
 }

--- a/src/sys/unix/emscripten.rs
+++ b/src/sys/unix/emscripten.rs
@@ -1,0 +1,254 @@
+use std;
+use std::collections::vec_deque::VecDeque;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int, c_void};
+use std::os::unix::io::RawFd;
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use {io, Ready, PollOpt, Token};
+use event_imp::Event;
+
+static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+
+#[derive(Debug)]
+struct EmRegistration {
+    token: Token,
+    interests: Ready,
+    opts: PollOpt,
+}
+
+#[derive(Debug)]
+pub struct Selector {
+    id: usize,
+    // Note: can't have any references
+}
+
+lazy_static! {
+    static ref EM_REGS   : Mutex<Vec<Option<EmRegistration>>> = Mutex::new(Vec::new());
+    static ref EM_EVENTS : Mutex<Option<VecDeque<Event>>> = Mutex::new(None);
+}
+
+impl Selector {
+    pub fn new() -> io::Result<Selector> {
+        // Create a queue to receive events for registered fds
+        let mut events = EM_EVENTS.lock().unwrap();
+        if events.is_some() {
+            // TODO: support multiple Selector queues
+            return Err(io::Error::new(io::ErrorKind::AlreadyExists, "Only 1 Selector supported"));
+        }
+        *events = Some(VecDeque::new());
+
+        // Register socket callback handlers with Emscripten runtime
+        // Note: Only one set of handlers can be registered at a time
+        // https://kripken.github.io/emscripten-site/docs/api_reference/emscripten.h.html#socket-event-registration
+        let data_ptr = std::ptr::null();
+        unsafe {
+            emscripten_set_socket_error_callback(data_ptr, error_callback);
+            emscripten_set_socket_open_callback(data_ptr, open_callback);
+            //emscripten_set_socket_listen_callback(data_ptr, listen_callback);
+            //emscripten_set_socket_connection_callback(data_ptr, connection_callback);
+            emscripten_set_socket_message_callback(data_ptr, message_callback);
+            //emscripten_set_socket_close_callback(data_ptr, close_callback);
+        }
+
+        // offset by 1 to avoid choosing 0 as the id of a selector
+        Ok(Selector { id: NEXT_ID.fetch_add(1, Ordering::Relaxed) + 1 })
+    }
+
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
+    /// Wait for events from the OS
+    pub fn select(&self,
+                  evts: &mut Events,
+                  _awakener: Token,
+                  _timeout: Option<Duration>)
+                  -> io::Result<bool> {
+        // Note: Emscripten is single threaded so the callbacks are envoked from the
+        // main thread.  This means waiting for the timeout to expire is pointless.
+        // https://kripken.github.io/emscripten-site/docs/porting/emscripten-runtime-environment.html#browser-main-loop
+
+        unsafe {
+            evts.events.set_len(0);
+        }
+
+        if let Some(ref mut events) = *EM_EVENTS.lock().unwrap() {
+            let num_events = std::cmp::min(events.len(), evts.capacity());
+            for e in events.drain(..num_events) {
+                evts.push_event(e);
+            }
+        }
+
+        Ok(false) // False prevents awakener use
+    }
+
+    /// Register event interests for the given IO handle with emscripten
+    pub fn register(&self,
+                    fd: RawFd,
+                    token: Token,
+                    interests: Ready,
+                    opts: PollOpt)
+                    -> io::Result<()> {
+
+        // Note: Emscripten reuses file descriptors, so a vector to record registration
+        // details is a reasonable choice.
+        let i = fd as usize;
+        let mut regs = EM_REGS.lock().unwrap();
+        while regs.len() <= i {
+            regs.push(None)
+        }
+        regs[i] = Some(EmRegistration {
+                           token: token,
+                           interests: interests,
+                           opts: opts,
+                       });
+        Ok(())
+    }
+
+    /// Register event interests for the given IO handle with the OS
+    pub fn reregister(&self,
+                      fd: RawFd,
+                      token: Token,
+                      interests: Ready,
+                      opts: PollOpt)
+                      -> io::Result<()> {
+        self.register(fd, token, interests, opts)
+    }
+
+    /// Deregister event interests for the given IO handle with the OS
+    pub fn deregister(&self, fd: RawFd) -> io::Result<()> {
+        let i = fd as usize;
+        let mut regs = EM_REGS.lock().unwrap();
+        if i < regs.len() {
+            regs[i] = None;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Selector {
+    fn drop(&mut self) {
+        // TODO: if this is the last selector, unregister emscripten callbacks
+    }
+}
+
+pub struct Events {
+    events: Vec<Event>,
+}
+
+impl Events {
+    pub fn with_capacity(u: usize) -> Events {
+        Events { events: Vec::with_capacity(u) }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.events.capacity()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<Event> {
+        self.events.get(idx).cloned()
+    }
+
+    pub fn push_event(&mut self, event: Event) {
+        self.events.push(event);
+    }
+}
+
+// Emscripten runtime socket support
+// https://kripken.github.io/emscripten-site/docs/api_reference/emscripten.h.html#socket-event-registration
+
+#[allow(non_camel_case_types)]
+type userData = c_void;
+#[allow(non_camel_case_types)]
+type em_socket_callback = extern "C" fn(c_int, *mut userData);
+#[allow(non_camel_case_types)]
+type em_socket_error_callback = extern "C" fn(c_int, c_int, *const c_char, *mut userData);
+
+// Emscripten callback registration definitions
+extern "C" {
+    fn emscripten_set_socket_error_callback(data: *const userData, cb: em_socket_error_callback);
+    fn emscripten_set_socket_open_callback(data: *const userData, cb: em_socket_callback);
+    //fn emscripten_set_socket_listen_callback(data: *const userData, cb: em_socket_callback);
+    //fn emscripten_set_socket_connection_callback(data: *const userData, cb: em_socket_callback);
+    fn emscripten_set_socket_message_callback(data: *const userData, cb: em_socket_callback);
+    //fn emscripten_set_socket_close_callback(data: *const userData, cb: em_socket_callback);
+}
+
+// Triggered by a WebSocket error
+extern "C" fn error_callback(fd: c_int, err: c_int, msg: *const c_char, _data: *mut userData) {
+    let err_msg;
+    unsafe {
+        err_msg = CStr::from_ptr(msg);
+    }
+    println!("DEBUG: error callback ({} {}): {:?}", fd, err, err_msg);
+}
+
+// Triggered when the WebSocket has opened
+extern "C" fn open_callback(fd: c_int, _data: *mut userData) {
+    let mut token = None;
+    let mut writable = false;
+    {
+        let regs = EM_REGS.lock().unwrap();
+        if let Some(ref reg) = regs[fd as usize] {
+            token = Some(reg.token);
+            writable = reg.interests.is_writable();
+        }
+    }
+
+    if writable {
+        let mut queue = EM_EVENTS.lock().unwrap();
+        if let Some(ref mut queue) = *queue {
+            queue.push_back(Event::new(Ready::writable(), token.unwrap()));
+        }
+    }
+}
+
+// Triggered when listen has been called (synthetic event)
+//extern "C" fn listen_callback(fd: c_int, _data: *mut userData) {
+//    println!("DEBUG: listen callback ({})", fd);
+//}
+
+// Triggered when the connection has been established
+//extern "C" fn connection_callback(fd: c_int, _data: *mut userData) {
+//    println!("DEBUG: connection callback ({})", fd);
+//}
+
+// Triggered when data is available to be read from the socket
+extern "C" fn message_callback(fd: c_int, _data: *mut userData) {
+    let mut token = None;
+    let mut readable = false;
+    {
+        let regs = EM_REGS.lock().unwrap();
+        if let Some(ref reg) = regs[fd as usize] {
+            token = Some(reg.token);
+            readable = reg.interests.is_readable();
+        }
+    }
+
+    if readable {
+        let mut queue = EM_EVENTS.lock().unwrap();
+        if let Some(ref mut queue) = *queue {
+            queue.push_back(Event::new(Ready::readable(), token.unwrap()));
+        }
+    }
+}
+
+// Triggered when the WebSocket has closed
+//extern "C" fn close_callback(fd: c_int, _data: *mut userData) {
+//    println!("DEBUG: close callback ({})", fd);
+//}

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -16,6 +16,7 @@ pub fn set_nonblock(fd: libc::c_int) -> io::Result<()> {
     }
 }
 
+#[cfg(not(target_os="emscripten"))]
 pub fn set_cloexec(fd: libc::c_int) -> io::Result<()> {
     unsafe {
         let flags = libc::fcntl(fd, libc::F_GETFD);

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -1,5 +1,7 @@
+#[cfg(not(target_os="emscripten"))]
 use libc::{self, c_int};
 
+#[cfg(not(target_os="emscripten"))]
 #[macro_use]
 pub mod dlsym;
 
@@ -41,8 +43,10 @@ pub use self::uds::UnixSocket;
 
 pub use iovec::IoVec;
 
+#[cfg(not(target_os="emscripten"))]
 use std::os::unix::io::FromRawFd;
 
+#[cfg(not(target_os="emscripten"))]
 pub fn pipe() -> ::io::Result<(Io, Io)> {
     // Use pipe2 for atomically setting O_CLOEXEC if we can, but otherwise
     // just fall back to using `pipe`.

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -37,7 +37,10 @@ pub use self::awakener::Awakener;
 pub use self::eventedfd::EventedFd;
 pub use self::io::{Io, set_nonblock};
 pub use self::ready::UnixReady;
-pub use self::tcp::{TcpStream, TcpListener};
+pub use self::tcp::TcpStream;
+
+#[cfg(not(target_os="emscripten"))]
+pub use self::tcp::TcpListener;
 
 #[cfg(not(target_os="emscripten"))]
 pub use self::udp::UdpSocket;

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -26,6 +26,8 @@ mod eventedfd;
 mod io;
 mod ready;
 mod tcp;
+
+#[cfg(not(target_os="emscripten"))]
 mod udp;
 
 #[cfg(feature = "with-deprecated")]
@@ -36,6 +38,8 @@ pub use self::eventedfd::EventedFd;
 pub use self::io::{Io, set_nonblock};
 pub use self::ready::UnixReady;
 pub use self::tcp::{TcpStream, TcpListener};
+
+#[cfg(not(target_os="emscripten"))]
 pub use self::udp::UdpSocket;
 
 #[cfg(feature = "with-deprecated")]

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -21,6 +21,12 @@ mod kqueue;
           target_os = "netbsd", target_os = "openbsd"))]
 pub use self::kqueue::{Events, Selector};
 
+#[cfg(target_os = "emscripten")]
+mod emscripten;
+
+#[cfg(target_os = "emscripten")]
+pub use self::emscripten::{Events, Selector};
+
 mod awakener;
 mod eventedfd;
 mod io;

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -209,6 +209,7 @@ impl AsRawFd for TcpStream {
     }
 }
 
+#[cfg(not(target_os="emscripten"))]
 impl TcpListener {
     pub fn new(inner: net::TcpListener, _addr: &SocketAddr) -> io::Result<TcpListener> {
         try!(set_nonblock(inner.as_raw_fd()));


### PR DESCRIPTION
This set of changes provides basic backend support for running mio within the Emscripten runtime.  It still needs some polish but I wanted to get some feedback on the general approach.

Some general notes...

- Emscripten only supports creating TCP client connections.  As such I disabled the unsupported capability so builds would fail instead of failing at runtime.
- Userspace events should be possible but I haven't tried them yet.
- Logic to simulate edge/level triggering is needed.
- Only one Selector is currently supported
- I haven't done any work to try and support the test suite since the build outputs javascript that needs to run in the browser.  I'm curious what other Emscripten projects due.

I have a repo demonstrating this functionality at https://github.com/tones111/mio-example

Thanks for taking a look.