### PR TITLE
Fix broken links

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -21,9 +21,9 @@ use std::{fmt, io, ops};
 /// [`Registration`] and [`SetReadiness`]. In this case, the implementer takes
 /// responsibility for driving the readiness state changes.
 ///
-/// [`Poll`]: struct.Poll.html
-/// [`Registration`]: struct.Registration.html
-/// [`SetReadiness`]: struct.SetReadiness.html
+/// [`Poll`]: ../struct.Poll.html
+/// [`Registration`]: ../struct.Registration.html
+/// [`SetReadiness`]: ../struct.SetReadiness.html
 ///
 /// # Examples
 ///
@@ -127,38 +127,30 @@ pub trait Evented {
     /// instead. Implementors should handle registration by either delegating
     /// the call to another `Evented` type or creating a [`Registration`].
     ///
-    /// See [struct] documentation for more details.
-    ///
-    /// [`Poll::register`]: struct.Poll.html#method.register
-    /// [`Registration`]: struct.Registration.html
-    /// [struct]: #
+    /// [`Poll::register`]: ../struct.Poll.html#method.register
+    /// [`Registration`]: ../struct.Registration.html
     fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()>;
 
     /// Re-register `self` with the given `Poll` instance.
     ///
     /// This function should not be called directly. Use [`Poll::reregister`]
     /// instead. Implementors should handle re-registration by either delegating
-    /// the call to another `Evented` type or calling [`Registration::update`].
+    /// the call to another `Evented` type or calling
+    /// [`SetReadiness::set_readiness`].
     ///
-    /// See [struct] documentation for more details.
-    ///
-    /// [`Poll::reregister`]: struct.Poll.html#method.register
-    /// [`Registration::update`]: struct.Registration.html#method.update
-    /// [struct]: #
+    /// [`Poll::reregister`]: ../struct.Poll.html#method.reregister
+    /// [`SetReadiness::set_readiness`]: ../struct.SetReadiness.html#method.set_readiness
     fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()>;
 
     /// Deregister `self` from the given `Poll` instance
     ///
     /// This function should not be called directly. Use [`Poll::deregister`]
-    /// instead. Implementors shuld handle deregistration by either delegating
+    /// instead. Implementors should handle deregistration by either delegating
     /// the call to another `Evented` type or by dropping the [`Registration`]
     /// associated with `self`.
     ///
-    /// See [struct] documentation for more details.
-    ///
-    /// [`Poll::deregister`]: struct.Poll.html#method.deregister
-    /// [`Registration`]: struct.Registration.html
-    /// [struct]: #
+    /// [`Poll::deregister`]: ../struct.Poll.html#method.deregister
+    /// [`Registration`]: ../struct.Registration.html
     fn deregister(&self, poll: &Poll) -> io::Result<()>;
 }
 
@@ -950,10 +942,10 @@ fn test_debug_ready() {
 /// assert_eq!(event.token(), Token(0));
 /// ```
 ///
-/// [`Poll::poll`]: struct.Poll.html#method.poll
-/// [`Poll`]: struct.Poll.html
-/// [readiness state ]: struct.Ready.html
-/// [`Token`]: struct.Token.html
+/// [`Poll::poll`]: ../struct.Poll.html#method.poll
+/// [`Poll`]: ../struct.Poll.html
+/// [readiness state]: ../struct.Ready.html
+/// [`Token`]: ../struct.Token.html
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct Event {
     kind: Ready,

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -215,7 +215,7 @@ impl TcpStream {
     /// For more information about this option, see
     /// [`set_recv_buffer_size`][link].
     ///
-    /// [link]: #tymethod.set_recv_buffer_size
+    /// [link]: #method.set_recv_buffer_size
     pub fn recv_buffer_size(&self) -> io::Result<usize> {
         self.sys.recv_buffer_size()
     }
@@ -230,9 +230,10 @@ impl TcpStream {
 
     /// Gets the value of the `SO_SNDBUF` option on this socket.
     ///
-    /// For more information about this option, see [`set_send_buffer`][link].
+    /// For more information about this option, see
+    /// [`set_send_buffer_size`][link].
     ///
-    /// [link]: #tymethod.set_send_buffer
+    /// [link]: #method.set_send_buffer_size
     pub fn send_buffer_size(&self) -> io::Result<usize> {
         self.sys.send_buffer_size()
     }
@@ -258,7 +259,7 @@ impl TcpStream {
     ///
     /// For more information about this option, see [`set_keepalive`][link].
     ///
-    /// [link]: #tymethod.set_keepalive
+    /// [link]: #method.set_keepalive
     pub fn keepalive(&self) -> io::Result<Option<Duration>> {
         self.sys.keepalive()
     }
@@ -275,7 +276,7 @@ impl TcpStream {
     ///
     /// For more information about this option, see [`set_ttl`][link].
     ///
-    /// [link]: #tymethod.set_ttl
+    /// [link]: #method.set_ttl
     pub fn ttl(&self) -> io::Result<u32> {
         self.sys.ttl()
     }
@@ -296,17 +297,21 @@ impl TcpStream {
     ///
     /// For more information about this option, see [`set_only_v6`][link].
     ///
-    /// [link]: #tymethod.set_only_v6
+    /// [link]: #method.set_only_v6
     pub fn only_v6(&self) -> io::Result<bool> {
         self.sys.only_v6()
     }
 
-    /// Sets the linger duration of this socket by setting the SO_LINGER option
+    /// Sets the value for the `SO_LINGER` option on this socket.
     pub fn set_linger(&self, dur: Option<Duration>) -> io::Result<()> {
         self.sys.set_linger(dur)
     }
 
-    /// reads the linger duration for this socket by getting the SO_LINGER option
+    /// Gets the value of the `SO_LINGER` option on this socket.
+    ///
+    /// For more information about this option, see [`set_linger`][link].
+    ///
+    /// [link]: #method.set_linger
     pub fn linger(&self) -> io::Result<Option<Duration>> {
         self.sys.linger()
     }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -433,6 +433,10 @@ pub struct Poll {
 /// [`Poll`]: struct.Poll.html
 /// [`Registration::new2`]: struct.Registration.html#method.new2
 /// [`Evented`]: event/trait.Evented.html
+/// [`set_readiness`]: struct.SetReadiness.html#method.set_readiness
+/// [`register`]: struct.Poll.html#method.register
+/// [`reregister`]: struct.Poll.html#method.reregister
+/// [`reregister`]: struct.Poll.html#method.reregister
 pub struct Registration {
     inner: RegistrationInner,
 }
@@ -440,12 +444,13 @@ pub struct Registration {
 unsafe impl Send for Registration {}
 unsafe impl Sync for Registration {}
 
-/// Updates the readiness state of the associated [`Registration`].
+/// Updates the readiness state of the associated `Registration`.
 ///
 /// See [`Registration`] for more documentation on using `SetReadiness` and
 /// [`Poll`] for high level polling documentation.
 ///
-/// [`Registration`]
+/// [`Poll`]: struct.Poll.html
+/// [`Registration`]: struct.Registration.html
 #[derive(Clone)]
 pub struct SetReadiness {
     inner: RegistrationInner,
@@ -663,7 +668,7 @@ impl Poll {
 
     /// Register an `Evented` handle with the `Poll` instance.
     ///
-    /// Once registerd, the `Poll` instance will monitor the `Evented` handle
+    /// Once registered, the `Poll` instance will monitor the `Evented` handle
     /// for readiness state changes. When it notices a state change, it will
     /// return a readiness event for the handle the next time [`poll`] is
     /// called.
@@ -1210,9 +1215,9 @@ impl AsRawFd for Poll {
 /// A collection of readiness events.
 ///
 /// `Events` is passed as an argument to [`Poll::poll`] and will be used to
-/// receive any new readiness events received since the last call to [`poll`].
-/// Usually, a single `Events` instance is created at the same time as the
-/// [`Poll`] and the single instance is reused for each call to [`poll`].
+/// receive any new readiness events received since the last poll. Usually, a
+/// single `Events` instance is created at the same time as a [`Poll`] and
+/// reused on each call to [`Poll::poll`].
 ///
 /// See [`Poll`] for more documentation on polling.
 ///
@@ -1245,7 +1250,6 @@ impl AsRawFd for Poll {
 /// ```
 ///
 /// [`Poll::poll`]: struct.Poll.html#method.poll
-/// [`poll`]: struct.Poll.html#method.poll
 /// [`Poll`]: struct.Poll.html
 pub struct Events {
     inner: sys::Events,
@@ -1719,9 +1723,9 @@ impl SetReadiness {
     /// Set the registration's readiness
     ///
     /// If the associated `Registration` is registered with a [`Poll`] instance
-    /// and has requested readiness events that include `ready`, then a call
-    /// [`poll`] will receive a readiness event representing the readiness
-    /// state change.
+    /// and has requested readiness events that include `ready`, then a future
+    /// call to [`Poll::poll`] will receive a readiness event representing the
+    /// readiness state change.
     ///
     /// # Note
     ///
@@ -1792,8 +1796,9 @@ impl SetReadiness {
     /// ```
     ///
     /// [`Registration`]: struct.Registration.html
+    /// [`Evented`]: event/trait.Evented.html#examples
     /// [`Poll`]: struct.Poll.html
-    /// [`poll`]: struct.Poll.html#method.poll
+    /// [`Poll::poll`]: struct.Poll.html#method.poll
     pub fn set_readiness(&self, ready: Ready) -> io::Result<()> {
         self.inner.set_readiness(ready)
     }

--- a/src/sys/unix/eventedfd.rs
+++ b/src/sys/unix/eventedfd.rs
@@ -10,7 +10,7 @@ use std::os::unix::io::RawFd;
 
 #[derive(Debug)]
 
-/// Adapter for [`RawFd`] providing an [`Evented`] implementation.
+/// Adapter for `RawFd` providing an [`Evented`] implementation.
 ///
 /// `EventedFd` enables registering any type with an FD with [`Poll`].
 ///
@@ -86,9 +86,9 @@ use std::os::unix::io::RawFd;
 /// }
 /// ```
 ///
-/// [`RawFd`]: #
-/// [`Evented`]: #
-/// [`Poll`]: #
+/// [`Evented`]: ../event/trait.Evented.html
+/// [`Poll`]: ../struct.Poll.html
+/// [`Poll::register`]: ../struct.Poll.html#method.register
 pub struct EventedFd<'a>(pub &'a RawFd);
 
 impl<'a> Evented for EventedFd<'a> {

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -87,7 +87,7 @@ use std::fmt;
 /// # }
 /// ```
 ///
-/// [`Poll`]: struct.Poll.html
+/// [`Poll`]: ../struct.Poll.html
 /// [readiness]: struct.Poll.html#readiness-operations
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct UnixReady(Ready);
@@ -111,7 +111,7 @@ impl UnixReady {
     /// assert!(ready.is_aio());
     /// ```
     ///
-    /// [`Poll`]: struct.Poll.html
+    /// [`Poll`]: ../struct.Poll.html
     #[inline]
     pub fn aio() -> UnixReady {
         UnixReady(ready_from_usize(AIO))
@@ -136,8 +136,8 @@ impl UnixReady {
     /// assert!(ready.is_error());
     /// ```
     ///
-    /// [`Poll`]: struct.Poll.html
-    /// [readiness]: struct.Poll.html#readiness-operations
+    /// [`Poll`]: ../struct.Poll.html
+    /// [readiness]: ../struct.Poll.html#readiness-operations
     #[inline]
     pub fn error() -> UnixReady {
         UnixReady(ready_from_usize(ERROR))
@@ -165,8 +165,8 @@ impl UnixReady {
     /// assert!(ready.is_hup());
     /// ```
     ///
-    /// [`Poll`]: struct.Poll.html
-    /// [readiness]: struct.Poll.html#readiness-operations
+    /// [`Poll`]: ../struct.Poll.html
+    /// [readiness]: ../struct.Poll.html#readiness-operations
     #[inline]
     pub fn hup() -> UnixReady {
         UnixReady(ready_from_usize(HUP))
@@ -185,6 +185,8 @@ impl UnixReady {
     ///
     /// assert!(ready.is_aio());
     /// ```
+    ///
+    /// [`Poll`]: ../struct.Poll.html
     #[inline]
     pub fn is_aio(&self) -> bool {
         self.contains(ready_from_usize(AIO))
@@ -209,7 +211,8 @@ impl UnixReady {
     /// assert!(ready.is_error());
     /// ```
     ///
-    /// [`Poll`]: struct.Poll.html
+    /// [`Poll`]: ../struct.Poll.html
+    /// [readiness]: ../struct.Poll.html#readiness-operations
     #[inline]
     pub fn is_error(&self) -> bool {
         self.contains(ready_from_usize(ERROR))
@@ -237,7 +240,8 @@ impl UnixReady {
     /// assert!(ready.is_hup());
     /// ```
     ///
-    /// [`Poll`]: struct.Poll.html
+    /// [`Poll`]: ../struct.Poll.html
+    /// [readiness]: ../struct.Poll.html#readiness-operations
     #[inline]
     pub fn is_hup(&self) -> bool {
         self.contains(ready_from_usize(HUP))

--- a/src/token.rs
+++ b/src/token.rs
@@ -115,7 +115,7 @@
 ///                         Ok(_) => unreachable!(),
 ///                         Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
 ///                             // Socket is not ready anymore, stop reading
-///                             continue;
+///                             break;
 ///                         }
 ///                         e => panic!("err={:?}", e), // Unexpected error
 ///                     }


### PR DESCRIPTION
Includes a few minor typo fixes and other random improvements.

Mostly fixes #683 (see my comment about how `Events` is exported under two locations causing relative link issues).