### PR TITLE
Fix Android CI

### DIFF
--- a/ci/docker/aarch64-linux-android/install-sdk.sh
+++ b/ci/docker/aarch64-linux-android/install-sdk.sh
@@ -26,8 +26,8 @@ curl -o sdk-tools-linux-3859397.zip https://dl.google.com/android/repository/sdk
 
 
 
-yes | sdkmanager --licenses
-sdkmanager tools platform-tools "build-tools;25.0.2" "platforms;android-24" "system-images;android-24;default;arm64-v8a"
+yes | sdkmanager --licenses --no_https
+sdkmanager tools platform-tools "build-tools;25.0.2" "platforms;android-24" "system-images;android-24;default;arm64-v8a" --no_https
 
 echo "no" | avdmanager create avd \
                 --force \

--- a/ci/docker/arm-linux-androideabi/install-sdk.sh
+++ b/ci/docker/arm-linux-androideabi/install-sdk.sh
@@ -25,7 +25,7 @@ curl https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz | \
 filter="platform-tools,android-21"
 filter="$filter,sys-img-armeabi-v7a-android-21"
 
-./accept-licenses.sh "android - update sdk -a --no-ui --filter $filter"
+./accept-licenses.sh "android - update sdk -a --no-ui --filter $filter --no-https"
 
 echo "no" | android create avd \
                 --name arm-21 \


### PR DESCRIPTION
Fixes #744.

@malbarbo pointed out that `libc` also had a similar problem (rust-lang/libc#791). The fix is to disable HTTPS when updating the SDK.