### PR TITLE
Split `Poll` into `Poll` and `Register`

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -1,11 +1,11 @@
-use {Poll, Token};
+use {Register, Token};
 use std::{fmt, io, ops};
 
-/// A value that may be registered with `Poll`
+/// A value that may be registered with `Register`
 ///
-/// Values that implement `Evented` can be registered with `Poll`. Users of Mio
-/// should not use the `Evented` trait functions directly. Instead, the
-/// equivalent functions on `Poll` should be used.
+/// Values that implement `Evented` can be registered with `Register`. Users of
+/// Mio should not use the `Evented` trait functions directly. Instead, the
+/// equivalent functions on `Register` should be used.
 ///
 /// See [`Poll`] for more details.
 ///
@@ -30,7 +30,7 @@ use std::{fmt, io, ops};
 /// Implementing `Evented` on a struct containing a socket:
 ///
 /// ```
-/// use mio::{Ready, Poll, PollOpt, Token};
+/// use mio::{Ready, Register, PollOpt, Token};
 /// use mio::event::Evented;
 /// use mio::net::TcpStream;
 ///
@@ -41,23 +41,23 @@ use std::{fmt, io, ops};
 /// }
 ///
 /// impl Evented for MyEvented {
-///     fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
 ///         // Delegate the `register` call to `socket`
-///         self.socket.register(poll, token, interest, opts)
+///         self.socket.register(register, token, interest, opts)
 ///     }
 ///
-///     fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
 ///         // Delegate the `reregister` call to `socket`
-///         self.socket.reregister(poll, token, interest, opts)
+///         self.socket.reregister(register, token, interest, opts)
 ///     }
 ///
-///     fn deregister(&self, poll: &Poll) -> io::Result<()> {
+///     fn deregister(&self, register: &Register) -> io::Result<()> {
 ///         // Delegate the `deregister` call to `socket`
-///         self.socket.deregister(poll)
+///         self.socket.deregister(register)
 ///     }
 /// }
 /// ```
@@ -65,7 +65,7 @@ use std::{fmt, io, ops};
 /// Implement `Evented` using [`Registration`] and [`SetReadiness`].
 ///
 /// ```
-/// use mio::{Ready, Registration, Poll, PollOpt, Token};
+/// use mio::{Ready, Registration, Register, PollOpt, Token};
 /// use mio::event::Evented;
 ///
 /// use std::io;
@@ -79,7 +79,7 @@ use std::{fmt, io, ops};
 ///
 /// impl Deadline {
 ///     pub fn new(when: Instant) -> Deadline {
-///         let (registration, set_readiness) = Registration::new2();
+///         let (registration, set_readiness) = Registration::new();
 ///
 ///         thread::spawn(move || {
 ///             let now = Instant::now();
@@ -103,58 +103,58 @@ use std::{fmt, io, ops};
 /// }
 ///
 /// impl Evented for Deadline {
-///     fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.register(poll, token, interest, opts)
+///         self.registration.register(register, token, interest, opts)
 ///     }
 ///
-///     fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.reregister(poll, token, interest, opts)
+///         self.registration.reregister(register, token, interest, opts)
 ///     }
 ///
-///     fn deregister(&self, poll: &Poll) -> io::Result<()> {
-///         self.registration.deregister(poll)
+///     fn deregister(&self, register: &Register) -> io::Result<()> {
+///         self.registration.deregister(register)
 ///     }
 /// }
 /// ```
 pub trait Evented {
-    /// Register `self` with the given `Poll` instance.
+    /// Register `self` with the given `Register` instance.
     ///
-    /// This function should not be called directly. Use [`Poll::register`]
+    /// This function should not be called directly. Use [`Register::register`]
     /// instead. Implementors should handle registration by either delegating
     /// the call to another `Evented` type or creating a [`Registration`].
     ///
-    /// [`Poll::register`]: ../struct.Poll.html#method.register
+    /// [`Register::register`]: ../struct.Register.html#method.register
     /// [`Registration`]: ../struct.Registration.html
-    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()>;
+    fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()>;
 
-    /// Re-register `self` with the given `Poll` instance.
+    /// Re-register `self` with the given `Register` instance.
     ///
-    /// This function should not be called directly. Use [`Poll::reregister`]
+    /// This function should not be called directly. Use [`Register::reregister`]
     /// instead. Implementors should handle re-registration by either delegating
     /// the call to another `Evented` type or calling
     /// [`SetReadiness::set_readiness`].
     ///
-    /// [`Poll::reregister`]: ../struct.Poll.html#method.reregister
+    /// [`Register::reregister`]: ../struct.Register.html#method.reregister
     /// [`SetReadiness::set_readiness`]: ../struct.SetReadiness.html#method.set_readiness
-    fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()>;
+    fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()>;
 
-    /// Deregister `self` from the given `Poll` instance
+    /// Deregister `self` from the given `Register` instance
     ///
-    /// This function should not be called directly. Use [`Poll::deregister`]
+    /// This function should not be called directly. Use [`Register::deregister`]
     /// instead. Implementors should handle deregistration by either delegating
     /// the call to another `Evented` type or by dropping the [`Registration`]
     /// associated with `self`.
     ///
-    /// [`Poll::deregister`]: ../struct.Poll.html#method.deregister
+    /// [`Register::deregister`]: ../struct.Register.html#method.deregister
     /// [`Registration`]: ../struct.Registration.html
-    fn deregister(&self, poll: &Poll) -> io::Result<()>;
+    fn deregister(&self, register: &Register) -> io::Result<()>;
 }
 
-/// Options supplied when registering an `Evented` handle with `Poll`
+/// Options supplied when registering an `Evented` handle with `Register`
 ///
 /// `PollOpt` values can be combined together using the various bitwise
 /// operators.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,17 +37,19 @@
 //! let server = TcpListener::bind(&addr).unwrap();
 //!
 //! // Create a poll instance
-//! let poll = Poll::new().unwrap();
+//! let mut poll = Poll::new().unwrap();
 //!
 //! // Start listening for incoming connections
-//! poll.register(&server, SERVER, Ready::readable(),
+//! poll.register()
+//!     .register(&server, SERVER, Ready::readable(),
 //!               PollOpt::edge()).unwrap();
 //!
 //! // Setup the client socket
 //! let sock = TcpStream::connect(&addr).unwrap();
 //!
 //! // Register the socket
-//! poll.register(&sock, CLIENT, Ready::readable(),
+//! poll.register()
+//!     .register(&sock, CLIENT, Ready::readable(),
 //!               PollOpt::edge()).unwrap();
 //!
 //! // Create storage for events
@@ -114,6 +116,7 @@ pub mod net;
 
 pub use poll::{
     Poll,
+    Register,
     Registration,
     SetReadiness,
 };

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use net2::TcpBuilder;
 use iovec::IoVec;
 
-use {io, sys, Ready, Poll, PollOpt, Token};
+use {io, sys, Ready, Register, PollOpt, Token};
 use event::Evented;
 use poll::SelectorId;
 
@@ -43,12 +43,13 @@ use poll::SelectorId;
 ///
 /// let stream = TcpStream::connect(&"127.0.0.1:34254".parse()?)?;
 ///
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 /// let mut events = Events::with_capacity(128);
 ///
 /// // Register the socket with `Poll`
-/// poll.register(&stream, Token(0), Ready::writable(),
-///               PollOpt::edge())?;
+/// poll.register().register(
+///     &stream, Token(0), Ready::writable(),
+///     PollOpt::edge())?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
 ///
@@ -389,19 +390,19 @@ impl<'a> Write for &'a TcpStream {
 }
 
 impl Evented for TcpStream {
-    fn register(&self, poll: &Poll, token: Token,
+    fn register(&self, register: &Register, token: Token,
                 interest: Ready, opts: PollOpt) -> io::Result<()> {
-        self.selector_id.associate_selector(poll)?;
-        self.sys.register(poll, token, interest, opts)
+        self.selector_id.associate_selector(register)?;
+        self.sys.register(register, token, interest, opts)
     }
 
-    fn reregister(&self, poll: &Poll, token: Token,
+    fn reregister(&self, register: &Register, token: Token,
                   interest: Ready, opts: PollOpt) -> io::Result<()> {
-        self.sys.reregister(poll, token, interest, opts)
+        self.sys.reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.sys.deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        self.sys.deregister(register)
     }
 }
 
@@ -424,11 +425,12 @@ impl Evented for TcpStream {
 ///
 /// let listener = TcpListener::bind(&"127.0.0.1:34254".parse()?)?;
 ///
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 /// let mut events = Events::with_capacity(128);
 ///
 /// // Register the socket with `Poll`
-/// poll.register(&listener, Token(0), Ready::writable(),
+/// poll.register()
+///     .register(&listener, Token(0), Ready::writable(),
 ///               PollOpt::edge())?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
@@ -574,19 +576,19 @@ impl TcpListener {
 }
 
 impl Evented for TcpListener {
-    fn register(&self, poll: &Poll, token: Token,
+    fn register(&self, register: &Register, token: Token,
                 interest: Ready, opts: PollOpt) -> io::Result<()> {
-        self.selector_id.associate_selector(poll)?;
-        self.sys.register(poll, token, interest, opts)
+        self.selector_id.associate_selector(register)?;
+        self.sys.register(register, token, interest, opts)
     }
 
-    fn reregister(&self, poll: &Poll, token: Token,
+    fn reregister(&self, register: &Register, token: Token,
                   interest: Ready, opts: PollOpt) -> io::Result<()> {
-        self.sys.reregister(poll, token, interest, opts)
+        self.sys.reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.sys.deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        self.sys.deregister(register)
     }
 }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -7,7 +7,7 @@
 //!
 /// [portability guidelines]: ../struct.Poll.html#portability
 
-use {io, sys, Ready, Poll, PollOpt, Token};
+use {io, sys, Ready, Register, PollOpt, Token};
 use event::Evented;
 use poll::SelectorId;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -273,17 +273,17 @@ impl UdpSocket {
 }
 
 impl Evented for UdpSocket {
-    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        self.selector_id.associate_selector(poll)?;
-        self.sys.register(poll, token, interest, opts)
+    fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        self.selector_id.associate_selector(register)?;
+        self.sys.register(register, token, interest, opts)
     }
 
-    fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        self.sys.reregister(poll, token, interest, opts)
+    fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        self.sys.reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.sys.deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        self.sys.deregister(register)
     }
 }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -7,9 +7,9 @@ use std::{mem, ops, isize};
 use std::os::unix::io::AsRawFd;
 #[cfg(all(unix, not(target_os = "fuchsia")))]
 use std::os::unix::io::RawFd;
-use std::sync::{Arc, Mutex, Condvar};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, AtomicPtr, AtomicBool};
-use std::sync::atomic::Ordering::{self, Acquire, Release, AcqRel, Relaxed, SeqCst};
+use std::sync::atomic::Ordering::{self, Acquire, Release, AcqRel, Relaxed};
 use std::time::{Duration, Instant};
 
 // Poll is backed by two readiness queues. The first is a system readiness queue
@@ -99,14 +99,15 @@ use std::time::{Duration, Instant};
 /// let server = TcpListener::bind(&addr)?;
 ///
 /// // Construct a new `Poll` handle as well as the `Events` we'll store into
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 /// let mut events = Events::with_capacity(1024);
 ///
 /// // Connect the stream
 /// let stream = TcpStream::connect(&server.local_addr()?)?;
 ///
 /// // Register the stream with `Poll`
-/// poll.register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+/// poll.register()
+///     .register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
 ///
 /// // Wait for the socket to become ready. This has to happens in a loop to
 /// // handle spurious wakeups.
@@ -274,11 +275,12 @@ use std::time::{Duration, Instant};
 ///
 /// thread::sleep(Duration::from_secs(1));
 ///
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 ///
 /// // The connect is not guaranteed to have started until it is registered at
 /// // this point
-/// poll.register(&sock, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+/// poll.register()
+///     .register(&sock, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
 /// #     Ok(())
 /// # }
 /// #
@@ -325,21 +327,22 @@ use std::time::{Duration, Instant};
 /// [`SetReadiness`]: struct.SetReadiness.html
 /// [`Poll::poll`]: struct.Poll.html#method.poll
 pub struct Poll {
+    register: Register,
+}
+
+/// Registers I/O resources.
+#[derive(Debug, Clone)]
+pub struct Register {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
     // Platform specific IO selector
     selector: sys::Selector,
 
     // Custom readiness queue
     readiness_queue: ReadinessQueue,
-
-    // Use an atomic to first check if a full lock will be required. This is a
-    // fast-path check for single threaded cases avoiding the extra syscall
-    lock_state: AtomicUsize,
-
-    // Sequences concurrent calls to `Poll::poll`
-    lock: Mutex<()>,
-
-    // Wakeup the next waiter
-    condvar: Condvar,
 }
 
 /// Handle to a user space `Poll` registration.
@@ -352,7 +355,7 @@ pub struct Poll {
 /// by [`poll`].
 ///
 /// A `Registration` / `SetReadiness` pair is created by calling
-/// [`Registration::new2`]. At this point, the registration is not being
+/// [`Registration::new`]. At this point, the registration is not being
 /// monitored by a [`Poll`] instance, so calls to `set_readiness` will not
 /// result in any readiness notifications.
 ///
@@ -371,7 +374,7 @@ pub struct Poll {
 /// # Examples
 ///
 /// ```
-/// use mio::{Ready, Registration, Poll, PollOpt, Token};
+/// use mio::{Ready, Registration, Register, PollOpt, Token};
 /// use mio::event::Evented;
 ///
 /// use std::io;
@@ -385,7 +388,7 @@ pub struct Poll {
 ///
 /// impl Deadline {
 ///     pub fn new(when: Instant) -> Deadline {
-///         let (registration, set_readiness) = Registration::new2();
+///         let (registration, set_readiness) = Registration::new();
 ///
 ///         thread::spawn(move || {
 ///             let now = Instant::now();
@@ -409,27 +412,27 @@ pub struct Poll {
 /// }
 ///
 /// impl Evented for Deadline {
-///     fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.register(poll, token, interest, opts)
+///         self.registration.register(register, token, interest, opts)
 ///     }
 ///
-///     fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         self.registration.reregister(poll, token, interest, opts)
+///         self.registration.reregister(register, token, interest, opts)
 ///     }
 ///
-///     fn deregister(&self, poll: &Poll) -> io::Result<()> {
-///         self.registration.deregister(poll)
+///     fn deregister(&self, register: &Register) -> io::Result<()> {
+///         self.registration.deregister(register)
 ///     }
 /// }
 /// ```
 ///
 /// [system selector]: struct.Poll.html#implementation-notes
 /// [`Poll`]: struct.Poll.html
-/// [`Registration::new2`]: struct.Registration.html#method.new2
+/// [`Registration::new`]: struct.Registration.html#method.new
 /// [`Evented`]: event/trait.Evented.html
 /// [`set_readiness`]: struct.SetReadiness.html#method.set_readiness
 /// [`register`]: struct.Poll.html#method.register
@@ -628,7 +631,7 @@ impl Poll {
     /// use mio::{Poll, Events};
     /// use std::time::Duration;
     ///
-    /// let poll = match Poll::new() {
+    /// let mut poll = match Poll::new() {
     ///     Ok(poll) => poll,
     ///     Err(e) => panic!("failed to create Poll instance; err={:?}", e),
     /// };
@@ -638,8 +641,7 @@ impl Poll {
     ///
     /// // Wait for events, but none will be received because no `Evented`
     /// // handles have been registered with this `Poll` instance.
-    /// let n = poll.poll(&mut events, Some(Duration::from_millis(500)))?;
-    /// assert_eq!(n, 0);
+    /// poll.poll(&mut events, Some(Duration::from_millis(500)))?;
     /// #     Ok(())
     /// # }
     /// #
@@ -652,19 +654,177 @@ impl Poll {
         is_sync::<Poll>();
 
         let poll = Poll {
-            selector: sys::Selector::new()?,
-            readiness_queue: ReadinessQueue::new()?,
-            lock_state: AtomicUsize::new(0),
-            lock: Mutex::new(()),
-            condvar: Condvar::new(),
+            register: Register {
+                inner: Arc::new(Inner {
+                    selector: sys::Selector::new()?,
+                    readiness_queue: ReadinessQueue::new()?,
+                }),
+            },
         };
 
         // Register the notification wakeup FD with the IO poller
-        poll.readiness_queue.inner.awakener.register(&poll, AWAKEN, Ready::readable(), PollOpt::edge())?;
+        poll.register.inner.readiness_queue.inner
+            .awakener.register(
+                poll.register(),
+                AWAKEN,
+                Ready::readable(),
+                PollOpt::edge())?;
 
         Ok(poll)
     }
 
+    /// Returns a reference to the `Register` for this `Poll` instance
+    pub fn register(&self) -> &Register {
+        &self.register
+    }
+
+    /// Wait for readiness events
+    ///
+    /// Blocks the current thread and waits for readiness events for any of the
+    /// `Evented` handles that have been registered with this `Poll` instance.
+    /// The function will block until either at least one readiness event has
+    /// been received or `timeout` has elapsed. A `timeout` of `None` means that
+    /// `poll` will block until a readiness event has been received.
+    ///
+    /// The supplied `events` will be cleared and newly received readiness events
+    /// will be pushed onto the end. At most `events.capacity()` events will be
+    /// returned. If there are further pending readiness events, they will be
+    /// returned on the next call to `poll`.
+    ///
+    /// A single call to `poll` may result in multiple readiness events being
+    /// returned for a single `Evented` handle. For example, if a TCP socket
+    /// becomes both readable and writable, it may be possible for a single
+    /// readiness event to be returned with both [`readable`] and [`writable`]
+    /// readiness **OR** two separate events may be returned, one with
+    /// [`readable`] set and one with [`writable`] set.
+    ///
+    /// Note that the `timeout` will be rounded up to the system clock
+    /// granularity (usually 1ms), and kernel scheduling delays mean that
+    /// the blocking interval may be overrun by a small amount.
+    ///
+    /// See the [struct] level documentation for a higher level discussion of
+    /// polling.
+    ///
+    /// [`readable`]: struct.Ready.html#method.readable
+    /// [`writable`]: struct.Ready.html#method.writable
+    /// [struct]: #
+    /// [`iter`]: struct.Events.html#method.iter
+    ///
+    /// # Examples
+    ///
+    /// A basic example -- establishing a `TcpStream` connection.
+    ///
+    /// ```
+    /// # use std::error::Error;
+    /// # fn try_main() -> Result<(), Box<Error>> {
+    /// use mio::{Events, Poll, Ready, PollOpt, Token};
+    /// use mio::net::TcpStream;
+    ///
+    /// use std::net::{TcpListener, SocketAddr};
+    /// use std::thread;
+    ///
+    /// // Bind a server socket to connect to.
+    /// let addr: SocketAddr = "127.0.0.1:0".parse()?;
+    /// let server = TcpListener::bind(&addr)?;
+    /// let addr = server.local_addr()?.clone();
+    ///
+    /// // Spawn a thread to accept the socket
+    /// thread::spawn(move || {
+    ///     let _ = server.accept();
+    /// });
+    ///
+    /// // Construct a new `Poll` handle as well as the `Events` we'll store into
+    /// let mut poll = Poll::new()?;
+    /// let mut events = Events::with_capacity(1024);
+    ///
+    /// // Connect the stream
+    /// let stream = TcpStream::connect(&addr)?;
+    ///
+    /// // Register the stream with `Poll`
+    /// poll.register()
+    ///     .register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+    ///
+    /// // Wait for the socket to become ready. This has to happens in a loop to
+    /// // handle spurious wakeups.
+    /// loop {
+    ///     poll.poll(&mut events, None)?;
+    ///
+    ///     for event in &events {
+    ///         if event.token() == Token(0) && event.readiness().is_writable() {
+    ///             // The socket connected (probably, it could still be a spurious
+    ///             // wakeup)
+    ///             return Ok(());
+    ///         }
+    ///     }
+    /// }
+    /// #     Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     try_main().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [struct]: #
+    pub fn poll(&mut self, events: &mut Events, mut timeout: Option<Duration>)
+        -> io::Result<()>
+    {
+        let inner = &*self.register.inner;
+
+        // Compute the timeout value passed to the system selector. If the
+        // readiness queue has pending nodes, we still want to poll the system
+        // selector for new events, but we don't want to block the thread to
+        // wait for new events.
+        if timeout == Some(Duration::from_millis(0)) {
+            // If blocking is not requested, then there is no need to prepare
+            // the queue for sleep
+        } else if inner.readiness_queue.prepare_for_sleep() {
+            // The readiness queue is empty. The call to `prepare_for_sleep`
+            // inserts `sleep_marker` into the queue. This signals to any
+            // threads setting readiness that the `Poll::poll` is going to
+            // sleep, so the awakener should be used.
+        } else {
+            // The readiness queue is not empty, so do not block the thread.
+            timeout = Some(Duration::from_millis(0));
+        }
+
+        loop {
+            let now = Instant::now();
+
+            // First get selector events
+            let res = inner.selector.select(&mut events.inner, AWAKEN, timeout);
+
+            match res {
+                Ok(true) => {
+                    // Some awakeners require reading from a FD.
+                    inner.readiness_queue.inner.awakener.cleanup();
+                    break;
+                }
+                Ok(false) => break,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {
+                    // Interrupted by a signal; update timeout if necessary and retry
+                    if let Some(to) = timeout {
+                        let elapsed = now.elapsed();
+                        if elapsed >= to {
+                            break;
+                        } else {
+                            timeout = Some(to - elapsed);
+                        }
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        // Poll custom event queue
+        inner.readiness_queue.poll(&mut events.inner);
+
+        // Return number of polled events
+        Ok(())
+    }
+}
+
+impl Register {
     /// Register an `Evented` handle with the `Poll` instance.
     ///
     /// Once registered, the `Poll` instance will monitor the `Evented` handle
@@ -737,11 +897,12 @@ impl Poll {
     /// use mio::net::TcpStream;
     /// use std::time::{Duration, Instant};
     ///
-    /// let poll = Poll::new()?;
+    /// let mut poll = Poll::new()?;
     /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
     ///
     /// // Register the socket with `poll`
-    /// poll.register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+    /// poll.register()
+    ///     .register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
     ///
     /// let mut events = Events::with_capacity(1024);
     /// let start = Instant::now();
@@ -821,16 +982,18 @@ impl Poll {
     /// use mio::{Poll, Ready, PollOpt, Token};
     /// use mio::net::TcpStream;
     ///
-    /// let poll = Poll::new()?;
+    /// let mut poll = Poll::new()?;
     /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
     ///
     /// // Register the socket with `poll`, requesting readable
-    /// poll.register(&socket, Token(0), Ready::readable(), PollOpt::edge())?;
+    /// poll.register()
+    ///     .register(&socket, Token(0), Ready::readable(), PollOpt::edge())?;
     ///
     /// // Reregister the socket specifying a different token and write interest
     /// // instead. `PollOpt::edge()` must be specified even though that value
     /// // is not being changed.
-    /// poll.reregister(&socket, Token(2), Ready::writable(), PollOpt::edge())?;
+    /// poll.register()
+    ///     .reregister(&socket, Token(2), Ready::writable(), PollOpt::edge())?;
     /// #     Ok(())
     /// # }
     /// #
@@ -879,19 +1042,20 @@ impl Poll {
     /// use mio::net::TcpStream;
     /// use std::time::Duration;
     ///
-    /// let poll = Poll::new()?;
+    /// let mut poll = Poll::new()?;
     /// let socket = TcpStream::connect(&"216.58.193.100:80".parse()?)?;
     ///
     /// // Register the socket with `poll`
-    /// poll.register(&socket, Token(0), Ready::readable(), PollOpt::edge())?;
+    /// poll.register()
+    ///     .register(&socket, Token(0), Ready::readable(), PollOpt::edge())?;
     ///
-    /// poll.deregister(&socket)?;
+    /// poll.register().deregister(&socket)?;
     ///
     /// let mut events = Events::with_capacity(1024);
     ///
     /// // Set a timeout because this poll should never receive any events.
-    /// let n = poll.poll(&mut events, Some(Duration::from_secs(1)))?;
-    /// assert_eq!(0, n);
+    /// poll.poll(&mut events, Some(Duration::from_secs(1)))?;
+    /// assert_eq!(0, events.iter().count());
     /// #     Ok(())
     /// # }
     /// #
@@ -908,284 +1072,6 @@ impl Poll {
         handle.deregister(self)?;
 
         Ok(())
-    }
-
-    /// Wait for readiness events
-    ///
-    /// Blocks the current thread and waits for readiness events for any of the
-    /// `Evented` handles that have been registered with this `Poll` instance.
-    /// The function will block until either at least one readiness event has
-    /// been received or `timeout` has elapsed. A `timeout` of `None` means that
-    /// `poll` will block until a readiness event has been received.
-    ///
-    /// The supplied `events` will be cleared and newly received readiness events
-    /// will be pushed onto the end. At most `events.capacity()` events will be
-    /// returned. If there are further pending readiness events, they will be
-    /// returned on the next call to `poll`.
-    ///
-    /// A single call to `poll` may result in multiple readiness events being
-    /// returned for a single `Evented` handle. For example, if a TCP socket
-    /// becomes both readable and writable, it may be possible for a single
-    /// readiness event to be returned with both [`readable`] and [`writable`]
-    /// readiness **OR** two separate events may be returned, one with
-    /// [`readable`] set and one with [`writable`] set.
-    ///
-    /// Note that the `timeout` will be rounded up to the system clock
-    /// granularity (usually 1ms), and kernel scheduling delays mean that
-    /// the blocking interval may be overrun by a small amount.
-    ///
-    /// `poll` returns the number of readiness events that have been pushed into
-    /// `events` or `Err` when an error has been encountered with the system
-    /// selector.  The value returned is deprecated and will be removed in 0.7.0.
-    /// Accessing the events by index is also deprecated.  Events can be
-    /// inserted by other events triggering, thus making sequential access
-    /// problematic.  Use the iterator API instead.  See [`iter`].
-    ///
-    /// See the [struct] level documentation for a higher level discussion of
-    /// polling.
-    ///
-    /// [`readable`]: struct.Ready.html#method.readable
-    /// [`writable`]: struct.Ready.html#method.writable
-    /// [struct]: #
-    /// [`iter`]: struct.Events.html#method.iter
-    ///
-    /// # Examples
-    ///
-    /// A basic example -- establishing a `TcpStream` connection.
-    ///
-    /// ```
-    /// # use std::error::Error;
-    /// # fn try_main() -> Result<(), Box<Error>> {
-    /// use mio::{Events, Poll, Ready, PollOpt, Token};
-    /// use mio::net::TcpStream;
-    ///
-    /// use std::net::{TcpListener, SocketAddr};
-    /// use std::thread;
-    ///
-    /// // Bind a server socket to connect to.
-    /// let addr: SocketAddr = "127.0.0.1:0".parse()?;
-    /// let server = TcpListener::bind(&addr)?;
-    /// let addr = server.local_addr()?.clone();
-    ///
-    /// // Spawn a thread to accept the socket
-    /// thread::spawn(move || {
-    ///     let _ = server.accept();
-    /// });
-    ///
-    /// // Construct a new `Poll` handle as well as the `Events` we'll store into
-    /// let poll = Poll::new()?;
-    /// let mut events = Events::with_capacity(1024);
-    ///
-    /// // Connect the stream
-    /// let stream = TcpStream::connect(&addr)?;
-    ///
-    /// // Register the stream with `Poll`
-    /// poll.register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
-    ///
-    /// // Wait for the socket to become ready. This has to happens in a loop to
-    /// // handle spurious wakeups.
-    /// loop {
-    ///     poll.poll(&mut events, None)?;
-    ///
-    ///     for event in &events {
-    ///         if event.token() == Token(0) && event.readiness().is_writable() {
-    ///             // The socket connected (probably, it could still be a spurious
-    ///             // wakeup)
-    ///             return Ok(());
-    ///         }
-    ///     }
-    /// }
-    /// #     Ok(())
-    /// # }
-    /// #
-    /// # fn main() {
-    /// #     try_main().unwrap();
-    /// # }
-    /// ```
-    ///
-    /// [struct]: #
-    pub fn poll(&self, events: &mut Events, mut timeout: Option<Duration>) -> io::Result<usize> {
-        let zero = Some(Duration::from_millis(0));
-
-        // At a high level, the synchronization strategy is to acquire access to
-        // the critical section by transitioning the atomic from unlocked ->
-        // locked. If the attempt fails, the thread will wait on the condition
-        // variable.
-        //
-        // # Some more detail
-        //
-        // The `lock_state` atomic usize combines:
-        //
-        // - locked flag, stored in the least significant bit
-        // - number of waiting threads, stored in the rest of the bits.
-        //
-        // When a thread transitions the locked flag from 0 -> 1, it has
-        // obtained access to the critical section.
-        //
-        // When entering `poll`, a compare-and-swap from 0 -> 1 is attempted.
-        // This is a fast path for the case when there are no concurrent calls
-        // to poll, which is very common.
-        //
-        // On failure, the mutex is locked, and the thread attempts to increment
-        // the number of waiting threads component of `lock_state`. If this is
-        // successfully done while the locked flag is set, then the thread can
-        // wait on the condition variable.
-        //
-        // When a thread exits the critical section, it unsets the locked flag.
-        // If there are any waiters, which is atomically determined while
-        // unsetting the locked flag, then the condvar is notified.
-
-        let mut curr = self.lock_state.compare_and_swap(0, 1, SeqCst);
-
-        if 0 != curr {
-            // Enter slower path
-            let mut lock = self.lock.lock().unwrap();
-            let mut inc = false;
-
-            loop {
-                if curr & 1 == 0 {
-                    // The lock is currently free, attempt to grab it
-                    let mut next = curr | 1;
-
-                    if inc {
-                        // The waiter count has previously been incremented, so
-                        // decrement it here
-                        next -= 2;
-                    }
-
-                    let actual = self.lock_state.compare_and_swap(curr, next, SeqCst);
-
-                    if actual != curr {
-                        curr = actual;
-                        continue;
-                    }
-
-                    // Lock acquired, break from the loop
-                    break;
-                }
-
-                if timeout == zero {
-                    if inc {
-                        self.lock_state.fetch_sub(2, SeqCst);
-                    }
-
-                    return Ok(0);
-                }
-
-                // The lock is currently held, so wait for it to become
-                // free. If the waiter count hasn't been incremented yet, do
-                // so now
-                if !inc {
-                    let next = curr.checked_add(2).expect("overflow");
-                    let actual = self.lock_state.compare_and_swap(curr, next, SeqCst);
-
-                    if actual != curr {
-                        curr = actual;
-                        continue;
-                    }
-
-                    // Track that the waiter count has been incremented for
-                    // this thread and fall through to the condvar waiting
-                    inc = true;
-                }
-
-                lock = match timeout {
-                    Some(to) => {
-                        let now = Instant::now();
-
-                        // Wait to be notified
-                        let (l, _) = self.condvar.wait_timeout(lock, to).unwrap();
-
-                        // See how much time was elapsed in the wait
-                        let elapsed = now.elapsed();
-
-                        // Update `timeout` to reflect how much time is left to
-                        // wait.
-                        if elapsed >= to {
-                            timeout = zero;
-                        } else {
-                            // Update the timeout
-                            timeout = Some(to - elapsed);
-                        }
-
-                        l
-                    }
-                    None => {
-                        self.condvar.wait(lock).unwrap()
-                    }
-                };
-
-                // Reload the state
-                curr = self.lock_state.load(SeqCst);
-
-                // Try to lock again...
-            }
-        }
-
-        let ret = self.poll2(events, timeout);
-
-        // Release the lock
-        if 1 != self.lock_state.fetch_and(!1, Release) {
-            // Acquire the mutex
-            let _lock = self.lock.lock().unwrap();
-
-            // There is at least one waiting thread, so notify one
-            self.condvar.notify_one();
-        }
-
-        ret
-    }
-
-    #[inline]
-    fn poll2(&self, events: &mut Events, mut timeout: Option<Duration>) -> io::Result<usize> {
-        // Compute the timeout value passed to the system selector. If the
-        // readiness queue has pending nodes, we still want to poll the system
-        // selector for new events, but we don't want to block the thread to
-        // wait for new events.
-        if timeout == Some(Duration::from_millis(0)) {
-            // If blocking is not requested, then there is no need to prepare
-            // the queue for sleep
-        } else if self.readiness_queue.prepare_for_sleep() {
-            // The readiness queue is empty. The call to `prepare_for_sleep`
-            // inserts `sleep_marker` into the queue. This signals to any
-            // threads setting readiness that the `Poll::poll` is going to
-            // sleep, so the awakener should be used.
-        } else {
-            // The readiness queue is not empty, so do not block the thread.
-            timeout = Some(Duration::from_millis(0));
-        }
-
-        loop {
-            let now = Instant::now();
-            // First get selector events
-            let res = self.selector.select(&mut events.inner, AWAKEN, timeout);
-            match res {
-                Ok(true) => {
-                    // Some awakeners require reading from a FD.
-                    self.readiness_queue.inner.awakener.cleanup();
-                    break;
-                }
-                Ok(false) => break,
-                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {
-                    // Interrupted by a signal; update timeout if necessary and retry
-                    if let Some(to) = timeout {
-                        let elapsed = now.elapsed();
-                        if elapsed >= to {
-                            break;
-                        } else {
-                            timeout = Some(to - elapsed);
-                        }
-                    }
-                }
-                Err(e) => return Err(e),
-            }
-        }
-
-        // Poll custom event queue
-        self.readiness_queue.poll(&mut events.inner);
-
-        // Return number of polled events
-        Ok(events.inner.len())
     }
 }
 
@@ -1207,7 +1093,7 @@ impl fmt::Debug for Poll {
 #[cfg(all(unix, not(target_os = "fuchsia")))]
 impl AsRawFd for Poll {
     fn as_raw_fd(&self) -> RawFd {
-        self.selector.as_raw_fd()
+        self.register.inner.selector.as_raw_fd()
     }
 }
 
@@ -1229,9 +1115,9 @@ impl AsRawFd for Poll {
 /// use std::time::Duration;
 ///
 /// let mut events = Events::with_capacity(1024);
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 ///
-/// assert_eq!(0, events.len());
+/// assert_eq!(0, events.iter().count());
 ///
 /// // Register `Evented` handles with `poll`
 ///
@@ -1267,7 +1153,7 @@ pub struct Events {
 /// use std::time::Duration;
 ///
 /// let mut events = Events::with_capacity(1024);
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 ///
 /// // Register handles with `poll`
 ///
@@ -1305,7 +1191,7 @@ pub struct Iter<'a> {
 /// use std::time::Duration;
 ///
 /// let mut events = Events::with_capacity(1024);
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 ///
 /// // Register handles with `poll`
 ///
@@ -1344,18 +1230,6 @@ impl Events {
         Events {
             inner: sys::Events::with_capacity(capacity),
         }
-    }
-
-    #[deprecated(since="0.6.10", note="Index access removed in favor of iterator only API.")]
-    #[doc(hidden)]
-    pub fn get(&self, idx: usize) -> Option<Event> {
-        self.inner.get(idx)
-    }
-
-    #[doc(hidden)]
-    #[deprecated(since="0.6.10", note="Index access removed in favor of iterator only API.")]
-    pub fn len(&self) -> usize {
-        self.inner.len()
     }
 
     /// Returns the number of `Event` values that `self` can hold.
@@ -1397,7 +1271,7 @@ impl Events {
     /// use std::time::Duration;
     ///
     /// let mut events = Events::with_capacity(1024);
-    /// let poll = Poll::new()?;
+    /// let mut poll = Poll::new()?;
     ///
     /// // Register handles with `poll`
     ///
@@ -1472,8 +1346,8 @@ impl fmt::Debug for Events {
 
 // ===== Accessors for internal usage =====
 
-pub fn selector(poll: &Poll) -> &sys::Selector {
-    &poll.selector
+pub fn selector(register: &Register) -> &sys::Selector {
+    &register.inner.selector
 }
 
 /*
@@ -1484,10 +1358,10 @@ pub fn selector(poll: &Poll) -> &sys::Selector {
 
 // TODO: get rid of this, windows depends on it for now
 #[allow(dead_code)]
-pub fn new_registration(poll: &Poll, token: Token, ready: Ready, opt: PollOpt)
+pub fn new_registration(register: &Register, token: Token, ready: Ready, opt: PollOpt)
         -> (Registration, SetReadiness)
 {
-    Registration::new_priv(poll, token, ready, opt)
+    Registration::new_priv(register, token, ready, opt)
 }
 
 impl Registration {
@@ -1505,7 +1379,7 @@ impl Registration {
     /// use mio::{Events, Ready, Registration, Poll, PollOpt, Token};
     /// use std::thread;
     ///
-    /// let (registration, set_readiness) = Registration::new2();
+    /// let (registration, set_readiness) = Registration::new();
     ///
     /// thread::spawn(move || {
     ///     use std::time::Duration;
@@ -1514,8 +1388,9 @@ impl Registration {
     ///     set_readiness.set_readiness(Ready::readable());
     /// });
     ///
-    /// let poll = Poll::new()?;
-    /// poll.register(&registration, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+    /// let mut poll = Poll::new()?;
+    /// poll.register()
+    ///     .register(&registration, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
     ///
     /// let mut events = Events::with_capacity(256);
     ///
@@ -1537,7 +1412,7 @@ impl Registration {
     /// ```
     /// [struct]: #
     /// [`Poll`]: struct.Poll.html
-    pub fn new2() -> (Registration, SetReadiness) {
+    pub fn new() -> (Registration, SetReadiness) {
         // Allocate the registration node. The new node will have `ref_count`
         // set to 2: one SetReadiness, one Registration.
         let node = Box::into_raw(Box::new(ReadinessNode::new(
@@ -1558,17 +1433,8 @@ impl Registration {
         (registration, set_readiness)
     }
 
-    #[deprecated(since = "0.6.5", note = "use `new2` instead")]
-    #[cfg(feature = "with-deprecated")]
-    #[doc(hidden)]
-    pub fn new(poll: &Poll, token: Token, interest: Ready, opt: PollOpt)
-        -> (Registration, SetReadiness)
-    {
-        Registration::new_priv(poll, token, interest, opt)
-    }
-
     // TODO: Get rid of this (windows depends on it for now)
-    fn new_priv(poll: &Poll, token: Token, interest: Ready, opt: PollOpt)
+    fn new_priv(register: &Register, token: Token, interest: Ready, opt: PollOpt)
         -> (Registration, SetReadiness)
     {
         is_send::<Registration>();
@@ -1577,7 +1443,7 @@ impl Registration {
         is_sync::<SetReadiness>();
 
         // Clone handle to the readiness queue, this bumps the ref count
-        let queue = poll.readiness_queue.inner.clone();
+        let queue = register.inner.readiness_queue.inner.clone();
 
         // Convert to a *mut () pointer
         let queue: *mut () = unsafe { mem::transmute(queue) };
@@ -1601,33 +1467,19 @@ impl Registration {
 
         (registration, set_readiness)
     }
-
-    #[deprecated(since = "0.6.5", note = "use `Evented` impl")]
-    #[cfg(feature = "with-deprecated")]
-    #[doc(hidden)]
-    pub fn update(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        self.inner.update(poll, token, interest, opts)
-    }
-
-    #[deprecated(since = "0.6.5", note = "use `Evented` impl")]
-    #[cfg(feature = "with-deprecated")]
-    #[doc(hidden)]
-    pub fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.inner.update(poll, Token(0), Ready::empty(), PollOpt::empty())
-    }
 }
 
 impl Evented for Registration {
-    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        self.inner.update(poll, token, interest, opts)
+    fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        self.inner.update(register, token, interest, opts)
     }
 
-    fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        self.inner.update(poll, token, interest, opts)
+    fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        self.inner.update(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        self.inner.update(poll, Token(0), Ready::empty(), PollOpt::empty())
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        self.inner.update(register, Token(0), Ready::empty(), PollOpt::empty())
     }
 }
 
@@ -1666,7 +1518,7 @@ impl SetReadiness {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::{Registration, Ready};
     ///
-    /// let (registration, set_readiness) = Registration::new2();
+    /// let (registration, set_readiness) = Registration::new();
     ///
     /// assert!(set_readiness.readiness().is_empty());
     ///
@@ -1706,10 +1558,11 @@ impl SetReadiness {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::{Events, Registration, Ready, Poll, PollOpt, Token};
     ///
-    /// let poll = Poll::new()?;
-    /// let (registration, set_readiness) = Registration::new2();
+    /// let mut poll = Poll::new()?;
+    /// let (registration, set_readiness) = Registration::new();
     ///
-    /// poll.register(&registration,
+    /// poll.register()
+    ///     .register(&registration,
     ///               Token(0),
     ///               Ready::readable(),
     ///               PollOpt::edge())?;
@@ -1723,7 +1576,7 @@ impl SetReadiness {
     ///
     /// // There is NO guarantee that the following will work. It is possible
     /// // that the readiness event will be delivered at a later time.
-    /// let event = events.get(0).unwrap();
+    /// let event = events.iter().next().unwrap();
     /// assert_eq!(event.token(), Token(0));
     /// assert!(event.readiness().is_readable());
     /// #     Ok(())
@@ -1744,7 +1597,7 @@ impl SetReadiness {
     /// # fn try_main() -> Result<(), Box<Error>> {
     /// use mio::{Registration, Ready};
     ///
-    /// let (registration, set_readiness) = Registration::new2();
+    /// let (registration, set_readiness) = Registration::new();
     ///
     /// assert!(set_readiness.readiness().is_empty());
     ///
@@ -1825,14 +1678,14 @@ impl RegistrationInner {
     }
 
     /// Update the registration details associated with the node
-    fn update(&self, poll: &Poll, token: Token, interest: Ready, opt: PollOpt) -> io::Result<()> {
+    fn update(&self, register: &Register, token: Token, interest: Ready, opt: PollOpt) -> io::Result<()> {
         // First, ensure poll instances match
         //
         // Load the queue pointer, `Relaxed` is sufficient here as only the
         // pointer is being operated on. The actual memory is guaranteed to be
-        // visible the `poll: &Poll` ref passed as an argument to the function.
+        // visible the `register: &Register` ref passed as an argument to the function.
         let mut queue = self.readiness_queue.load(Relaxed);
-        let other: &*mut () = unsafe { mem::transmute(&poll.readiness_queue.inner) };
+        let other: &*mut () = unsafe { mem::transmute(&register.inner.readiness_queue.inner) };
         let other = *other;
 
         debug_assert!(mem::size_of::<Arc<ReadinessQueueInner>>() == mem::size_of::<*mut ()>());
@@ -1860,7 +1713,7 @@ impl RegistrationInner {
                 // Down below in `release_node` when we deallocate this
                 // `RegistrationInner` is where we'll transmute this back to an
                 // arc and decrement the reference count.
-                mem::forget(poll.readiness_queue.clone());
+                mem::forget(register.inner.readiness_queue.clone());
             } else {
                 // The CAS failed, another thread set the queue pointer, so ensure
                 // that the pointer and `other` match
@@ -1875,7 +1728,7 @@ impl RegistrationInner {
         }
 
         unsafe {
-            let actual = &poll.readiness_queue.inner as *const _ as *const usize;
+            let actual = &register.inner.readiness_queue.inner as *const _ as *const usize;
             debug_assert_eq!(queue as usize, *actual);
         }
 
@@ -2234,6 +2087,13 @@ impl Drop for ReadinessQueue {
 
             release_node(ptr);
         }
+    }
+}
+
+impl fmt::Debug for ReadinessQueue {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("ReadinessQueue")
+            .finish()
     }
 }
 
@@ -2650,13 +2510,13 @@ impl SelectorId {
         }
     }
 
-    pub fn associate_selector(&self, poll: &Poll) -> io::Result<()> {
+    pub fn associate_selector(&self, register: &Register) -> io::Result<()> {
         let selector_id = self.id.load(Ordering::SeqCst);
 
-        if selector_id != 0 && selector_id != poll.selector.id() {
+        if selector_id != 0 && selector_id != register.inner.selector.id() {
             Err(io::Error::new(io::ErrorKind::Other, "socket already registered"))
         } else {
-            self.id.store(poll.selector.id(), Ordering::SeqCst);
+            self.id.store(register.inner.selector.id(), Ordering::SeqCst);
             Ok(())
         }
     }

--- a/src/sys/unix/awakener.rs
+++ b/src/sys/unix/awakener.rs
@@ -3,7 +3,7 @@ pub use self::pipe::Awakener;
 /// Default awakener backed by a pipe
 mod pipe {
     use sys::unix;
-    use {io, Ready, Poll, PollOpt, Token};
+    use {io, Ready, Register, PollOpt, Token};
     use event::Evented;
     use std::io::{Read, Write};
 
@@ -59,16 +59,16 @@ mod pipe {
     }
 
     impl Evented for Awakener {
-        fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-            self.reader().register(poll, token, interest, opts)
+        fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+            self.reader().register(register, token, interest, opts)
         }
 
-        fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-            self.reader().reregister(poll, token, interest, opts)
+        fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+            self.reader().reregister(register, token, interest, opts)
         }
 
-        fn deregister(&self, poll: &Poll) -> io::Result<()> {
-            self.reader().deregister(poll)
+        fn deregister(&self, register: &Register) -> io::Result<()> {
+            self.reader().deregister(register)
         }
     }
 }

--- a/src/sys/unix/eventedfd.rs
+++ b/src/sys/unix/eventedfd.rs
@@ -1,4 +1,4 @@
-use {io, poll, Ready, Poll, PollOpt, Token};
+use {io, poll, Ready, Register, PollOpt, Token};
 use event::Evented;
 use std::os::unix::io::RawFd;
 
@@ -12,7 +12,7 @@ use std::os::unix::io::RawFd;
 
 /// Adapter for `RawFd` providing an [`Evented`] implementation.
 ///
-/// `EventedFd` enables registering any type with an FD with [`Poll`].
+/// `EventedFd` enables registering any type with an FD with [`Register`].
 ///
 /// While only implementations for TCP and UDP are provided, Mio supports
 /// registering any FD that can be registered with the underlying OS selector.
@@ -22,7 +22,7 @@ use std::os::unix::io::RawFd;
 /// not** take ownership of the FD. Specifically, it will not manage any
 /// lifecycle related operations, such as closing the FD on drop. It is expected
 /// that the `EventedFd` is constructed right before a call to
-/// [`Poll::register`]. See the examples for more detail.
+/// [`Register::register`]. See the examples for more detail.
 ///
 /// # Examples
 ///
@@ -40,11 +40,13 @@ use std::os::unix::io::RawFd;
 /// // Bind a std listener
 /// let listener = TcpListener::bind("127.0.0.1:0")?;
 ///
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 ///
 /// // Register the listener
-/// poll.register(&EventedFd(&listener.as_raw_fd()),
-///              Token(0), Ready::readable(), PollOpt::edge())?;
+/// poll.register()
+///     .register(
+///         &EventedFd(&listener.as_raw_fd()),
+///         Token(0), Ready::readable(), PollOpt::edge())?;
 /// #     Ok(())
 /// # }
 /// #
@@ -56,7 +58,7 @@ use std::os::unix::io::RawFd;
 /// Implementing `Evented` for a custom type backed by a `RawFd`.
 ///
 /// ```
-/// use mio::{Ready, Poll, PollOpt, Token};
+/// use mio::{Ready, Register, PollOpt, Token};
 /// use mio::event::Evented;
 /// use mio::unix::EventedFd;
 ///
@@ -68,20 +70,20 @@ use std::os::unix::io::RawFd;
 /// }
 ///
 /// impl Evented for MyIo {
-///     fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         EventedFd(&self.fd).register(poll, token, interest, opts)
+///         EventedFd(&self.fd).register(register, token, interest, opts)
 ///     }
 ///
-///     fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
+///     fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt)
 ///         -> io::Result<()>
 ///     {
-///         EventedFd(&self.fd).reregister(poll, token, interest, opts)
+///         EventedFd(&self.fd).reregister(register, token, interest, opts)
 ///     }
 ///
-///     fn deregister(&self, poll: &Poll) -> io::Result<()> {
-///         EventedFd(&self.fd).deregister(poll)
+///     fn deregister(&self, register: &Register) -> io::Result<()> {
+///         EventedFd(&self.fd).deregister(register)
 ///     }
 /// }
 /// ```
@@ -92,15 +94,18 @@ use std::os::unix::io::RawFd;
 pub struct EventedFd<'a>(pub &'a RawFd);
 
 impl<'a> Evented for EventedFd<'a> {
-    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        poll::selector(poll).register(*self.0, token, interest, opts)
+    fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        poll::selector(register)
+            .register(*self.0, token, interest, opts)
     }
 
-    fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        poll::selector(poll).reregister(*self.0, token, interest, opts)
+    fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        poll::selector(register)
+            .reregister(*self.0, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        poll::selector(poll).deregister(*self.0)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        poll::selector(register)
+            .deregister(*self.0)
     }
 }

--- a/src/sys/unix/io.rs
+++ b/src/sys/unix/io.rs
@@ -4,7 +4,7 @@ use std::os::unix::io::{IntoRawFd, AsRawFd, FromRawFd, RawFd};
 
 use libc;
 
-use {io, Ready, Poll, PollOpt, Token};
+use {io, Ready, Register, PollOpt, Token};
 use event::Evented;
 use unix::EventedFd;
 use sys::unix::cvt;
@@ -61,16 +61,16 @@ impl AsRawFd for Io {
 }
 
 impl Evented for Io {
-    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(poll, token, interest, opts)
+    fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
     }
 
-    fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(poll, token, interest, opts)
+    fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(register)
     }
 }
 

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -337,8 +337,10 @@ fn does_not_register_rw() {
 
     // registering kqueue fd will fail if write is requested (On anything but some versions of OS
     // X)
-    poll.register(&kqf, Token(1234), Ready::readable(),
-                  PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    poll.register()
+        .register(
+            &kqf, Token(1234), Ready::readable(),
+            PollOpt::edge() | PollOpt::oneshot()).unwrap();
 }
 
 #[cfg(any(target_os = "dragonfly",

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -73,9 +73,10 @@ use std::fmt;
 /// let addr = "216.58.193.68:80".parse()?;
 /// let socket = TcpStream::connect(&addr)?;
 ///
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 ///
-/// poll.register(&socket,
+/// poll.register()
+///     .register(&socket,
 ///               Token(0),
 ///               Ready::readable() | UnixReady::error(),
 ///               PollOpt::edge())?;

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -9,7 +9,7 @@ use net2::TcpStreamExt;
 use iovec::IoVec;
 use iovec::unix as iovec;
 
-use {io, Ready, Poll, PollOpt, Token};
+use {io, Ready, Register, PollOpt, Token};
 use event::Evented;
 
 use sys::unix::eventedfd::EventedFd;
@@ -174,18 +174,18 @@ impl<'a> Write for &'a TcpStream {
 }
 
 impl Evented for TcpStream {
-    fn register(&self, poll: &Poll, token: Token,
+    fn register(&self, register: &Register, token: Token,
                 interest: Ready, opts: PollOpt) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
     }
 
-    fn reregister(&self, poll: &Poll, token: Token,
+    fn reregister(&self, register: &Register, token: Token,
                   interest: Ready, opts: PollOpt) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(register)
     }
 }
 
@@ -247,18 +247,18 @@ impl TcpListener {
 }
 
 impl Evented for TcpListener {
-    fn register(&self, poll: &Poll, token: Token,
+    fn register(&self, register: &Register, token: Token,
                 interest: Ready, opts: PollOpt) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
     }
 
-    fn reregister(&self, poll: &Poll, token: Token,
+    fn reregister(&self, register: &Register, token: Token,
                   interest: Ready, opts: PollOpt) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(poll, token, interest, opts)
+        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(register)
     }
 }
 

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,4 +1,4 @@
-use {io, Ready, Poll, PollOpt, Token};
+use {io, Ready, Register, PollOpt, Token};
 use event::Evented;
 use unix::EventedFd;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -131,16 +131,16 @@ impl UdpSocket {
 }
 
 impl Evented for UdpSocket {
-    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).register(poll, token, interest, opts)
+    fn register(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).register(register, token, interest, opts)
     }
 
-    fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).reregister(poll, token, interest, opts)
+    fn reregister(&self, register: &Register, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).reregister(register, token, interest, opts)
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        EventedFd(&self.as_raw_fd()).deregister(poll)
+    fn deregister(&self, register: &Register) -> io::Result<()> {
+        EventedFd(&self.as_raw_fd()).deregister(register)
     }
 }
 

--- a/src/sys/windows/awakener.rs
+++ b/src/sys/windows/awakener.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 
 use miow::iocp::CompletionStatus;
-use {io, poll, Ready, Poll, PollOpt, Token};
+use {io, poll, Ready, Register, PollOpt, Token};
 use event::Evented;
 use sys::windows::Selector;
 
@@ -43,23 +43,23 @@ impl Awakener {
 }
 
 impl Evented for Awakener {
-    fn register(&self, poll: &Poll, token: Token, events: Ready,
+    fn register(&self, register: &Register, token: Token, events: Ready,
                 opts: PollOpt) -> io::Result<()> {
         assert_eq!(opts, PollOpt::edge());
         assert_eq!(events, Ready::readable());
         *self.inner.lock().unwrap() = Some(AwakenerInner {
-            selector: poll::selector(poll).clone_ref(),
+            selector: poll::selector(register).clone_ref(),
             token: token,
         });
         Ok(())
     }
 
-    fn reregister(&self, poll: &Poll, token: Token, events: Ready,
+    fn reregister(&self, register: &Register, token: Token, events: Ready,
                   opts: PollOpt) -> io::Result<()> {
-        self.register(poll, token, events, opts)
+        self.register(register, token, events, opts)
     }
 
-    fn deregister(&self, _poll: &Poll) -> io::Result<()> {
+    fn deregister(&self, _: &Register) -> io::Result<()> {
         *self.inner.lock().unwrap() = None;
         Ok(())
     }

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -12,7 +12,7 @@ use miow;
 use miow::iocp::{CompletionPort, CompletionStatus};
 
 use event_imp::{Event, Evented, Ready};
-use poll::{self, Poll};
+use poll::{self, Register};
 use sys::windows::buffer_pool::BufferPool;
 use {Token, PollOpt};
 
@@ -119,6 +119,13 @@ impl Selector {
     }
 }
 
+impl fmt::Debug for Selector {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Selector")
+            .finish()
+    }
+}
+
 impl SelectorInner {
     fn identical(&self, other: &SelectorInner) -> bool {
         (self as *const SelectorInner) == (other as *const SelectorInner)
@@ -177,12 +184,12 @@ impl Binding {
     pub unsafe fn register_handle(&self,
                                   handle: &AsRawHandle,
                                   token: Token,
-                                  poll: &Poll) -> io::Result<()> {
-        let selector = poll::selector(poll);
+                                  register: &Register) -> io::Result<()> {
+        let selector = poll::selector(register);
 
         // Ignore errors, we'll see them on the next line.
         drop(self.selector.fill(selector.inner.clone()));
-        self.check_same_selector(poll)?;
+        self.check_same_selector(register)?;
 
         selector.inner.port.add_handle(usize::from(token), handle)
     }
@@ -191,21 +198,21 @@ impl Binding {
     pub unsafe fn register_socket(&self,
                                   handle: &AsRawSocket,
                                   token: Token,
-                                  poll: &Poll) -> io::Result<()> {
-        let selector = poll::selector(poll);
+                                  register: &Register) -> io::Result<()> {
+        let selector = poll::selector(register);
         drop(self.selector.fill(selector.inner.clone()));
-        self.check_same_selector(poll)?;
+        self.check_same_selector(register)?;
         selector.inner.port.add_socket(usize::from(token), handle)
     }
 
-    /// Reregisters the handle provided from the `Poll` provided.
+    /// Reregisters the handle provided from the `Register` provided.
     ///
     /// This is intended to be used as part of `Evented::reregister` but note
     /// that this function does not currently reregister the provided handle
     /// with the `poll` specified. IOCP has a special binding for changing the
     /// token which has not yet been implemented. Instead this function should
     /// be used to assert that the call to `reregister` happened on the same
-    /// `Poll` that was passed into to `register`.
+    /// `Register` that was passed into to `register`.
     ///
     /// Eventually, though, the provided `handle` will be re-assigned to have
     /// the token `token` on the given `poll` assuming that it's been
@@ -218,26 +225,26 @@ impl Binding {
     pub unsafe fn reregister_handle(&self,
                                     _handle: &AsRawHandle,
                                     _token: Token,
-                                    poll: &Poll) -> io::Result<()> {
-        self.check_same_selector(poll)
+                                    register: &Register) -> io::Result<()> {
+        self.check_same_selector(register)
     }
 
     /// Same as `reregister_handle`, but for sockets.
     pub unsafe fn reregister_socket(&self,
                                     _socket: &AsRawSocket,
                                     _token: Token,
-                                    poll: &Poll) -> io::Result<()> {
+                                    poll: &Register) -> io::Result<()> {
         self.check_same_selector(poll)
     }
 
-    /// Deregisters the handle provided from the `Poll` provided.
+    /// Deregisters the handle provided from the `Register` provided.
     ///
     /// This is intended to be used as part of `Evented::deregister` but note
     /// that this function does not currently deregister the provided handle
-    /// from the `poll` specified. IOCP has a special binding for that which has
-    /// not yet been implemented. Instead this function should be used to assert
-    /// that the call to `deregister` happened on the same `Poll` that was
-    /// passed into to `register`.
+    /// from the `Register` specified. IOCP has a special binding for that which
+    /// has not yet been implemented. Instead this function should be used to
+    /// assert that the call to `deregister` happened on the same `Register`
+    /// that was passed into to `register`.
     ///
     /// # Unsafety
     ///
@@ -245,19 +252,19 @@ impl Binding {
     /// there may be pending I/O events and such which aren't handled correctly.
     pub unsafe fn deregister_handle(&self,
                                     _handle: &AsRawHandle,
-                                    poll: &Poll) -> io::Result<()> {
-        self.check_same_selector(poll)
+                                    register: &Register) -> io::Result<()> {
+        self.check_same_selector(register)
     }
 
     /// Same as `deregister_handle`, but for sockets.
     pub unsafe fn deregister_socket(&self,
                                     _socket: &AsRawSocket,
-                                    poll: &Poll) -> io::Result<()> {
-        self.check_same_selector(poll)
+                                    register: &Register) -> io::Result<()> {
+        self.check_same_selector(register)
     }
 
-    fn check_same_selector(&self, poll: &Poll) -> io::Result<()> {
-        let selector = poll::selector(poll);
+    fn check_same_selector(&self, register: &Register) -> io::Result<()> {
+        let selector = poll::selector(register);
         match self.selector.borrow() {
             Some(prev) if prev.identical(&selector.inner) => Ok(()),
             Some(_) |
@@ -348,7 +355,7 @@ impl ReadyBinding {
     /// possible change tokens.
     pub fn register_socket(&mut self,
                            socket: &AsRawSocket,
-                           poll: &Poll,
+                           register: &Register,
                            token: Token,
                            events: Ready,
                            opts: PollOpt,
@@ -356,10 +363,10 @@ impl ReadyBinding {
                            -> io::Result<()> {
         trace!("register {:?} {:?}", token, events);
         unsafe {
-            self.binding.register_socket(socket, token, poll)?;
+            self.binding.register_socket(socket, token, register)?;
         }
 
-        let (r, s) = poll::new_registration(poll, token, events, opts);
+        let (r, s) = poll::new_registration(register, token, events, opts);
         self.readiness = Some(s);
         *registration.lock().unwrap() = Some(r);
         Ok(())
@@ -368,7 +375,7 @@ impl ReadyBinding {
     /// Implementation of `Evented::reregister` function.
     pub fn reregister_socket(&mut self,
                              socket: &AsRawSocket,
-                             poll: &Poll,
+                             register: &Register,
                              token: Token,
                              events: Ready,
                              opts: PollOpt,
@@ -376,12 +383,12 @@ impl ReadyBinding {
                              -> io::Result<()> {
         trace!("reregister {:?} {:?}", token, events);
         unsafe {
-            self.binding.reregister_socket(socket, token, poll)?;
+            self.binding.reregister_socket(socket, token, register)?;
         }
 
         registration.lock().unwrap()
                     .as_mut().unwrap()
-                    .reregister(poll, token, events, opts)
+                    .reregister(register, token, events, opts)
     }
 
     /// Implementation of the `Evented::deregister` function.
@@ -390,17 +397,17 @@ impl ReadyBinding {
     /// readiness notifications and such.
     pub fn deregister(&mut self,
                       socket: &AsRawSocket,
-                      poll: &Poll,
+                      register: &Register,
                       registration: &Mutex<Option<poll::Registration>>)
                       -> io::Result<()> {
         trace!("deregistering");
         unsafe {
-            self.binding.deregister_socket(socket, poll)?;
+            self.binding.deregister_socket(socket, register)?;
         }
 
         registration.lock().unwrap()
                     .as_ref().unwrap()
-                    .deregister(poll)
+                    .deregister(register)
     }
 }
 

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -12,7 +12,7 @@ use net2::{TcpBuilder, TcpStreamExt as Net2TcpExt};
 use winapi::*;
 use iovec::IoVec;
 
-use {poll, Ready, Poll, PollOpt, Token};
+use {poll, Ready, Register, PollOpt, Token};
 use event::Evented;
 use sys::windows::from_raw_arc::FromRawArc;
 use sys::windows::selector::{Overlapped, ReadyBinding};
@@ -552,10 +552,10 @@ fn write_done(status: &OVERLAPPED_ENTRY) {
 }
 
 impl Evented for TcpStream {
-    fn register(&self, poll: &Poll, token: Token,
+    fn register(&self, register: &Register, token: Token,
                 interest: Ready, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
-        me.iocp.register_socket(&self.imp.inner.socket, poll, token,
+        me.iocp.register_socket(&self.imp.inner.socket, register, token,
                                      interest, opts, &self.registration)?;
 
         unsafe {
@@ -574,18 +574,18 @@ impl Evented for TcpStream {
         Ok(())
     }
 
-    fn reregister(&self, poll: &Poll, token: Token,
+    fn reregister(&self, register: &Register, token: Token,
                   interest: Ready, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
-        me.iocp.reregister_socket(&self.imp.inner.socket, poll, token,
+        me.iocp.reregister_socket(&self.imp.inner.socket, register, token,
                                        interest, opts, &self.registration)?;
         self.post_register(interest, &mut me);
         Ok(())
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+    fn deregister(&self, register: &Register) -> io::Result<()> {
         self.inner().iocp.deregister(&self.imp.inner.socket,
-                                     poll, &self.registration)
+                                     register, &self.registration)
     }
 }
 
@@ -757,10 +757,10 @@ fn accept_done(status: &OVERLAPPED_ENTRY) {
 }
 
 impl Evented for TcpListener {
-    fn register(&self, poll: &Poll, token: Token,
+    fn register(&self, register: &Register, token: Token,
                 interest: Ready, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
-        me.iocp.register_socket(&self.imp.inner.socket, poll, token,
+        me.iocp.register_socket(&self.imp.inner.socket, register, token,
                                      interest, opts, &self.registration)?;
 
         unsafe {
@@ -772,18 +772,18 @@ impl Evented for TcpListener {
         Ok(())
     }
 
-    fn reregister(&self, poll: &Poll, token: Token,
+    fn reregister(&self, register: &Register, token: Token,
                   interest: Ready, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
-        me.iocp.reregister_socket(&self.imp.inner.socket, poll, token,
+        me.iocp.reregister_socket(&self.imp.inner.socket, register, token,
                                        interest, opts, &self.registration)?;
         self.imp.schedule_accept(&mut me);
         Ok(())
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+    fn deregister(&self, register: &Register) -> io::Result<()> {
         self.inner().iocp.deregister(&self.imp.inner.socket,
-                                     poll, &self.registration)
+                                     register, &self.registration)
     }
 }
 

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -17,7 +17,7 @@ use miow::iocp::CompletionStatus;
 use miow::net::SocketAddrBuf;
 use miow::net::UdpSocketExt as MiowUdpSocketExt;
 
-use {poll, Ready, Poll, PollOpt, Token};
+use {poll, Ready, Register, PollOpt, Token};
 use event::Evented;
 use sys::windows::from_raw_arc::FromRawArc;
 use sys::windows::selector::{Overlapped, ReadyBinding};
@@ -329,29 +329,29 @@ impl Imp {
 }
 
 impl Evented for UdpSocket {
-    fn register(&self, poll: &Poll, token: Token,
+    fn register(&self, register: &Register, token: Token,
                 interest: Ready, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
         me.iocp.register_socket(&self.imp.inner.socket,
-                                     poll, token, interest, opts,
+                                     register, token, interest, opts,
                                      &self.registration)?;
         self.post_register(interest, &mut me);
         Ok(())
     }
 
-    fn reregister(&self, poll: &Poll, token: Token,
+    fn reregister(&self, register: &Register, token: Token,
                   interest: Ready, opts: PollOpt) -> io::Result<()> {
         let mut me = self.inner();
         me.iocp.reregister_socket(&self.imp.inner.socket,
-                                       poll, token, interest,
+                                       register, token, interest,
                                        opts, &self.registration)?;
         self.post_register(interest, &mut me);
         Ok(())
     }
 
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+    fn deregister(&self, register: &Register) -> io::Result<()> {
         self.inner().iocp.deregister(&self.imp.inner.socket,
-                                     poll, &self.registration)
+                                     register, &self.registration)
     }
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -34,13 +34,14 @@
 /// let mut next_socket_index = 0;
 ///
 /// // The `Poll` instance
-/// let poll = Poll::new()?;
+/// let mut poll = Poll::new()?;
 ///
 /// // Tcp listener
 /// let listener = TcpListener::bind(&"127.0.0.1:0".parse()?)?;
 ///
 /// // Register the listener
-/// poll.register(&listener,
+/// poll.register()
+///     .register(&listener,
 ///               LISTENER,
 ///               Ready::readable(),
 ///               PollOpt::edge())?;
@@ -86,7 +87,8 @@
 ///                             next_socket_index += 1;
 ///
 ///                             // Register the new socket w/ poll
-///                             poll.register(&socket,
+///                             poll.register()
+///                                 .register(&socket,
 ///                                          token,
 ///                                          Ready::readable(),
 ///                                          PollOpt::edge())?;

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -153,7 +153,7 @@ pub fn sleep_ms(ms: u64) {
     thread::sleep(Duration::from_millis(ms));
 }
 
-pub fn expect_events(poll: &Poll,
+pub fn expect_events(poll: &mut Poll,
                      event_buffer: &mut Events,
                      poll_try_count: usize,
                      mut expected: Vec<Event>)

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -60,7 +60,7 @@ impl TestHandler {
             }
             _ => panic!("received unknown token {:?}", tok)
         }
-        poll.reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge()).unwrap();
+        poll.register().reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge()).unwrap();
     }
 
     fn handle_write(&mut self, poll: &mut Poll, tok: Token, _: Ready) {
@@ -68,7 +68,7 @@ impl TestHandler {
             SERVER => panic!("received writable for token 0"),
             CLIENT => {
                 debug!("client connected");
-                poll.reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge()).unwrap();
+                poll.register().reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge()).unwrap();
             }
             _ => panic!("received unknown token {:?}", tok)
         }
@@ -86,12 +86,12 @@ pub fn test_close_on_drop() {
     // == Create & setup server socket
     let srv = TcpListener::bind(&addr).unwrap();
 
-    poll.register(&srv, SERVER, Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&srv, SERVER, Ready::readable(), PollOpt::edge()).unwrap();
 
     // == Create & setup client socket
     let sock = TcpStream::connect(&addr).unwrap();
 
-    poll.register(&sock, CLIENT, Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&sock, CLIENT, Ready::writable(), PollOpt::edge()).unwrap();
 
     // == Create storage for events
     let mut events = Events::with_capacity(1024);

--- a/test/test_custom_evented.rs
+++ b/test/test_custom_evented.rs
@@ -4,20 +4,19 @@ use std::time::Duration;
 
 #[test]
 fn smoke() {
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(128);
 
-    let (r, set) = Registration::new2();
-    r.register(&poll, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+    let (r, set) = Registration::new();
+    r.register(poll.register(), Token(0), Ready::readable(), PollOpt::edge()).unwrap();
 
-    let n = poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
-    assert_eq!(n, 0);
+    poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
+    assert!(events.iter().next().is_none());
 
     set.set_readiness(Ready::readable()).unwrap();
 
-    let n = poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
-    assert_eq!(n, 1);
-
+    poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
+    assert_eq!(events.iter().count(), 1);
     assert_eq!(events.iter().next().unwrap().token(), Token(0));
 }
 
@@ -26,11 +25,11 @@ fn set_readiness_before_register() {
     use std::sync::{Arc, Barrier};
     use std::thread;
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(128);
 
     for _ in 0..5_000 {
-        let (r, set) = Registration::new2();
+        let (r, set) = Registration::new();
 
         let b1 = Arc::new(Barrier::new(2));
         let b2 = b1.clone();
@@ -42,10 +41,12 @@ fn set_readiness_before_register() {
 
         b1.wait();
 
-        poll.register(&r, Token(123), Ready::readable(), PollOpt::edge()).unwrap();
+        poll.register()
+            .register(&r, Token(123), Ready::readable(), PollOpt::edge()).unwrap();
 
         loop {
-            let n = poll.poll(&mut events, None).unwrap();
+            poll.poll(&mut events, None).unwrap();
+            let n = events.iter().count();
 
             if n == 0 {
                 continue;
@@ -79,12 +80,12 @@ mod stress {
         const NUM_REGISTRATIONS: usize = 128;
 
         for _ in 0..NUM_ATTEMPTS {
-            let poll = Poll::new().unwrap();
+            let mut poll = Poll::new().unwrap();
             let mut events = Events::with_capacity(128);
 
             let registrations: Vec<_> = (0..NUM_REGISTRATIONS).map(|i| {
-                let (r, s) = Registration::new2();
-                r.register(&poll, Token(i), Ready::readable(), PollOpt::edge()).unwrap();
+                let (r, s) = Registration::new();
+                r.register(poll.register(), Token(i), Ready::readable(), PollOpt::edge()).unwrap();
                 (r, s)
             }).collect();
 
@@ -120,7 +121,7 @@ mod stress {
             while remaining.load(Acquire) > 0 {
                 // Set interest
                 for (i, &(ref r, _)) in registrations.iter().enumerate() {
-                    r.reregister(&poll, Token(i), Ready::writable(), PollOpt::edge()).unwrap();
+                    r.reregister(poll.register(), Token(i), Ready::writable(), PollOpt::edge()).unwrap();
                 }
 
                 poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
@@ -132,7 +133,7 @@ mod stress {
                 // Update registration
                 // Set interest
                 for (i, &(ref r, _)) in registrations.iter().enumerate() {
-                    r.reregister(&poll, Token(i), Ready::readable(), PollOpt::edge()).unwrap();
+                    r.reregister(poll.register(), Token(i), Ready::readable(), PollOpt::edge()).unwrap();
                 }
             }
 
@@ -151,126 +152,6 @@ mod stress {
     }
 
     #[test]
-    fn multi_threaded_poll() {
-        use std::sync::{Arc, Barrier};
-        use std::sync::atomic::{AtomicUsize};
-        use std::sync::atomic::Ordering::{Relaxed, SeqCst};
-        use std::thread;
-
-        const ENTRIES: usize = 10_000;
-        const PER_ENTRY: usize = 16;
-        const THREADS: usize = 4;
-        const NUM: usize = ENTRIES * PER_ENTRY;
-
-        struct Entry {
-            #[allow(dead_code)]
-            registration: Registration,
-            set_readiness: SetReadiness,
-            num: AtomicUsize,
-        }
-
-        impl Entry {
-            fn fire(&self) {
-                self.set_readiness.set_readiness(Ready::readable()).unwrap();
-            }
-        }
-
-        let poll = Arc::new(Poll::new().unwrap());
-        let mut entries = vec![];
-
-        // Create entries
-        for i in 0..ENTRIES {
-            let (registration, set_readiness) = Registration::new2();
-            registration.register(&poll, Token(i), Ready::readable(), PollOpt::edge()).unwrap();
-
-            entries.push(Entry {
-                registration: registration,
-                set_readiness: set_readiness,
-                num: AtomicUsize::new(0),
-            });
-        }
-
-        let total = Arc::new(AtomicUsize::new(0));
-        let entries = Arc::new(entries);
-        let barrier = Arc::new(Barrier::new(THREADS));
-
-        let mut threads = vec![];
-
-        for th in 0..THREADS {
-            let poll = poll.clone();
-            let total = total.clone();
-            let entries = entries.clone();
-            let barrier = barrier.clone();
-
-            threads.push(thread::spawn(move || {
-                let mut events = Events::with_capacity(128);
-
-                barrier.wait();
-
-                // Prime all the registrations
-                let mut i = th;
-                while i < ENTRIES {
-                    entries[i].fire();
-                    i += THREADS;
-                }
-
-                let mut n = 0;
-
-
-                while total.load(SeqCst) < NUM {
-                    // A poll timeout is necessary here because there may be more
-                    // than one threads blocked in `poll` when the final wakeup
-                    // notification arrives (and only notifies one thread).
-                    n += poll.poll(&mut events, Some(Duration::from_millis(100))).unwrap();
-
-                    let mut num_this_tick = 0;
-
-                    for event in &events {
-                        let e = &entries[event.token().0];
-
-                        let mut num = e.num.load(Relaxed);
-
-                        loop {
-                            if num < PER_ENTRY {
-                                let actual = e.num.compare_and_swap(num, num + 1, Relaxed);
-
-                                if actual == num {
-                                    num_this_tick += 1;
-                                    e.fire();
-                                    break;
-                                }
-
-                                num = actual;
-                            } else {
-                                break;
-                            }
-                        }
-                    }
-
-                    total.fetch_add(num_this_tick, SeqCst);
-                }
-
-                n
-            }));
-        }
-
-        let per_thread: Vec<_> = threads.into_iter()
-            .map(|th| th.join().unwrap())
-            .collect();
-
-        for entry in entries.iter() {
-            assert_eq!(PER_ENTRY, entry.num.load(Relaxed));
-        }
-
-        for th in per_thread {
-            // Kind of annoying that we can't really test anything better than this,
-            // but CI tends to be very non deterministic when it comes to multi
-            // threading.
-            assert!(th > 0, "actual={:?}", th);
-        }
-    }
-
-    #[test]
     fn with_small_events_collection() {
         const N: usize = 8;
         const ITER: usize = 1_000;
@@ -280,15 +161,15 @@ mod stress {
         use std::sync::atomic::Ordering::{Acquire, Release};
         use std::thread;
 
-        let poll = Poll::new().unwrap();
+        let mut poll = Poll::new().unwrap();
         let mut registrations = vec![];
 
         let barrier = Arc::new(Barrier::new(N + 1));
         let done = Arc::new(AtomicBool::new(false));
 
         for i in 0..N {
-            let (registration, set_readiness) = Registration::new2();
-            poll.register(&registration, Token(i), Ready::readable(), PollOpt::edge()).unwrap();
+            let (registration, set_readiness) = Registration::new();
+            poll.register().register(&registration, Token(i), Ready::readable(), PollOpt::edge()).unwrap();
 
             registrations.push(registration);
 
@@ -367,8 +248,8 @@ fn drop_registration_from_non_main_thread() {
 
     let mut index: usize = 0;
     for _ in 0..ITERS {
-        let (registration, set_readiness) = Registration::new2();
-        registration.register(&mut poll, Token(token_index), Ready::readable(), PollOpt::edge()).unwrap();
+        let (registration, set_readiness) = Registration::new();
+        registration.register(poll.register(), Token(token_index), Ready::readable(), PollOpt::edge()).unwrap();
         let _ = senders[index].send((registration, set_readiness));
 
         token_index += 1;
@@ -376,8 +257,8 @@ fn drop_registration_from_non_main_thread() {
         if index == THREADS {
             index = 0;
 
-            let (registration, set_readiness) = Registration::new2();
-            registration.register(&mut poll, Token(token_index), Ready::readable(), PollOpt::edge()).unwrap();
+            let (registration, set_readiness) = Registration::new();
+            registration.register(poll.register(), Token(token_index), Ready::readable(), PollOpt::edge()).unwrap();
             let _ = set_readiness.set_readiness(Ready::readable());
             drop(registration);
             drop(set_readiness);

--- a/test/test_double_register.rs
+++ b/test/test_double_register.rs
@@ -12,6 +12,6 @@ pub fn test_double_register() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register(&l, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
-    assert!(poll.register(&l, Token(1), Ready::readable(), PollOpt::edge()).is_err());
+    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+    assert!(poll.register().register(&l, Token(1), Ready::readable(), PollOpt::edge()).is_err());
 }

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -51,8 +51,10 @@ impl EchoConn {
         }
 
         assert!(self.interest.is_readable() || self.interest.is_writable(), "actual={:?}", self.interest);
-        poll.reregister(&self.sock, self.token.unwrap(), self.interest,
-                              PollOpt::edge() | PollOpt::oneshot())
+        poll.register()
+            .reregister(
+                &self.sock, self.token.unwrap(), self.interest,
+                PollOpt::edge() | PollOpt::oneshot())
     }
 
     fn readable(&mut self, poll: &mut Poll) -> io::Result<()> {
@@ -80,8 +82,10 @@ impl EchoConn {
         };
 
         assert!(self.interest.is_readable() || self.interest.is_writable(), "actual={:?}", self.interest);
-        poll.reregister(&self.sock, self.token.unwrap(), self.interest,
-                              PollOpt::edge())
+        poll.register()
+            .reregister(
+                &self.sock, self.token.unwrap(), self.interest,
+                PollOpt::edge())
     }
 }
 
@@ -101,8 +105,10 @@ impl EchoServer {
 
         // Register the connection
         self.conns[tok].token = Some(tok);
-        poll.register(&self.conns[tok].sock, tok, Ready::readable(),
-                                PollOpt::edge() | PollOpt::oneshot())
+        poll.register()
+            .register(
+                &self.conns[tok].sock, tok, Ready::readable(),
+                PollOpt::edge() | PollOpt::oneshot())
             .ok().expect("could not register socket with event loop");
 
         Ok(())
@@ -192,8 +198,10 @@ impl EchoClient {
 
         if !self.interest.is_empty() {
             assert!(self.interest.is_readable() || self.interest.is_writable(), "actual={:?}", self.interest);
-            poll.reregister(&self.sock, self.token, self.interest,
-                                       PollOpt::edge() | PollOpt::oneshot())?;
+            poll.register()
+                .reregister(
+                    &self.sock, self.token, self.interest,
+                    PollOpt::edge() | PollOpt::oneshot())?;
         }
 
         Ok(())
@@ -216,8 +224,10 @@ impl EchoClient {
         }
 
         if self.interest.is_readable() || self.interest.is_writable() {
-            try!(poll.reregister(&self.sock, self.token, self.interest,
-                                  PollOpt::edge() | PollOpt::oneshot()));
+            try!(poll.register()
+                 .reregister(
+                     &self.sock, self.token, self.interest,
+                     PollOpt::edge() | PollOpt::oneshot()));
         }
 
         Ok(())
@@ -236,8 +246,10 @@ impl EchoClient {
         self.rx = SliceBuf::wrap(curr.as_bytes());
 
         self.interest.insert(Ready::writable());
-        poll.reregister(&self.sock, self.token, self.interest,
-                              PollOpt::edge() | PollOpt::oneshot())
+        poll.register()
+            .reregister(
+                &self.sock, self.token, self.interest,
+                PollOpt::edge() | PollOpt::oneshot())
     }
 }
 
@@ -267,14 +279,19 @@ pub fn test_echo_server() {
     let srv = TcpListener::bind(&addr).unwrap();
 
     info!("listen for connections");
-    poll.register(&srv, SERVER, Ready::readable(),
-                            PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    poll.register()
+        .register(
+            &srv, SERVER, Ready::readable(),
+            PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
     let sock = TcpStream::connect(&addr).unwrap();
 
     // Connect to the server
-    poll.register(&sock, CLIENT, Ready::writable(),
-                        PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    poll.register()
+        .register(
+            &sock, CLIENT, Ready::writable(),
+            PollOpt::edge() | PollOpt::oneshot()).unwrap();
+
     // == Create storage for events
     let mut events = Events::with_capacity(1024);
 

--- a/test/test_local_addr_ready.rs
+++ b/test/test_local_addr_ready.rs
@@ -19,13 +19,17 @@ fn local_addr_ready() {
     let server = TcpListener::bind(&addr).unwrap();
     let addr = server.local_addr().unwrap();
 
-    let poll = Poll::new().unwrap();
-    poll.register(&server, LISTEN, Ready::readable(),
-                        PollOpt::edge()).unwrap();
+    let mut poll = Poll::new().unwrap();
+    poll.register()
+        .register(
+            &server, LISTEN, Ready::readable(),
+            PollOpt::edge()).unwrap();
 
     let sock = TcpStream::connect(&addr).unwrap();
-    poll.register(&sock, CLIENT, Ready::readable(),
-                        PollOpt::edge()).unwrap();
+    poll.register()
+        .register(
+            &sock, CLIENT, Ready::readable(),
+            PollOpt::edge()).unwrap();
 
     let mut events = Events::with_capacity(1024);
 
@@ -43,7 +47,8 @@ fn local_addr_ready() {
             match event.token() {
                 LISTEN => {
                     let sock = handler.listener.accept().unwrap().0;
-                    poll.register(&sock,
+                    poll.register()
+                        .register(&sock,
                                   SERVER,
                                   Ready::writable(),
                                   PollOpt::edge()).unwrap();

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -86,10 +86,10 @@ pub fn test_multicast() {
     rx.join_multicast_v4(&"227.1.1.101".parse().unwrap(), &any).unwrap();
 
     info!("Registering SENDER");
-    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::edge()).unwrap();
 
     info!("Registering LISTENER");
-    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::edge()).unwrap();
 
     let mut events = Events::with_capacity(1024);
 

--- a/test/test_oneshot.rs
+++ b/test/test_oneshot.rs
@@ -16,17 +16,17 @@ pub fn test_tcp_edge_oneshot() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register(&l, Token(0), Ready::readable(), PollOpt::level()).unwrap();
+    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::level()).unwrap();
 
     // Connect a socket, we are going to write to it
     let mut s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register(&s1, Token(1), Ready::writable(), PollOpt::level()).unwrap();
+    poll.register().register(&s1, Token(1), Ready::writable(), PollOpt::level()).unwrap();
 
     wait_for(&mut poll, &mut events, Token(0));
 
     // Get pair
     let (mut s2, _) = l.accept().unwrap();
-    poll.register(&s2, Token(2), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    poll.register().register(&s2, Token(2), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
     wait_for(&mut poll, &mut events, Token(1));
 
@@ -41,10 +41,10 @@ pub fn test_tcp_edge_oneshot() {
         assert_eq!(1, s2.read(&mut buf).unwrap());
         assert_eq!(*byte, buf[0]);
 
-        poll.reregister(&s2, Token(2), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+        poll.register().reregister(&s2, Token(2), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
         if *byte == b'o' {
-            poll.reregister(&s2, Token(2), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+            poll.register().reregister(&s2, Token(2), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
         }
     }
 }

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -4,11 +4,12 @@ use std::time::Duration;
 #[test]
 fn test_poll_closes_fd() {
     for _ in 0..2000 {
-        let poll = Poll::new().unwrap();
+        let mut poll = Poll::new().unwrap();
         let mut events = Events::with_capacity(4);
-        let (registration, set_readiness) = Registration::new2();
+        let (registration, set_readiness) = Registration::new();
 
-        poll.register(&registration, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+        poll.register()
+            .register(&registration, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
         poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
 
         drop(poll);

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -34,7 +34,7 @@ impl TestHandler {
                 trace!("handle_read; token=CLIENT");
                 assert!(self.state == 0, "unexpected state {}", self.state);
                 self.state = 1;
-                poll.reregister(&self.client, CLIENT, Ready::writable(), PollOpt::level()).unwrap();
+                poll.register().reregister(&self.client, CLIENT, Ready::writable(), PollOpt::level()).unwrap();
             }
             _ => panic!("unexpected token"),
         }
@@ -47,8 +47,8 @@ impl TestHandler {
         assert!(self.state == 1, "unexpected state {}", self.state);
 
         self.state = 2;
-        poll.deregister(&self.client).unwrap();
-        poll.deregister(&self.server).unwrap();
+        poll.register().deregister(&self.client).unwrap();
+        poll.register().deregister(&self.server).unwrap();
     }
 }
 
@@ -65,12 +65,12 @@ pub fn test_register_deregister() {
     let server = TcpListener::bind(&addr).unwrap();
 
     info!("register server socket");
-    poll.register(&server, SERVER, Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&server, SERVER, Ready::readable(), PollOpt::edge()).unwrap();
 
     let client = TcpStream::connect(&addr).unwrap();
 
     // Register client socket only as writable
-    poll.register(&client, CLIENT, Ready::readable(), PollOpt::level()).unwrap();
+    poll.register().register(&client, CLIENT, Ready::readable(), PollOpt::level()).unwrap();
 
     let mut handler = TestHandler::new(server, client);
 
@@ -95,29 +95,29 @@ pub fn test_register_deregister() {
 
 #[test]
 pub fn test_register_empty_interest() {
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
     let addr = localhost();
 
     let sock = TcpListener::bind(&addr).unwrap();
 
-    poll.register(&sock, Token(0), Ready::empty(), PollOpt::edge()).unwrap();
+    poll.register().register(&sock, Token(0), Ready::empty(), PollOpt::edge()).unwrap();
 
     let client = TcpStream::connect(&addr).unwrap();
 
     // The connect is not guaranteed to have started until it is registered
     // https://docs.rs/mio/0.6.10/mio/struct.Poll.html#registering-handles
-    poll.register(&client, Token(1), Ready::empty(), PollOpt::edge()).unwrap();
+    poll.register().register(&client, Token(1), Ready::empty(), PollOpt::edge()).unwrap();
 
     // sock is registered with empty interest, we should not receive any event
     poll.poll(&mut events, Some(Duration::from_millis(100))).unwrap();
     assert!(events.iter().next().is_none(), "Received unexpected event: {:?}", events.iter().next().unwrap());
 
     // now sock is reregistered with readable, we should receive the pending event
-    poll.reregister(&sock, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
-    expect_events(&poll, &mut events, 2, vec![
+    poll.register().reregister(&sock, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+    expect_events(&mut poll, &mut events, 2, vec![
         Event::new(Ready::readable(), Token(0))
     ]);
 
-    poll.reregister(&sock, Token(0), Ready::empty(), PollOpt::edge()).unwrap();
+    poll.register().reregister(&sock, Token(0), Ready::empty(), PollOpt::edge()).unwrap();
 }

--- a/test/test_register_multiple_event_loops.rs
+++ b/test/test_register_multiple_event_loops.rs
@@ -9,33 +9,33 @@ fn test_tcp_register_multiple_event_loops() {
     let listener = TcpListener::bind(&addr).unwrap();
 
     let poll1 = Poll::new().unwrap();
-    poll1.register(&listener, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
+    poll1.register().register(&listener, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
 
     let poll2 = Poll::new().unwrap();
 
     // Try registering the same socket with the initial one
-    let res = poll2.register(&listener, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&listener, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try cloning the socket and registering it again
     let listener2 = listener.try_clone().unwrap();
-    let res = poll2.register(&listener2, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&listener2, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try the stream
     let stream = TcpStream::connect(&addr).unwrap();
 
-    poll1.register(&stream, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
+    poll1.register().register(&stream, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
 
-    let res = poll2.register(&stream, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&stream, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge());
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try cloning the socket and registering it again
     let stream2 = stream.try_clone().unwrap();
-    let res = poll2.register(&stream2, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&stream2, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge());
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 }
@@ -46,18 +46,18 @@ fn test_udp_register_multiple_event_loops() {
     let socket = UdpSocket::bind(&addr).unwrap();
 
     let poll1 = Poll::new().unwrap();
-    poll1.register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
+    poll1.register().register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
 
     let poll2 = Poll::new().unwrap();
 
     // Try registering the same socket with the initial one
-    let res = poll2.register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try cloning the socket and registering it again
     let socket2 = socket.try_clone().unwrap();
-    let res = poll2.register(&socket2, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&socket2, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 }

--- a/test/test_reregister_without_poll.rs
+++ b/test/test_reregister_without_poll.rs
@@ -8,20 +8,20 @@ const MS: u64 = 1_000;
 #[test]
 pub fn test_reregister_different_without_poll() {
     let mut events = Events::with_capacity(1024);
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
     // Create the listener
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register(&l, Token(0), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
     let s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register(&s1, Token(2), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&s1, Token(2), Ready::readable(), PollOpt::edge()).unwrap();
 
     sleep_ms(MS);
 
-    poll.reregister(&l, Token(0), Ready::writable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    poll.register().reregister(&l, Token(0), Ready::writable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
 
     poll.poll(&mut events, Some(Duration::from_millis(MS))).unwrap();
     assert!(events.iter().next().is_none());

--- a/test/test_smoke.rs
+++ b/test/test_smoke.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 #[test]
 fn run_once_with_nothing() {
     let mut events = Events::with_capacity(1024);
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     poll.poll(&mut events, Some(Duration::from_millis(100))).unwrap();
 }
 
@@ -15,8 +15,8 @@ fn run_once_with_nothing() {
 fn add_then_drop() {
     let mut events = Events::with_capacity(1024);
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
-    let poll = Poll::new().unwrap();
-    poll.register(&l, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
+    let mut poll = Poll::new().unwrap();
+    poll.register().register(&l, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
     drop(l);
     poll.poll(&mut events, Some(Duration::from_millis(100))).unwrap();
 

--- a/test/test_tcp_level.rs
+++ b/test/test_tcp_level.rs
@@ -9,17 +9,17 @@ const MS: u64 = 1_000;
 
 #[test]
 pub fn test_tcp_listener_level_triggered() {
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut pevents = Events::with_capacity(1024);
 
     // Create the listener
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register(&l, Token(0), Ready::readable(), PollOpt::level()).unwrap();
+    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::level()).unwrap();
 
     let s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register(&s1, Token(1), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&s1, Token(1), Ready::readable(), PollOpt::edge()).unwrap();
 
     while filter(&pevents, Token(0)).len() == 0 {
         poll.poll(&mut pevents, Some(Duration::from_millis(MS))).unwrap();
@@ -42,7 +42,7 @@ pub fn test_tcp_listener_level_triggered() {
     assert!(events.is_empty(), "actual={:?}", events);
 
     let s3 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register(&s3, Token(2), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&s3, Token(2), Ready::readable(), PollOpt::edge()).unwrap();
 
     while filter(&pevents, Token(0)).len() == 0 {
         poll.poll(&mut pevents, Some(Duration::from_millis(MS))).unwrap();
@@ -62,22 +62,22 @@ pub fn test_tcp_listener_level_triggered() {
 #[test]
 pub fn test_tcp_stream_level_triggered() {
     drop(::env_logger::init());
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut pevents = Events::with_capacity(1024);
 
     // Create the listener
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register(&l, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
 
     let mut s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register(&s1, Token(1), Ready::readable() | Ready::writable(), PollOpt::level()).unwrap();
+    poll.register().register(&s1, Token(1), Ready::readable() | Ready::writable(), PollOpt::level()).unwrap();
 
     // Sleep a bit to ensure it arrives at dest
     sleep_ms(250);
 
-    expect_events(&poll, &mut pevents, 2, vec![
+    expect_events(&mut poll, &mut pevents, 2, vec![
         Event::new(Ready::readable(), Token(0)),
         Event::new(Ready::writable(), Token(1)),
     ]);
@@ -88,12 +88,12 @@ pub fn test_tcp_stream_level_triggered() {
     // Sleep a bit to ensure it arrives at dest
     sleep_ms(250);
 
-    expect_events(&poll, &mut pevents, 2, vec![
+    expect_events(&mut poll, &mut pevents, 2, vec![
         Event::new(Ready::writable(), Token(1))
     ]);
 
     // Register the socket
-    poll.register(&s1_tx, Token(123), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&s1_tx, Token(123), Ready::readable(), PollOpt::edge()).unwrap();
 
     debug!("writing some data ----------");
 
@@ -107,7 +107,7 @@ pub fn test_tcp_stream_level_triggered() {
     debug!("looking at rx end ----------");
 
     // Poll rx end
-    expect_events(&poll, &mut pevents, 2, vec![
+    expect_events(&mut poll, &mut pevents, 2, vec![
         Event::new(Ready::readable(), Token(1))
     ]);
 
@@ -122,7 +122,7 @@ pub fn test_tcp_stream_level_triggered() {
 
     debug!("checking just read ----------");
 
-    expect_events(&poll, &mut pevents, 1, vec![
+    expect_events(&mut poll, &mut pevents, 1, vec![
         Event::new(Ready::writable(), Token(1))]);
 
     // Closing the socket clears all active level events

--- a/test/test_udp_level.rs
+++ b/test/test_udp_level.rs
@@ -5,8 +5,7 @@ use {expect_events, sleep_ms};
 
 #[test]
 pub fn test_udp_level_triggered() {
-    let poll = Poll::new().unwrap();
-    let poll = &poll;
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
     let events = &mut events;
 
@@ -14,12 +13,12 @@ pub fn test_udp_level_triggered() {
     let tx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let rx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
-    poll.register(&tx, Token(0), Ready::readable() | Ready::writable(), PollOpt::level()).unwrap();
-    poll.register(&rx, Token(1), Ready::readable() | Ready::writable(), PollOpt::level()).unwrap();
+    poll.register().register(&tx, Token(0), Ready::readable() | Ready::writable(), PollOpt::level()).unwrap();
+    poll.register().register(&rx, Token(1), Ready::readable() | Ready::writable(), PollOpt::level()).unwrap();
 
 
     for _ in 0..2 {
-        expect_events(poll, events, 2, vec![
+        expect_events(&mut poll, events, 2, vec![
             Event::new(Ready::writable(), Token(0)),
             Event::new(Ready::writable(), Token(1)),
         ]);
@@ -30,7 +29,7 @@ pub fn test_udp_level_triggered() {
     sleep_ms(250);
 
     for _ in 0..2 {
-        expect_events(poll, events, 2, vec![
+        expect_events(&mut poll, events, 2, vec![
             Event::new(Ready::readable() | Ready::writable(), Token(1))
         ]);
     }
@@ -39,13 +38,13 @@ pub fn test_udp_level_triggered() {
     while rx.recv_from(&mut buf).is_ok() {}
 
     for _ in 0..2 {
-        expect_events(poll, events, 4, vec![Event::new(Ready::writable(), Token(1))]);
+        expect_events(&mut poll, events, 4, vec![Event::new(Ready::writable(), Token(1))]);
     }
 
     tx.send_to(b"hello world!", &rx.local_addr().unwrap()).unwrap();
     sleep_ms(250);
 
-    expect_events(poll, events, 10,
+    expect_events(&mut poll, events, 10,
                   vec![Event::new(Ready::readable() | Ready::writable(), Token(1))]);
 
     drop(rx);

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -42,7 +42,7 @@ fn assert_sync<T: Sync>() {
 #[cfg(test)]
 fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
     debug!("Starting TEST_UDP_SOCKETS");
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
     assert_send::<UdpSocket>();
     assert_sync::<UdpSocket>();
@@ -52,10 +52,10 @@ fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
     assert_eq!(ErrorKind::WouldBlock, rx.recv_from(&mut buf).unwrap_err().kind());
 
     info!("Registering SENDER");
-    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::edge()).unwrap();
 
     info!("Registering LISTENER");
-    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::edge()).unwrap();
 
     let mut events = Events::with_capacity(1024);
 
@@ -145,18 +145,18 @@ pub fn test_udp_socket_discard() {
 
     let tx_addr = tx.local_addr().unwrap();
     let rx_addr = rx.local_addr().unwrap();
- 
+
     assert!(tx.connect(rx_addr).is_ok());
     assert!(udp_outside.connect(rx_addr).is_ok());
     assert!(rx.connect(tx_addr).is_ok());
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
     let r = udp_outside.send("hello world".as_bytes());
     assert!(r.is_ok() || r.unwrap_err().kind() == ErrorKind::WouldBlock);
 
-    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge()).unwrap();
-    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::edge()).unwrap();
 
     let mut events = Events::with_capacity(1024);
 

--- a/test/test_write_then_drop.rs
+++ b/test/test_write_then_drop.rs
@@ -12,13 +12,13 @@ fn write_then_drop() {
     let addr = a.local_addr().unwrap();
     let mut s = TcpStream::connect(&addr).unwrap();
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
-    a.register(&poll,
+    a.register(poll.register(),
                Token(1),
                Ready::readable(),
                PollOpt::edge()).unwrap();
-    s.register(&poll,
+    s.register(poll.register(),
                Token(3),
                Ready::empty(),
                PollOpt::edge()).unwrap();
@@ -32,7 +32,7 @@ fn write_then_drop() {
 
     let mut s2 = a.accept().unwrap().0;
 
-    s2.register(&poll,
+    s2.register(poll.register(),
                 Token(2),
                 Ready::writable(),
                 PollOpt::edge()).unwrap();
@@ -47,7 +47,7 @@ fn write_then_drop() {
     s2.write(&[1, 2, 3, 4]).unwrap();
     drop(s2);
 
-    s.reregister(&poll,
+    s.reregister(poll.register(),
                  Token(3),
                  Ready::readable(),
                  PollOpt::edge()).unwrap();
@@ -71,13 +71,13 @@ fn write_then_deregister() {
     let addr = a.local_addr().unwrap();
     let mut s = TcpStream::connect(&addr).unwrap();
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
 
-    a.register(&poll,
+    a.register(poll.register(),
                Token(1),
                Ready::readable(),
                PollOpt::edge()).unwrap();
-    s.register(&poll,
+    s.register(poll.register(),
                Token(3),
                Ready::empty(),
                PollOpt::edge()).unwrap();
@@ -91,7 +91,7 @@ fn write_then_deregister() {
 
     let mut s2 = a.accept().unwrap().0;
 
-    s2.register(&poll,
+    s2.register(poll.register(),
                 Token(2),
                 Ready::writable(),
                 PollOpt::edge()).unwrap();
@@ -104,9 +104,9 @@ fn write_then_deregister() {
     assert_eq!(events.iter().next().unwrap().token(), Token(2));
 
     s2.write(&[1, 2, 3, 4]).unwrap();
-    s2.deregister(&poll).unwrap();
+    s2.deregister(poll.register()).unwrap();
 
-    s.reregister(&poll,
+    s.reregister(poll.register(),
                  Token(3),
                  Ready::readable(),
                  PollOpt::edge()).unwrap();


### PR DESCRIPTION
This also makes `Poll::poll` require `&mut self` since `Poll` is no
longer expected to be stored in a `Sync` context.

Resolves #757