### PR TITLE
Remove unrelated documentation

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -84,9 +84,6 @@ impl UdpSocket {
 
     /// Sends data on the socket to the address previously bound via connect(). On success,
     /// returns the number of bytes written.
-    ///
-    /// Address type can be any implementor of `ToSocketAddrs` trait. See its
-    /// documentation for concrete examples.
     pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
         self.sys.send(buf)
     }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -89,9 +89,6 @@ impl UdpSocket {
 
     /// Sends data on the socket to the address previously bound via connect(). On success,
     /// returns the number of bytes written.
-    ///
-    /// Address type can be any implementor of `ToSocketAddrs` trait. See its
-    /// documentation for concrete examples.
     pub fn send(&self, buf: &[u8])
                    -> io::Result<Option<usize>> {
         self.sys.send(buf).map_non_block()


### PR DESCRIPTION
Remove the SockAddr part from the send() documentation that was copied
from send_to().