### PR TITLE
Remove deprecated uses of hup.

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -816,7 +816,6 @@ impl Ready {
     ///
     /// assert!(!Ready::readable().contains(readiness));
     /// assert!(readiness.contains(readiness));
-    /// assert!((readiness | Ready::hup()).contains(readiness));
     /// ```
     ///
     /// [`Poll`]: struct.Poll.html

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -60,7 +60,7 @@ impl TestHandler {
             }
             _ => panic!("received unknown token {:?}", tok)
         }
-        poll.reregister(&self.cli, CLIENT, Ready::readable() | Ready::hup(), PollOpt::edge()).unwrap();
+        poll.reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge()).unwrap();
     }
 
     fn handle_write(&mut self, poll: &mut Poll, tok: Token, _: Ready) {
@@ -68,7 +68,7 @@ impl TestHandler {
             SERVER => panic!("received writable for token 0"),
             CLIENT => {
                 debug!("client connected");
-                poll.reregister(&self.cli, CLIENT, Ready::readable() | Ready::hup(), PollOpt::edge()).unwrap();
+                poll.reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge()).unwrap();
             }
             _ => panic!("received unknown token {:?}", tok)
         }

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -26,7 +26,7 @@ impl EchoConn {
             buf: None,
             mut_buf: Some(ByteBuf::mut_with_capacity(2048)),
             token: None,
-            interest: Ready::hup()
+            interest: Ready::empty(),
         }
     }
 

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -99,9 +99,9 @@ pub fn test_register_with_no_readable_writable_is_error() {
 
     let sock = TcpListener::bind(&addr).unwrap();
 
-    assert!(poll.register(&sock, Token(0), Ready::hup(), PollOpt::edge()).is_err());
+    assert!(poll.register(&sock, Token(0), Ready::empty(), PollOpt::edge()).is_err());
 
     poll.register(&sock, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
 
-    assert!(poll.reregister(&sock, Token(0), Ready::hup(), PollOpt::edge()).is_err());
+    assert!(poll.reregister(&sock, Token(0), Ready::empty(), PollOpt::edge()).is_err());
 }


### PR DESCRIPTION
I'm not sure if these are the best changes, but the docs say that hup is an optimization, so removing it should be safe.