### PR TITLE
Sync with Fuchsia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ net2     = "0.2.29"
 iovec    = "0.1.0"
 
 [target.'cfg(target_os = "fuchsia")'.dependencies]
-fuchsia-zircon = "0.2.0"
+fuchsia-zircon = "0.2.1"
 fuchsia-zircon-sys = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ net2     = "0.2.29"
 iovec    = "0.1.0"
 
 [target.'cfg(target_os = "fuchsia")'.dependencies]
-magenta = "0.2.0"
-magenta-sys = "0.2.0"
+fuchsia-zircon = "0.2.0"
+fuchsia-zircon-sys = "0.2.0"
 
 [target.'cfg(unix)'.dependencies]
 libc   = "0.2.19"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,9 +85,9 @@ extern crate net2;
 extern crate iovec;
 
 #[cfg(target_os = "fuchsia")]
-extern crate zircon;
+extern crate fuchsia_zircon as zircon;
 #[cfg(target_os = "fuchsia")]
-extern crate zircon_sys;
+extern crate fuchsia_zircon_sys as zircon_sys;
 
 #[cfg(unix)]
 extern crate libc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,9 +85,9 @@ extern crate net2;
 extern crate iovec;
 
 #[cfg(target_os = "fuchsia")]
-extern crate magenta;
+extern crate zircon;
 #[cfg(target_os = "fuchsia")]
-extern crate magenta_sys;
+extern crate zircon_sys;
 
 #[cfg(unix)]
 extern crate libc;
@@ -203,7 +203,7 @@ pub mod fuchsia {
     pub use sys::{
         EventedHandle,
     };
-    pub use sys::fuchsia::{FuchsiaReady, mx_signals_t};
+    pub use sys::fuchsia::{FuchsiaReady, zx_signals_t};
 }
 
 /// Windows-only extensions to the mio crate.

--- a/src/sys/fuchsia/awakener.rs
+++ b/src/sys/fuchsia/awakener.rs
@@ -1,5 +1,4 @@
 use {io, poll, Evented, Ready, Poll, PollOpt, Token};
-use sys::fuchsia::status_to_io_err;
 use zircon;
 use std::sync::{Arc, Mutex, Weak};
 
@@ -30,7 +29,7 @@ impl Awakener {
         let packet = zircon::Packet::from_user_packet(
             token.0 as u64, status, zircon::UserPacket::from_u8_array([0; 32]));
 
-        port.queue(&packet).map_err(status_to_io_err)
+        Ok(port.queue(&packet)?)
     }
 
     pub fn cleanup(&self) {}

--- a/src/sys/fuchsia/awakener.rs
+++ b/src/sys/fuchsia/awakener.rs
@@ -1,13 +1,13 @@
 use {io, poll, Evented, Ready, Poll, PollOpt, Token};
 use sys::fuchsia::status_to_io_err;
-use magenta;
+use zircon;
 use std::sync::{Arc, Mutex, Weak};
 
 pub struct Awakener {
     /// Token and weak reference to the port on which Awakener was registered.
     ///
     /// When `Awakener::wakeup` is called, these are used to send a wakeup message to the port.
-    inner: Mutex<Option<(Token, Weak<magenta::Port>)>>,
+    inner: Mutex<Option<(Token, Weak<zircon::Port>)>>,
 }
 
 impl Awakener {
@@ -27,8 +27,8 @@ impl Awakener {
         let port = weak_port.upgrade().expect("Tried to wakeup a closed port.");
 
         let status = 0; // arbitrary
-        let packet = magenta::Packet::from_user_packet(
-            token.0 as u64, status, magenta::UserPacket::from_u8_array([0; 32]));
+        let packet = zircon::Packet::from_user_packet(
+            token.0 as u64, status, zircon::UserPacket::from_u8_array([0; 32]));
 
         port.queue(&packet).map_err(status_to_io_err)
     }

--- a/src/sys/fuchsia/eventedfd.rs
+++ b/src/sys/fuchsia/eventedfd.rs
@@ -1,7 +1,7 @@
 use {io, poll, Evented, Ready, Poll, PollOpt, Token};
 use libc;
-use magenta;
-use magenta::AsHandleRef;
+use zircon;
+use zircon::AsHandleRef;
 use sys::fuchsia::{DontDrop, poll_opts_to_wait_async, sys};
 use std::mem;
 use std::os::unix::io::RawFd;
@@ -11,24 +11,24 @@ use std::sync::{Arc, Mutex};
 #[derive(Debug)]
 pub struct EventedFdRegistration {
     token: Token,
-    handle: DontDrop<magenta::Handle>,
-    rereg_signals: Option<(magenta::Signals, magenta::WaitAsyncOpts)>,
+    handle: DontDrop<zircon::Handle>,
+    rereg_signals: Option<(zircon::Signals, zircon::WaitAsyncOpts)>,
 }
 
 impl EventedFdRegistration {
     unsafe fn new(token: Token,
-                  raw_handle: sys::mx_handle_t,
-                  rereg_signals: Option<(magenta::Signals, magenta::WaitAsyncOpts)>,
+                  raw_handle: sys::zx_handle_t,
+                  rereg_signals: Option<(zircon::Signals, zircon::WaitAsyncOpts)>,
                   ) -> Self
     {
         EventedFdRegistration {
             token: token,
-            handle: DontDrop::new(magenta::Handle::from_raw(raw_handle)),
+            handle: DontDrop::new(zircon::Handle::from_raw(raw_handle)),
             rereg_signals: rereg_signals
         }
     }
 
-    pub fn rereg_signals(&self) -> Option<(magenta::Signals, magenta::WaitAsyncOpts)> {
+    pub fn rereg_signals(&self) -> Option<(zircon::Signals, zircon::WaitAsyncOpts)> {
         self.rereg_signals
     }
 }
@@ -44,12 +44,12 @@ pub struct EventedFdInner {
     /// `fd` is closed on `Drop`, so modifying `fd` is a memory-unsafe operation.
     fd: RawFd,
 
-    /// Owned `mxio_t` ponter.
-    mxio: *const sys::mxio_t,
+    /// Owned `fdio_t` ponter.
+    fdio: *const sys::fdio_t,
 }
 
 impl EventedFdInner {
-    pub fn rereg_for_level(&self, port: &magenta::Port) {
+    pub fn rereg_for_level(&self, port: &zircon::Port) {
         let registration_opt = self.registration.lock().unwrap();
         if let Some(ref registration) = *registration_opt {
             if let Some((rereg_signals, rereg_opts)) = registration.rereg_signals {
@@ -69,25 +69,25 @@ impl EventedFdInner {
         &self.registration
     }
 
-    pub fn mxio(&self) -> &sys::mxio_t {
-        unsafe { &*self.mxio }
+    pub fn fdio(&self) -> &sys::fdio_t {
+        unsafe { &*self.fdio }
     }
 }
 
 impl Drop for EventedFdInner {
     fn drop(&mut self) {
         unsafe {
-            sys::__mxio_release(self.mxio);
+            sys::__fdio_release(self.fdio);
             let _ = libc::close(self.fd);
         }
     }
 }
 
 // `EventedInner` must be manually declared `Send + Sync` because it contains a `RawFd` and a
-// `*const sys::mxio_t`. These are only used to make thread-safe system calls, so accessing
+// `*const sys::fdio_t`. These are only used to make thread-safe system calls, so accessing
 // them is entirely thread-safe.
 //
-// Note: one minor exception to this are the calls to `libc::close` and `__mxio_release`, which
+// Note: one minor exception to this are the calls to `libc::close` and `__fdio_release`, which
 // happen on `Drop`. These accesses are safe because `drop` can only be called at most once from
 // a single thread, and after it is called no other functions can be called on the `EventedFdInner`.
 unsafe impl Sync for EventedFdInner {}
@@ -100,27 +100,27 @@ pub struct EventedFd {
 
 impl EventedFd {
     pub unsafe fn new(fd: RawFd) -> Self {
-        let mxio = sys::__mxio_fd_to_io(fd);
-        assert!(mxio != ::std::ptr::null(), "FileDescriptor given to EventedFd must be valid.");
+        let fdio = sys::__fdio_fd_to_io(fd);
+        assert!(fdio != ::std::ptr::null(), "FileDescriptor given to EventedFd must be valid.");
 
         EventedFd {
             inner: Arc::new(EventedFdInner {
                 registration: Mutex::new(None),
                 fd: fd,
-                mxio: mxio,
+                fdio: fdio,
             })
         }
     }
 
     fn handle_and_signals_for_events(&self, interest: Ready, opts: PollOpt)
-                -> (sys::mx_handle_t, magenta::Signals)
+                -> (sys::zx_handle_t, zircon::Signals)
     {
         let epoll_events = ioevent_to_epoll(interest, opts);
 
         unsafe {
-            let mut raw_handle: sys::mx_handle_t = mem::uninitialized();
-            let mut signals: sys::mx_signals_t = mem::uninitialized();
-            sys::__mxio_wait_begin(self.inner.mxio, epoll_events, &mut raw_handle, &mut signals);
+            let mut raw_handle: sys::zx_handle_t = mem::uninitialized();
+            let mut signals: sys::zx_signals_t = mem::uninitialized();
+            sys::__fdio_wait_begin(self.inner.fdio, epoll_events, &mut raw_handle, &mut signals);
 
             (raw_handle, signals)
         }
@@ -158,7 +158,7 @@ impl EventedFd {
         );
 
         // We don't have ownership of the handle, so we can't drop it
-        let handle = DontDrop::new(unsafe { magenta::Handle::from_raw(raw_handle) });
+        let handle = DontDrop::new(unsafe { zircon::Handle::from_raw(raw_handle) });
 
         let registered = poll::selector(poll)
             .register_fd(handle.inner_ref(), self, token, signals, opts);

--- a/src/sys/fuchsia/handles.rs
+++ b/src/sys/fuchsia/handles.rs
@@ -1,12 +1,12 @@
 use {io, poll, Evented, Ready, Poll, PollOpt, Token};
-use magenta_sys::mx_handle_t;
+use zircon_sys::zx_handle_t;
 use std::sync::Mutex;
 
 /// Wrapper for registering a `HandleBase` type with mio.
 #[derive(Debug)]
 pub struct EventedHandle {
     /// The handle to be registered.
-    handle: mx_handle_t,
+    handle: zx_handle_t,
 
     /// The current `Token` with which the handle is registered with mio.
     token: Mutex<Option<Token>>,
@@ -18,7 +18,7 @@ impl EventedHandle {
     ///
     /// The underlying handle must not be dropped while the
     /// `EventedHandle` still exists.
-    pub unsafe fn new(handle: mx_handle_t) -> Self {
+    pub unsafe fn new(handle: zx_handle_t) -> Self {
         EventedHandle {
             handle: handle,
             token: Mutex::new(None),
@@ -26,7 +26,7 @@ impl EventedHandle {
     }
 
     /// Get the underlying handle being registered.
-    pub fn get_handle(&self) -> mx_handle_t {
+    pub fn get_handle(&self) -> zx_handle_t {
         self.handle
     }
 }

--- a/src/sys/fuchsia/mod.rs
+++ b/src/sys/fuchsia/mod.rs
@@ -82,57 +82,6 @@ mod sys {
     }
 }
 
-/// Convert from zircon::Status to io::Error.
-///
-/// Note: these conversions are done on a "best-effort" basis and may not necessarily reflect
-/// exactly equivalent error types.
-fn status_to_io_err(status: zircon::Status) -> io::Error {
-    use zircon::Status;
-
-    let err_kind: io::ErrorKind = match status {
-        Status::ErrInterruptedRetry => io::ErrorKind::Interrupted,
-        Status::ErrBadHandle => io::ErrorKind::BrokenPipe,
-        Status::ErrTimedOut => io::ErrorKind::TimedOut,
-        Status::ErrShouldWait => io::ErrorKind::WouldBlock,
-        Status::ErrPeerClosed => io::ErrorKind::ConnectionAborted,
-        Status::ErrNotFound => io::ErrorKind::NotFound,
-        Status::ErrAlreadyExists => io::ErrorKind::AlreadyExists,
-        Status::ErrAlreadyBound => io::ErrorKind::AddrInUse,
-        Status::ErrUnavailable => io::ErrorKind::AddrNotAvailable,
-        Status::ErrAccessDenied => io::ErrorKind::PermissionDenied,
-        Status::ErrIoRefused => io::ErrorKind::ConnectionRefused,
-        Status::ErrIoDataIntegrity => io::ErrorKind::InvalidData,
-
-        Status::ErrBadPath |
-        Status::ErrInvalidArgs |
-        Status::ErrOutOfRange |
-        Status::ErrWrongType => io::ErrorKind::InvalidInput,
-
-        Status::UnknownOther |
-        Status::ErrNext |
-        Status::ErrStop |
-        Status::ErrNoSpace |
-        Status::ErrFileBig |
-        Status::ErrNotFile |
-        Status::ErrNotDir |
-        Status::ErrIoDataLoss |
-        Status::ErrIo |
-        Status::ErrCanceled |
-        Status::ErrBadState |
-        Status::ErrBufferTooSmall |
-        Status::ErrBadSyscall |
-        Status::NoError |
-        Status::ErrInternal |
-        Status::ErrNotSupported |
-        Status::ErrNoResources |
-        Status::ErrNoMemory |
-        Status::ErrCallFailed
-        => io::ErrorKind::Other
-    }.into();
-
-    err_kind.into()
-}
-
 fn epoll_event_to_ready(epoll: u32) -> Ready {
     let epoll = epoll as i32; // casts the bits directly
     let mut kind = Ready::empty();

--- a/src/sys/fuchsia/ready.rs
+++ b/src/sys/fuchsia/ready.rs
@@ -1,8 +1,8 @@
 use event_imp::{Ready, ready_as_usize, ready_from_usize};
-pub use magenta_sys::{
-    mx_signals_t,
-    MX_OBJECT_READABLE,
-    MX_OBJECT_WRITABLE,
+pub use zircon_sys::{
+    zx_signals_t,
+    ZX_OBJECT_READABLE,
+    ZX_OBJECT_WRITABLE,
 };
 use std::ops;
 
@@ -14,12 +14,12 @@ use std::ops;
 #[inline]
 pub fn assert_fuchsia_ready_repr() {
     debug_assert!(
-        MX_OBJECT_READABLE.bits() as usize == ready_as_usize(Ready::readable()),
-        "Magenta MX_OBJECT_READABLE should have the same repr as Ready::readable()"
+        ZX_OBJECT_READABLE.bits() as usize == ready_as_usize(Ready::readable()),
+        "Zircon ZX_OBJECT_READABLE should have the same repr as Ready::readable()"
     );
     debug_assert!(
-        MX_OBJECT_WRITABLE.bits() as usize == ready_as_usize(Ready::writable()),
-        "Magenta MX_OBJECT_WRITABLE should have the same repr as Ready::writable()"
+        ZX_OBJECT_WRITABLE.bits() as usize == ready_as_usize(Ready::writable()),
+        "Zircon ZX_OBJECT_WRITABLE should have the same repr as Ready::writable()"
     );
 }
 
@@ -36,32 +36,32 @@ pub fn assert_fuchsia_ready_repr() {
 pub struct FuchsiaReady(Ready);
 
 impl FuchsiaReady {
-    /// Returns the `FuchsiaReady` as raw magenta signals.
+    /// Returns the `FuchsiaReady` as raw zircon signals.
     /// This function is just a more explicit, non-generic version of
     /// `FuchsiaReady::into`.
     #[inline]
-    pub fn into_mx_signals(self) -> mx_signals_t {
-        mx_signals_t::from_bits_truncate(ready_as_usize(self.0) as u32)
+    pub fn into_zx_signals(self) -> zx_signals_t {
+        zx_signals_t::from_bits_truncate(ready_as_usize(self.0) as u32)
     }
 }
 
-impl Into<mx_signals_t> for FuchsiaReady {
+impl Into<zx_signals_t> for FuchsiaReady {
     #[inline]
-    fn into(self) -> mx_signals_t {
-        self.into_mx_signals()
+    fn into(self) -> zx_signals_t {
+        self.into_zx_signals()
     }
 }
 
-impl From<mx_signals_t> for FuchsiaReady {
+impl From<zx_signals_t> for FuchsiaReady {
     #[inline]
-    fn from(src: mx_signals_t) -> Self {
+    fn from(src: zx_signals_t) -> Self {
         FuchsiaReady(src.into())
     }
 }
 
-impl From<mx_signals_t> for Ready {
+impl From<zx_signals_t> for Ready {
     #[inline]
-    fn from(src: mx_signals_t) -> Self {
+    fn from(src: zx_signals_t) -> Self {
         ready_from_usize(src.bits() as usize)
     }
 }
@@ -144,38 +144,38 @@ impl ops::Not for FuchsiaReady {
     }
 }
 
-impl ops::BitOr<mx_signals_t> for FuchsiaReady {
+impl ops::BitOr<zx_signals_t> for FuchsiaReady {
     type Output = FuchsiaReady;
 
     #[inline]
-    fn bitor(self, other: mx_signals_t) -> FuchsiaReady {
+    fn bitor(self, other: zx_signals_t) -> FuchsiaReady {
         self | FuchsiaReady::from(other)
     }
 }
 
-impl ops::BitXor<mx_signals_t> for FuchsiaReady {
+impl ops::BitXor<zx_signals_t> for FuchsiaReady {
     type Output = FuchsiaReady;
 
     #[inline]
-    fn bitxor(self, other: mx_signals_t) -> FuchsiaReady {
+    fn bitxor(self, other: zx_signals_t) -> FuchsiaReady {
         self ^ FuchsiaReady::from(other)
     }
 }
 
-impl ops::BitAnd<mx_signals_t> for FuchsiaReady {
+impl ops::BitAnd<zx_signals_t> for FuchsiaReady {
     type Output = FuchsiaReady;
 
     #[inline]
-    fn bitand(self, other: mx_signals_t) -> FuchsiaReady {
+    fn bitand(self, other: zx_signals_t) -> FuchsiaReady {
         self & FuchsiaReady::from(other)
     }
 }
 
-impl ops::Sub<mx_signals_t> for FuchsiaReady {
+impl ops::Sub<zx_signals_t> for FuchsiaReady {
     type Output = FuchsiaReady;
 
     #[inline]
-    fn sub(self, other: mx_signals_t) -> FuchsiaReady {
+    fn sub(self, other: zx_signals_t) -> FuchsiaReady {
         self - FuchsiaReady::from(other)
     }
 }

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -12,7 +12,7 @@ extern crate slab;
 extern crate tempdir;
 
 #[cfg(target_os = "fuchsia")]
-extern crate zircon;
+extern crate fuchsia_zircon as zircon;
 
 pub use ports::localhost;
 

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -12,7 +12,7 @@ extern crate slab;
 extern crate tempdir;
 
 #[cfg(target_os = "fuchsia")]
-extern crate magenta;
+extern crate zircon;
 
 pub use ports::localhost;
 

--- a/test/test_fuchsia_handles.rs
+++ b/test/test_fuchsia_handles.rs
@@ -1,6 +1,6 @@
 use mio::*;
 use mio::fuchsia::EventedHandle;
-use magenta::{self, AsHandleRef};
+use zircon::{self, AsHandleRef};
 use std::time::Duration;
 
 const MS: u64 = 1_000;
@@ -11,7 +11,7 @@ pub fn test_fuchsia_channel() {
     let mut event_buffer = Events::with_capacity(1);
     let event_buffer = &mut event_buffer;
 
-    let (channel0, channel1) = magenta::Channel::create(magenta::ChannelOpts::Normal).unwrap();
+    let (channel0, channel1) = zircon::Channel::create(zircon::ChannelOpts::Normal).unwrap();
     let channel1_evented = unsafe { EventedHandle::new(channel1.raw_handle()) };
 
     poll.register(&channel1_evented, Token(1), Ready::readable(), PollOpt::edge()).unwrap();


### PR DESCRIPTION
Fuchsia's kernel got a new name, and the `Status` -> `io::Error` conversions were moved into the `fuchsia_zircon` crate.