### PR TITLE
lio_listio(2) support

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -550,10 +550,10 @@ fn test_debug_pollopt() {
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct Ready(usize);
 
-const READABLE: usize = 0b00001;
-const WRITABLE: usize = 0b00010;
-const ERROR: usize    = 0b00100;
-const HUP: usize      = 0b01000;
+const READABLE: usize = 0b000001;
+const WRITABLE: usize = 0b000010;
+const ERROR: usize    = 0b000100;
+const HUP: usize      = 0b001000;
 
 impl Ready {
     /// Returns the empty `Ready` set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,12 @@ pub mod unix {
         EventedFd,
     };
     pub use sys::unix::UnixReady;
+    #[cfg(any(target_os = "bitrig", target_os = "dragonfly",
+              target_os = "freebsd", target_os = "ios", target_os = "macos",
+              target_os = "netbsd", target_os = "openbsd"))]
+    pub use sys::unix::BSDReady;
+    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+    pub use sys::unix::FreeBSDReady;
 }
 
 #[cfg(target_os = "fuchsia")]

--- a/src/sys/unix/bsd/freebsd/mod.rs
+++ b/src/sys/unix/bsd/freebsd/mod.rs
@@ -1,0 +1,1 @@
+pub mod ready;

--- a/src/sys/unix/bsd/freebsd/ready.rs
+++ b/src/sys/unix/bsd/freebsd/ready.rs
@@ -1,0 +1,206 @@
+use event_imp::{Ready, ready_as_usize, ready_from_usize};
+use unix::UnixReady;
+use super::super::ready::BSDReady;
+
+use std::ops;
+use std::fmt;
+
+/// FreeBSD specific extensions to `Ready`
+///
+/// Provides additional readiness event kinds that are available on FreeBSD and
+/// DragonFlyBSD.
+///
+/// LIO events occur when an lio_listio operation is complete.  Unlike other
+/// event types, LIO events are not associated with file descriptors.  Instead,
+/// they're associated with lists of AIO control block structures.
+///
+/// Conversion traits are implemented between `FreeBSDReady`, `BSDReady`,
+/// `UnixReady`, and `Ready`.  See the examples.
+///
+/// # Examples
+///
+/// ```
+/// use mio::unix::FreeBSDReady;
+///
+/// let ready = FreeBSDReady::lio();
+///
+/// assert!(FreeBSDReady::from(ready).is_lio());
+/// ```
+///
+/// Basic conversion between ready types.
+///
+/// ```
+/// use mio::Ready;
+/// use mio::unix::FreeBSDReady;
+///
+/// // Start with a portable ready
+/// let ready = Ready::empty();
+/// // Convert to a BSD ready, add AIO
+/// let mut bsd_ready = FreeBSDReady::from(ready) | FreeBSDReady::lio();
+/// assert!(bsd_ready.is_lio());
+/// // Convert back to `Ready`
+/// let ready = Ready::from(bsd_ready);
+/// ```
+///
+/// [readiness]: struct.Poll.html#readiness-operations
+ #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
+pub struct FreeBSDReady(Ready);
+
+const LIO: usize = 0b100000;
+
+impl FreeBSDReady {
+    /// Returns a `Ready` representing LIO completion readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::unix::FreeBSDReady;
+    ///
+    /// let ready = FreeBSDReady::lio();
+    ///
+    /// assert!(ready.is_lio());
+    /// ```
+    ///
+    /// [`Poll`]: ../struct.Poll.html
+    #[inline]
+    pub fn lio() -> FreeBSDReady {
+        FreeBSDReady(ready_from_usize(LIO))
+    }
+
+    /// Returns true if `Ready` contains LIO readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::unix::FreeBSDReady;
+    ///
+    /// let ready = FreeBSDReady::lio();
+    ///
+    /// assert!(ready.is_lio());
+    /// ```
+    ///
+    /// [`Poll`]: ../struct.Poll.html
+    #[inline]
+    pub fn is_lio(&self) -> bool {
+        self.contains(ready_from_usize(LIO))
+    }
+}
+
+impl From<Ready> for FreeBSDReady {
+    fn from(src: Ready) -> FreeBSDReady {
+        FreeBSDReady(src)
+    }
+}
+
+impl From<FreeBSDReady> for Ready {
+    fn from(src: FreeBSDReady) -> Ready {
+        src.0
+    }
+}
+
+impl From<UnixReady> for FreeBSDReady {
+    fn from(src: UnixReady) -> FreeBSDReady {
+        FreeBSDReady(Ready::from(src))
+    }
+}
+
+impl From<FreeBSDReady> for UnixReady {
+    fn from(src: FreeBSDReady) -> UnixReady {
+        UnixReady::from(src.0)
+    }
+}
+
+impl From<BSDReady> for FreeBSDReady {
+    fn from(src: BSDReady) -> FreeBSDReady {
+        FreeBSDReady(Ready::from(src))
+    }
+}
+
+impl From<FreeBSDReady> for BSDReady {
+    fn from(src: FreeBSDReady) -> BSDReady {
+        BSDReady::from(src.0)
+    }
+}
+
+impl ops::Deref for FreeBSDReady {
+    type Target = Ready;
+
+    fn deref(&self) -> &Ready {
+        &self.0
+    }
+}
+
+impl ops::DerefMut for FreeBSDReady {
+    fn deref_mut(&mut self) -> &mut Ready {
+        &mut self.0
+    }
+}
+
+impl ops::BitOr for FreeBSDReady {
+    type Output = FreeBSDReady;
+
+    #[inline]
+    fn bitor(self, other: FreeBSDReady) -> FreeBSDReady {
+        (self.0 | other.0).into()
+    }
+}
+
+impl ops::BitXor for FreeBSDReady {
+    type Output = FreeBSDReady;
+
+    #[inline]
+    fn bitxor(self, other: FreeBSDReady) -> FreeBSDReady {
+        (self.0 ^ other.0).into()
+    }
+}
+
+impl ops::BitAnd for FreeBSDReady {
+    type Output = FreeBSDReady;
+
+    #[inline]
+    fn bitand(self, other: FreeBSDReady) -> FreeBSDReady {
+        (self.0 & other.0).into()
+    }
+}
+
+impl ops::Sub for FreeBSDReady {
+    type Output = FreeBSDReady;
+
+    #[inline]
+    fn sub(self, other: FreeBSDReady) -> FreeBSDReady {
+        ready_from_usize(ready_as_usize(self.0) & !ready_as_usize(other.0)).into()
+    }
+}
+
+impl fmt::Debug for FreeBSDReady {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let mut one = false;
+        let flags = [
+            (Ready::readable(), "Readable"),
+            (Ready::writable(), "Writable"),
+            (Ready::from(UnixReady::error()), "Error"),
+            (Ready::from(UnixReady::hup()), "Hup"),
+            (Ready::from(BSDReady::aio()), "AIO"),
+            (Ready::from(FreeBSDReady::lio()), "LIO"),
+        ];
+
+        for &(flag, msg) in &flags {
+            if self.contains(flag) {
+                if one { write!(fmt, " | ")? }
+                write!(fmt, "{}", msg)?;
+
+                one = true
+            }
+        }
+
+        if !one {
+            fmt.write_str("(empty)")?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/sys/unix/bsd/mod.rs
+++ b/src/sys/unix/bsd/mod.rs
@@ -1,0 +1,3 @@
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+pub mod freebsd;
+pub mod ready;

--- a/src/sys/unix/bsd/ready.rs
+++ b/src/sys/unix/bsd/ready.rs
@@ -1,0 +1,194 @@
+use event_imp::{Ready, ready_as_usize, ready_from_usize};
+use unix::UnixReady;
+
+use std::ops;
+use std::fmt;
+
+/// BSD specific extensions to `Ready`
+///
+/// Provides additional readiness event kinds that are available on BSD
+/// platforms.
+///
+/// AIO events occur when a POSIX AIO operation is complete.  Unlike other event
+/// types, AIO events are not associated with file descriptors.  Instead,
+/// they're associated with AIO control block structures.  Each operation has
+/// its own control block structure, and each control block structure is
+/// generally only used for a single operation.
+///
+/// Conversion traits are implemented between `BSDReady`, `UnixReady`, and
+/// `Ready`.  See the examples.
+///
+/// # Examples
+///
+/// ```
+/// use mio::unix::BSDReady;
+///
+/// let ready = BSDReady::aio();
+///
+/// assert!(BSDReady::from(ready).is_aio());
+/// ```
+///
+/// Basic conversion between ready types.
+///
+/// ```
+/// use mio::Ready;
+/// use mio::unix::BSDReady;
+///
+/// // Start with a portable ready
+/// let ready = Ready::empty();
+/// // Convert to a BSD ready, add AIO
+/// let mut bsd_ready = BSDReady::from(ready) | BSDReady::aio();
+/// assert!(bsd_ready.is_aio());
+/// // Convert back to `Ready`
+/// let ready = Ready::from(bsd_ready);
+/// ```
+///
+/// [readiness]: struct.Poll.html#readiness-operations
+ #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
+pub struct BSDReady(Ready);
+
+const AIO: usize = 0b010000;
+
+impl BSDReady {
+    /// Returns a `Ready` representing AIO completion readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::unix::BSDReady;
+    ///
+    /// let ready = BSDReady::aio();
+    ///
+    /// assert!(ready.is_aio());
+    /// ```
+    ///
+    /// [`Poll`]: ../struct.Poll.html
+    #[inline]
+    pub fn aio() -> BSDReady {
+        BSDReady(ready_from_usize(AIO))
+    }
+
+    /// Returns true if `Ready` contains AIO readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::unix::BSDReady;
+    ///
+    /// let ready = BSDReady::aio();
+    ///
+    /// assert!(ready.is_aio());
+    /// ```
+    ///
+    /// [`Poll`]: ../struct.Poll.html
+    #[inline]
+    pub fn is_aio(&self) -> bool {
+        self.contains(ready_from_usize(AIO))
+    }
+}
+
+impl From<Ready> for BSDReady {
+    fn from(src: Ready) -> BSDReady {
+        BSDReady(src)
+    }
+}
+
+impl From<BSDReady> for Ready {
+    fn from(src: BSDReady) -> Ready {
+        src.0
+    }
+}
+
+impl From<UnixReady> for BSDReady {
+    fn from(src: UnixReady) -> BSDReady {
+        BSDReady(Ready::from(src))
+    }
+}
+
+impl From<BSDReady> for UnixReady {
+    fn from(src: BSDReady) -> UnixReady {
+        UnixReady::from(src.0)
+    }
+}
+
+impl ops::Deref for BSDReady {
+    type Target = Ready;
+
+    fn deref(&self) -> &Ready {
+        &self.0
+    }
+}
+
+impl ops::DerefMut for BSDReady {
+    fn deref_mut(&mut self) -> &mut Ready {
+        &mut self.0
+    }
+}
+
+impl ops::BitOr for BSDReady {
+    type Output = BSDReady;
+
+    #[inline]
+    fn bitor(self, other: BSDReady) -> BSDReady {
+        (self.0 | other.0).into()
+    }
+}
+
+impl ops::BitXor for BSDReady {
+    type Output = BSDReady;
+
+    #[inline]
+    fn bitxor(self, other: BSDReady) -> BSDReady {
+        (self.0 ^ other.0).into()
+    }
+}
+
+impl ops::BitAnd for BSDReady {
+    type Output = BSDReady;
+
+    #[inline]
+    fn bitand(self, other: BSDReady) -> BSDReady {
+        (self.0 & other.0).into()
+    }
+}
+
+impl ops::Sub for BSDReady {
+    type Output = BSDReady;
+
+    #[inline]
+    fn sub(self, other: BSDReady) -> BSDReady {
+        ready_from_usize(ready_as_usize(self.0) & !ready_as_usize(other.0)).into()
+    }
+}
+
+impl fmt::Debug for BSDReady {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let mut one = false;
+        let flags = [
+            (Ready::readable(), "Readable"),
+            (Ready::writable(), "Writable"),
+            (Ready::from(UnixReady::error()), "Error"),
+            (Ready::from(UnixReady::hup()), "Hup"),
+            (Ready::from(BSDReady::aio()), "AIO"),
+        ];
+
+        for &(flag, msg) in &flags {
+            if self.contains(flag) {
+                if one { write!(fmt, " | ")? }
+                write!(fmt, "{}", msg)?;
+
+                one = true
+            }
+        }
+
+        if !one {
+            fmt.write_str("(empty)")?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -298,6 +298,12 @@ impl Events {
                     event::kind_mut(&mut self.events[idx]).insert(UnixReady::aio());
                 }
             }
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+            {
+                if e.filter == libc::EVFILT_LIO {
+                    event::kind_mut(&mut self.events[idx]).insert(UnixReady::lio());
+                }
+            }
 
             if e.flags & libc::EV_EOF != 0 {
                 event::kind_mut(&mut self.events[idx]).insert(UnixReady::hup());

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -12,6 +12,11 @@ use libc::{self, time_t};
 use {io, Ready, PollOpt, Token};
 use event_imp::{self as event, Event};
 use sys::unix::{cvt, UnixReady};
+#[cfg(any(target_os = "dragonfly",
+    target_os = "freebsd", target_os = "ios", target_os = "macos"))]
+use sys::unix::BSDReady;
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+use sys::unix::FreeBSDReady;
 use sys::unix::io::set_cloexec;
 
 /// Each Selector has a globally unique(ish) ID associated with it. This ID
@@ -295,13 +300,13 @@ impl Events {
     target_os = "freebsd", target_os = "ios", target_os = "macos"))]
             {
                 if e.filter == libc::EVFILT_AIO {
-                    event::kind_mut(&mut self.events[idx]).insert(UnixReady::aio());
+                    event::kind_mut(&mut self.events[idx]).insert(BSDReady::aio());
                 }
             }
 #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
             {
                 if e.filter == libc::EVFILT_LIO {
-                    event::kind_mut(&mut self.events[idx]).insert(UnixReady::lio());
+                    event::kind_mut(&mut self.events[idx]).insert(FreeBSDReady::lio());
                 }
             }
 
@@ -354,6 +359,6 @@ fn test_coalesce_aio() {
     let mut events = Events::with_capacity(1);
     events.sys_events.0.push(kevent!(0x1234, libc::EVFILT_AIO, 0, 42));
     events.coalesce(Token(0));
-    assert!(events.events[0].readiness() == UnixReady::aio().into());
+    assert!(events.events[0].readiness() == BSDReady::aio().into());
     assert!(events.events[0].token() == Token(42));
 }

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -20,6 +20,10 @@ mod kqueue;
 pub use self::kqueue::{Events, Selector};
 
 mod awakener;
+#[cfg(any(target_os = "bitrig", target_os = "dragonfly",
+          target_os = "freebsd", target_os = "ios", target_os = "macos",
+          target_os = "netbsd", target_os = "openbsd"))]
+mod bsd;
 mod eventedfd;
 mod io;
 mod ready;
@@ -33,6 +37,12 @@ pub use self::awakener::Awakener;
 pub use self::eventedfd::EventedFd;
 pub use self::io::{Io, set_nonblock};
 pub use self::ready::UnixReady;
+#[cfg(any(target_os = "bitrig", target_os = "dragonfly",
+          target_os = "freebsd", target_os = "ios", target_os = "macos",
+          target_os = "netbsd", target_os = "openbsd"))]
+pub use self::bsd::ready::BSDReady;
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+pub use self::bsd::freebsd::ready::FreeBSDReady;
 pub use self::tcp::{TcpStream, TcpListener};
 pub use self::udp::UdpSocket;
 

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -94,30 +94,8 @@ pub struct UnixReady(Ready);
 
 const ERROR: usize = 0b000100;
 const HUP: usize   = 0b001000;
-const AIO: usize   = 0b010000;
-const LIO: usize   = 0b100000;
 
 impl UnixReady {
-    /// Returns a `Ready` representing AIO completion readiness
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::unix::UnixReady;
-    ///
-    /// let ready = UnixReady::aio();
-    ///
-    /// assert!(ready.is_aio());
-    /// ```
-    ///
-    /// [`Poll`]: ../struct.Poll.html
-    #[inline]
-    pub fn aio() -> UnixReady {
-        UnixReady(ready_from_usize(AIO))
-    }
-
     /// Returns a `Ready` representing error readiness.
     ///
     /// **Note that only readable and writable readiness is guaranteed to be
@@ -173,46 +151,6 @@ impl UnixReady {
         UnixReady(ready_from_usize(HUP))
     }
 
-    /// Returns a `Ready` representing LIO completion readiness
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::unix::UnixReady;
-    ///
-    /// let ready = UnixReady::lio();
-    ///
-    /// assert!(ready.is_lio());
-    /// ```
-    ///
-    /// [`Poll`]: struct.Poll.html
-    #[inline]
-    pub fn lio() -> UnixReady {
-        UnixReady(ready_from_usize(LIO))
-    }
-
-    /// Returns true if `Ready` contains AIO readiness
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::unix::UnixReady;
-    ///
-    /// let ready = UnixReady::aio();
-    ///
-    /// assert!(ready.is_aio());
-    /// ```
-    ///
-    /// [`Poll`]: ../struct.Poll.html
-    #[inline]
-    pub fn is_aio(&self) -> bool {
-        self.contains(ready_from_usize(AIO))
-    }
-
     /// Returns true if the value includes error readiness
     ///
     /// **Note that only readable and writable readiness is guaranteed to be
@@ -266,24 +204,6 @@ impl UnixReady {
     #[inline]
     pub fn is_hup(&self) -> bool {
         self.contains(ready_from_usize(HUP))
-    }
-
-    /// Returns true if `Ready` contains LIO readiness
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::unix::UnixReady;
-    ///
-    /// let ready = UnixReady::lio();
-    ///
-    /// assert!(ready.is_lio());
-    /// ```
-    #[inline]
-    pub fn is_lio(&self) -> bool {
-        self.contains(ready_from_usize(LIO))
     }
 }
 
@@ -368,8 +288,7 @@ impl fmt::Debug for UnixReady {
             (UnixReady(Ready::readable()), "Readable"),
             (UnixReady(Ready::writable()), "Writable"),
             (UnixReady::error(), "Error"),
-            (UnixReady::hup(), "Hup"),
-            (UnixReady::aio(), "Aio")];
+            (UnixReady::hup(), "Hup")];
 
         for &(flag, msg) in &flags {
             if self.contains(flag) {

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -92,9 +92,10 @@ use std::fmt;
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct UnixReady(Ready);
 
-const ERROR: usize = 0b00100;
-const HUP: usize   = 0b01000;
-const AIO: usize   = 0b10000;
+const ERROR: usize = 0b000100;
+const HUP: usize   = 0b001000;
+const AIO: usize   = 0b010000;
+const LIO: usize   = 0b100000;
 
 impl UnixReady {
     /// Returns a `Ready` representing AIO completion readiness
@@ -172,6 +173,26 @@ impl UnixReady {
         UnixReady(ready_from_usize(HUP))
     }
 
+    /// Returns a `Ready` representing LIO completion readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::unix::UnixReady;
+    ///
+    /// let ready = UnixReady::lio();
+    ///
+    /// assert!(ready.is_lio());
+    /// ```
+    ///
+    /// [`Poll`]: struct.Poll.html
+    #[inline]
+    pub fn lio() -> UnixReady {
+        UnixReady(ready_from_usize(LIO))
+    }
+
     /// Returns true if `Ready` contains AIO readiness
     ///
     /// See [`Poll`] for more documentation on polling.
@@ -245,6 +266,24 @@ impl UnixReady {
     #[inline]
     pub fn is_hup(&self) -> bool {
         self.contains(ready_from_usize(HUP))
+    }
+
+    /// Returns true if `Ready` contains LIO readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::unix::UnixReady;
+    ///
+    /// let ready = UnixReady::lio();
+    ///
+    /// assert!(ready.is_lio());
+    /// ```
+    #[inline]
+    pub fn is_lio(&self) -> bool {
+        self.contains(ready_from_usize(LIO))
     }
 }
 


### PR DESCRIPTION
On FreeBSD and DragonflyBSD, kevent(2) has a distinct filter type for
use with lio_listio(2).  This commit adds 2 new public methods:
UnixReady::lio and UnixReady::is_lio.