### PR TITLE
Correct test target file path in iOS CI

### DIFF
--- a/ci/run-ios.sh
+++ b/ci/run-ios.sh
@@ -20,7 +20,7 @@ case "$TARGET" in
 
 
     # Find the file to run
-    TEST_FILE="$(find target/$TARGET/debug -maxdepth 1 -type f -name test-* | head -1)";
+    TEST_FILE="$(find $TARGET/debug -maxdepth 1 -type f -name test-* | head -1)";
 
     rustc -O ./ci/ios/deploy_and_run_on_ios_simulator.rs;
     ./deploy_and_run_on_ios_simulator $TEST_FILE;


### PR DESCRIPTION
There exists target file like `x86_64-apple-ios/debug/test-b4dc53cf1da916aa`, instead of `target/x86_64-apple-ios/debug/test-b4dc53cf1da916aa`.