### PR TITLE
Consider adding support for reading into uninitialized buffers via the `buffer` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,12 @@ with-deprecated = []
 default = ["with-deprecated"]
 
 [dependencies]
+buffer   = "0.1.8"
+iovec    = "0.1.0"
 lazycell = "0.4.0"
 log      = "0.3.1"
-slab     = "0.3.0"
 net2     = "0.2.29"
-iovec    = "0.1.0"
+slab     = "0.3.0"
 
 [target.'cfg(unix)'.dependencies]
 libc   = "0.2.19"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,10 +80,11 @@
 
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
+extern crate buffer;
+extern crate iovec;
 extern crate lazycell;
 extern crate net2;
 extern crate slab;
-extern crate iovec;
 
 #[cfg(unix)]
 extern crate libc;

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -12,8 +12,9 @@ use std::io::{Read, Write};
 use std::net::{self, SocketAddr, SocketAddrV4, SocketAddrV6, Ipv4Addr, Ipv6Addr};
 use std::time::Duration;
 
-use net2::TcpBuilder;
+use buffer;
 use iovec::IoVec;
+use net2::TcpBuilder;
 
 use {io, sys, Ready, Poll, PollOpt, Token};
 use event::Evented;
@@ -379,6 +380,9 @@ impl<'a> Read for &'a TcpStream {
         (&self.sys).read(buf)
     }
 }
+
+unsafe impl buffer::ReadBufferMarker for TcpStream { }
+unsafe impl<'a> buffer::ReadBufferMarker for &'a TcpStream { }
 
 impl Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -90,7 +90,7 @@ impl UdpSocket {
         -> io::Result<(&'d [u8], SocketAddr)>
     {
         unsafe {
-            let (received, from) = self.recv_from(buf.uninitialized_mut())?;
+            let (received, from) = try!(self.recv_from(buf.uninitialized_mut()));
             buf.advance(received);
             Ok((buf.initialized(), from))
         }
@@ -124,7 +124,7 @@ impl UdpSocket {
         -> io::Result<&'d [u8]>
     {
         unsafe {
-            let received = self.recv(buf.uninitialized_mut())?;
+            let received = try!(self.recv(buf.uninitialized_mut()));
             buf.advance(received);
             Ok(buf.initialized())
         }


### PR DESCRIPTION
This will allow users of this library to receive data from the network
into uninitialized buffers, like an empty `ArrayVec` or a `Vec` with
remaining capacity.

See also https://www.reddit.com/r/rust/comments/6md04j/how_to_create_variable_length_byte_buffer/dk2hjmz/?context=3.

This is just a suggestion, what do you think about it?