### PR TITLE
Remove uses of deprecated iovec re-export.

### DIFF
--- a/test/mod.rs
+++ b/test/mod.rs
@@ -7,6 +7,7 @@ extern crate net2;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
+extern crate iovec;
 extern crate slab;
 extern crate tempdir;
 

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -12,7 +12,8 @@ use std::time::Duration;
 use net2::{self, TcpStreamExt};
 
 use {TryRead, TryWrite};
-use mio::{Token, Ready, PollOpt, Poll, Events, IoVec};
+use mio::{Token, Ready, PollOpt, Poll, Events};
+use iovec::IoVec;
 use mio::deprecated::{EventLoop, Handler};
 use mio::tcp::{TcpListener, TcpStream};
 


### PR DESCRIPTION
#655 