### PR TITLE
Allow registration with empty interest

### DIFF
--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -93,15 +93,15 @@ pub fn test_register_deregister() {
 }
 
 #[test]
-pub fn test_register_with_no_readable_writable_is_error() {
+pub fn test_register_with_no_readable_writable_is_ok() {
     let poll = Poll::new().unwrap();
     let addr = localhost();
 
     let sock = TcpListener::bind(&addr).unwrap();
 
-    assert!(poll.register(&sock, Token(0), Ready::empty(), PollOpt::edge()).is_err());
+    poll.register(&sock, Token(0), Ready::empty(), PollOpt::edge()).unwrap();
 
-    poll.register(&sock, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.reregister(&sock, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
 
-    assert!(poll.reregister(&sock, Token(0), Ready::empty(), PollOpt::edge()).is_err());
+    poll.reregister(&sock, Token(0), Ready::empty(), PollOpt::edge()).unwrap();
 }

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -1,5 +1,6 @@
-use {localhost, TryWrite};
-use mio::*;
+use {expect_events, localhost, TryWrite};
+use mio::{Events, Poll, PollOpt, Ready, Token};
+use mio::event::Event;
 use mio::net::{TcpListener, TcpStream};
 use bytes::SliceBuf;
 use std::time::Duration;
@@ -93,15 +94,30 @@ pub fn test_register_deregister() {
 }
 
 #[test]
-pub fn test_register_with_no_readable_writable_is_ok() {
+pub fn test_register_empty_interest() {
     let poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(1024);
     let addr = localhost();
 
     let sock = TcpListener::bind(&addr).unwrap();
 
     poll.register(&sock, Token(0), Ready::empty(), PollOpt::edge()).unwrap();
 
+    let client = TcpStream::connect(&addr).unwrap();
+
+    // The connect is not guaranteed to have started until it is registered
+    // https://docs.rs/mio/0.6.10/mio/struct.Poll.html#registering-handles
+    poll.register(&client, Token(1), Ready::empty(), PollOpt::edge()).unwrap();
+
+    // sock is registered with empty interest, we should not receive any event
+    poll.poll(&mut events, Some(Duration::from_millis(100))).unwrap();
+    assert_eq!(events.len(), 0, "Received unexpected event: {:?}", events.get(0).unwrap());
+
+    // now sock is reregistered with readable, we should receive the pending event
     poll.reregister(&sock, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+    expect_events(&poll, &mut events, 2, vec![
+        Event::new(Ready::readable(), Token(0))
+    ]);
 
     poll.reregister(&sock, Token(0), Ready::empty(), PollOpt::edge()).unwrap();
 }


### PR DESCRIPTION
In order to temporarily disable event listening for a specific handle, it may be convenient to reregister it with an empty interest.

This avoids to temporarily deregister the handle before registering it again (which, by the way, [is not supported on Windows][1]).

Therefore, remove the check that prohibited registration with empty interest.

Note that ERROR and HUP may still be triggered in that case.

[1]: https://github.com/carllerche/mio/issues/633