### PR TITLE
Fix x86_64-android socklen_t in bind()

### DIFF
--- a/src/sys/unix/uds.rs
+++ b/src/sys/unix/uds.rs
@@ -122,7 +122,7 @@ impl UnixSocket {
     }
 
     /// Bind the socket to the specified address
-    #[cfg(not(all(target_arch = "aarch64",target_os = "android")))]
+    #[cfg(not(all(any(target_arch = "aarch64", target_arch = "x86_64"), target_os = "android")))]
     pub fn bind<P: AsRef<Path> + ?Sized>(&self, addr: &P) -> io::Result<()> {
         unsafe {
             let (addr, len) = sockaddr_un(addr.as_ref())?;
@@ -133,7 +133,7 @@ impl UnixSocket {
         }
     }
 
-    #[cfg(all(target_arch = "aarch64",target_os = "android"))]
+    #[cfg(all(any(target_arch = "aarch64", target_arch = "x86_64"), target_os = "android"))]
     pub fn bind<P: AsRef<Path> + ?Sized>(&self, addr: &P) -> io::Result<()> {
         unsafe {
             let (addr, len) = sockaddr_un(addr.as_ref())?;


### PR DESCRIPTION
https://travis-ci.org/rust-lang-nursery/rustup.rs/jobs/263713429#L1612

x86_64-linux-android also uses u32 for socklen_t, for whatever reason.