### PR TITLE
Add TcpListener::accept_std

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -553,14 +553,17 @@ impl TcpListener {
     /// If an accepted stream is returned, the remote address of the peer is
     /// returned along with it.
     pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
-        self.sys.accept().map(|(s, a)| {
-            let stream = TcpStream {
-                sys: s,
-                selector_id: SelectorId::new(),
-            };
+        let (s, a) = try!(self.accept_std());
+        Ok((TcpStream::from_stream(s)?, a))
+    }
 
-            (stream, a)
-        })
+    /// Accepts a new `std::net::TcpStream`.
+    ///
+    /// This method is the same as `accept`, except that it returns a TCP socket
+    /// *in blocking mode* which isn't bound to `mio`. This can be later then
+    /// converted to a `mio` type, if necessary.
+    pub fn accept_std(&self) -> io::Result<(net::TcpStream, SocketAddr)> {
+        self.sys.accept()
     }
 
     /// Returns the local socket address of this listener.

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -229,13 +229,8 @@ impl TcpListener {
         })
     }
 
-    pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
-        self.inner.accept().and_then(|(s, a)| {
-            set_nonblock(s.as_raw_fd())?;
-            Ok((TcpStream {
-                inner: s,
-            }, a))
-        })
+    pub fn accept(&self) -> io::Result<(net::TcpStream, SocketAddr)> {
+        self.inner.accept()
     }
 
     #[allow(deprecated)]

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -647,7 +647,7 @@ impl TcpListener {
         }
     }
 
-    pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
+    pub fn accept(&self) -> io::Result<(net::TcpStream, SocketAddr)> {
         let mut me = self.inner();
 
         let ret = match mem::replace(&mut me.accept, State::Empty) {
@@ -656,10 +656,7 @@ impl TcpListener {
                 me.accept = State::Pending(t);
                 return Err(io::ErrorKind::WouldBlock.into());
             }
-            State::Ready((s, a)) => {
-                s.set_nonblocking(true)?;
-                Ok((TcpStream::new(s, None), a))
-            }
+            State::Ready((s, a)) => Ok((s, a)),
             State::Error(e) => Err(e),
         };
 


### PR DESCRIPTION
This commit adds an `accept_std` method to `TcpListener` which is added with
the intention of helping downstream libraries improve interoperability without
exposing `mio` as a public dependency. The `TcpStream` type is already
convertible from a raw `std::net::TcpStream`, so it should be possible to
quickly reassociate this socket back with mio.