### PR TITLE
Ensure html_root_url is kept in sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,10 @@ miow   = "0.2.1"
 kernel32-sys = "0.2"
 
 [dev-dependencies]
-env_logger = { version = "0.4.0", default-features = false }
-tempdir    = "0.3.4"
-bytes      = "0.3.0"
+env_logger   = { version = "0.4.0", default-features = false }
+version-sync = "0.4"
+tempdir      = "0.3.4"
+bytes        = "0.3.0"
 
 [[test]]
 name = "test"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@
 //!
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/mio/0.6.1")]
+#![doc(html_root_url = "https://docs.rs/mio/0.6.11")]
 #![crate_name = "mio"]
 
 #![deny(warnings, missing_docs, missing_debug_implementations)]

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -10,6 +10,8 @@ extern crate env_logger;
 extern crate iovec;
 extern crate slab;
 extern crate tempdir;
+#[macro_use]
+extern crate version_sync;
 
 #[cfg(target_os = "fuchsia")]
 extern crate fuchsia_zircon as zircon;
@@ -33,6 +35,7 @@ mod test_tcp_level;
 mod test_udp_level;
 mod test_udp_socket;
 mod test_write_then_drop;
+mod test_version_numbers;
 
 #[cfg(feature = "with-deprecated")]
 mod test_notify;

--- a/test/test_version_numbers.rs
+++ b/test/test_version_numbers.rs
@@ -1,0 +1,9 @@
+#[test]
+fn test_readme_deps() {
+    assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
This adds two new unit tests: one that checks that the html_root_url
attribute always uses the current crate version number, and one that
checks that the TOML code blocks in the README use the correct version
number.

This is implemented by my version-sync crate -- I hope it's useful!

Fixes #613.