### PR TITLE
Prefer ErrorKind::WouldBlock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ matrix:
 
     # Test compatibility
     #
-    # 1.13.0 is the oldest supported version of Rust. This value should NOT be
+    # 1.14.0 is the oldest supported version of Rust. This value should NOT be
     # changed without prior discussion.
     #
     # This build also deploys docs
     - os: linux
-      rust: 1.13.0
+      rust: 1.14.0
       before_script:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
       script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Minimum Rust version is now 1.14.0
+
 # 0.6.10 (July 27, 2017)
 
 * Experimental support for Fuchsia

--- a/src/io.rs
+++ b/src/io.rs
@@ -28,14 +28,8 @@ impl<T> MapNonBlock<T> for Result<T> {
 
 #[cfg(feature = "with-deprecated")]
 pub mod deprecated {
-    #[cfg(unix)]
-    const WOULDBLOCK: i32 = ::libc::EAGAIN;
-
-    #[cfg(windows)]
-    const WOULDBLOCK: i32 = ::winapi::winerror::WSAEWOULDBLOCK as i32;
-
     /// Returns a std `WouldBlock` error without allocating
     pub fn would_block() -> ::std::io::Error {
-        ::std::io::Error::from_raw_os_error(WOULDBLOCK)
+        ::std::io::ErrorKind::WouldBlock.into()
     }
 }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -160,10 +160,6 @@ enum Family {
     V4, V6,
 }
 
-fn wouldblock() -> io::Error {
-    io::Error::new(io::ErrorKind::WouldBlock, "operation would block")
-}
-
 unsafe fn cancel(socket: &AsRawSocket,
                  overlapped: &Overlapped) -> io::Result<()> {
     let handle = socket.as_raw_socket() as winapi::HANDLE;


### PR DESCRIPTION
Fix #616 

Not a big difference but an improvement nevertheless.

Also includes a version bump in a separated commit.

```
pub fn before2() -> io::Error {
    std::io::Error::from_raw_os_error(111111)
}

pub fn after() -> io::Error {
    io::ErrorKind::WouldBlock.into()
}


example::before2:
        push    rbp
        mov     rbp, rsp
        push    rbx
        push    rax
        mov     rbx, rdi
        mov     esi, 111111
        call    std::io::error::Error::from_raw_os_error@PLT
        mov     rax, rbx
        add     rsp, 8
        pop     rbx
        pop     rbp
        ret

example::after:
        push    rbp
        mov     rbp, rsp
        mov     word ptr [rdi], 2561
        mov     rax, rdi
        pop     rbp
        ret

str.0:
        .ascii  "would block"
```