### PR TITLE
Poll::poll(): Retry select() on EINTR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* `Poll`: retry select() when interrupted by a signal
+
 # 0.6.11 (October 25, 2017)
 
 * Allow register to take empty interest (#640).


### PR DESCRIPTION
Usually the user should retry poll() on EINTR; however, this is an
easily-overlooked case. Let's improve the reliability of mio-based
programs by handing EINTR by default.

Closes #494.