### PR TITLE
Ensure errors on TCP writes happen on Windows

### DIFF
--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)]
 
-use std::{fmt, io, u32};
+use std::{fmt, io};
 use std::cell::UnsafeCell;
 use std::os::windows::prelude::*;
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
Previously an error in a TCP write might accidentally get covered up as the
`write` function didn't check for `State::Error`. This updates that logic to
propagate the error out to ensure if we see an error it goes upwards.

Closes https://github.com/tokio-rs/tokio-core/issues/243