### PR TITLE
Have consistent debug representation for opaque structs.

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -888,7 +888,6 @@ impl ops::Not for Ready {
     }
 }
 
-// TODO: impl Debug for UnixReady
 impl fmt::Debug for Ready {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut one = false;
@@ -897,8 +896,6 @@ impl fmt::Debug for Ready {
             (Ready::writable(), "Writable"),
             (Ready(ERROR), "Error"),
             (Ready(HUP), "Hup")];
-
-        write!(fmt, "Ready {{")?;
 
         for &(flag, msg) in &flags {
             if self.contains(flag) {
@@ -909,7 +906,9 @@ impl fmt::Debug for Ready {
             }
         }
 
-        write!(fmt, "}}")?;
+        if !one {
+            fmt.write_str("(empty)")?;
+        }
 
         Ok(())
     }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1139,7 +1139,8 @@ fn validate_args(token: Token, interest: Ready) -> io::Result<()> {
 
 impl fmt::Debug for Poll {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "Poll")
+        fmt.debug_struct("Poll")
+            .finish()
     }
 }
 
@@ -1623,7 +1624,8 @@ impl SetReadiness {
 
 impl fmt::Debug for SetReadiness {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "SetReadiness")
+        f.debug_struct("SetReadiness")
+            .finish()
     }
 }
 

--- a/src/sys/fuchsia/selector.rs
+++ b/src/sys/fuchsia/selector.rs
@@ -348,6 +348,8 @@ impl Events {
 
 impl fmt::Debug for Events {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "Events {{ len: {} }}", self.len())
+        fmt.debug_struct("Events")
+            .field("len", self.len())
+            .finish()
     }
 }

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -320,7 +320,9 @@ impl Events {
 
 impl fmt::Debug for Events {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "Events {{ len: {} }}", self.sys_events.0.len())
+        fmt.debug_struct("Events")
+            .field("len", &self.sys_events.0.len())
+            .finish()
     }
 }
 

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -1,6 +1,7 @@
 use event_imp::{Ready, ready_from_usize};
 
 use std::ops;
+use std::fmt;
 
 /// Unix specific extensions to `Ready`
 ///
@@ -81,7 +82,7 @@ use std::ops;
 ///
 /// [`Poll`]: struct.Poll.html
 /// [readiness]: struct.Poll.html#readiness-operations
-#[derive(Debug, Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
+#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct UnixReady(Ready);
 
 const ERROR: usize = 0b00100;
@@ -304,5 +305,32 @@ impl ops::Not for UnixReady {
     #[inline]
     fn not(self) -> UnixReady {
         (!self.0).into()
+    }
+}
+
+impl fmt::Debug for UnixReady {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let mut one = false;
+        let flags = [
+            (UnixReady(Ready::readable()), "Readable"),
+            (UnixReady(Ready::writable()), "Writable"),
+            (UnixReady::error(), "Error"),
+            (UnixReady::hup(), "Hup"),
+            (UnixReady::aio(), "Aio")];
+
+        for &(flag, msg) in &flags {
+            if self.contains(flag) {
+                if one { write!(fmt, " | ")? }
+                write!(fmt, "{}", msg)?;
+
+                one = true
+            }
+        }
+
+        if !one {
+            fmt.write_str("(empty)")?;
+        }
+
+        Ok(())
     }
 }

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -270,7 +270,8 @@ impl Binding {
 
 impl fmt::Debug for Binding {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Binding")
+        f.debug_struct("Binding")
+            .finish()
     }
 }
 
@@ -517,7 +518,8 @@ impl Overlapped {
 
 impl fmt::Debug for Overlapped {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Overlapped")
+        f.debug_struct("Overlapped")
+            .finish()
     }
 }
 

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -586,7 +586,8 @@ impl Evented for TcpStream {
 
 impl fmt::Debug for TcpStream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        "TcpStream { ... }".fmt(f)
+        f.debug_struct("TcpStream")
+            .finish()
     }
 }
 
@@ -796,7 +797,8 @@ impl Evented for TcpListener {
 
 impl fmt::Debug for TcpListener {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        "TcpListener { ... }".fmt(f)
+        f.debug_struct("TcpListener")
+            .finish()
     }
 }
 

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -357,7 +357,8 @@ impl Evented for UdpSocket {
 
 impl fmt::Debug for UdpSocket {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        "UdpSocket { ... }".fmt(f)
+        f.debug_struct("UdpSocket")
+            .finish()
     }
 }
 


### PR DESCRIPTION
Fixes #671.
Fixes #670.
Fixes #672.