### PR TITLE
RFC: Balancing system evens and custom events

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -769,6 +769,7 @@ impl Poll {
     {
         let inner = &*self.register.inner;
         let now = Instant::now();
+        let timeout_user = timeout;
 
         // If in ReadinessQueue still pending nodes read them straight, otherwise if
         // the tail is pointing to the sleep_marker, dive into the system selector and
@@ -829,7 +830,7 @@ impl Poll {
                         // Interrupted by a signal; update timeout if necessary and retry
                         let elapsed = now.elapsed();
 
-                        match timeout {
+                        match timeout_user {
                             Some(to) if elapsed < to => timeout = Some(to - elapsed), // !! change param to "&mut timeout"
                             Some(_) => break,
                             None => break // The original code does not check this condition!!
@@ -853,7 +854,7 @@ impl Poll {
                 let elapsed = now.elapsed();
 
                 // adapt the timeout if specified
-                match timeout {
+                match timeout_user {
                     Some(to) if elapsed < to => timeout = Some(to - elapsed), // !! change param to "&mut timeout"
                     Some(_) => timeout = Some(Duration::from_millis(0)),
                     None => timeout = None // The original code does not check this condition!!

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1633,7 +1633,7 @@ impl RegistrationInner {
         let mut next;
 
         loop {
-            next = state; // clone
+            next = state;
 
             if state.is_dropped() {
                 // Node is dropped, no more notifications
@@ -1678,7 +1678,7 @@ impl RegistrationInner {
         let other: &*mut () = unsafe { mem::transmute(&register.inner.readiness_queue.inner) };
         let other = *other;
 
-        //debug_assert!(mem::size_of::<Arc<ReadinessQueueInner>>() == mem::size_of::<*mut ()>());
+        debug_assert!(mem::size_of::<Arc<ReadinessQueueInner>>() == mem::size_of::<*mut ()>());
 
         if queue.is_null() {
             // Attempt to set the queue pointer. `Release` ordering synchronizes
@@ -1816,9 +1816,6 @@ impl RegistrationInner {
 
         // Release the lock
         self.update_lock.store(false, Release);
-
-       let _state_queued = state.is_queued();
-       let _next_queued = next.is_queued();
 
         if !state.is_queued() && next.is_queued() {
             // We are responsible for enqueing the node.
@@ -2024,8 +2021,6 @@ impl Drop for ReadinessQueue {
     fn drop(&mut self) {
         // Close the queue by enqueuing the closed node
         self.inner.enqueue_node(&*self.inner.closed_marker);
-        let _sleep_marker = self.inner.sleep_marker();
-        let _closed_marker = self.inner.closed_marker();
 
         loop {
             // Free any nodes that happen to be left in the readiness queue
@@ -2080,17 +2075,6 @@ impl ReadinessQueueInner {
             let mut prev = self.head_readiness.load(Acquire);
 
             loop {
-
-                if prev == node_ptr {
-                    if node_ptr != self.sleep_marker()  {
-                        let _i = 1;
-                    } else if node_ptr != self.closed_marker() {
-                        let _j = 2;
-                    } else {
-                        let _k = 3;
-                    }
-                }
-
                 if prev == self.closed_marker() {
                     debug_assert!(node_ptr != self.closed_marker());
 

--- a/src/sys/fuchsia/awakener.rs
+++ b/src/sys/fuchsia/awakener.rs
@@ -31,8 +31,10 @@ impl Awakener {
 
         Ok(port.queue(&packet)?)
     }
-
-    pub fn cleanup(&self) {}
+    
+    pub fn take(&self) -> bool {
+        // dummy, to be implemented
+    }
 }
 
 impl Evented for Awakener {

--- a/src/sys/fuchsia/awakener.rs
+++ b/src/sys/fuchsia/awakener.rs
@@ -31,10 +31,12 @@ impl Awakener {
 
         Ok(port.queue(&packet)?)
     }
-    
+
     pub fn take(&self) -> bool {
         // dummy, to be implemented
+        return true;
     }
+
 }
 
 impl Evented for Awakener {

--- a/src/sys/unix/awakener.rs
+++ b/src/sys/unix/awakener.rs
@@ -41,18 +41,6 @@ mod pipe {
             }
         }
 
-//        pub fn cleanup(&self) {
-//            let mut buf = [0; 128];
-//
-//            loop {
-//                // Consume data until all bytes are purged
-//                match (&self.reader).read(&mut buf) {
-//                    Ok(i) if i > 0 => {},
-//                    _ => return,
-//                }
-//            }
-//        }
-
         pub fn take(&self) -> bool {
             let mut buf = [0; 1];
 

--- a/src/sys/unix/awakener.rs
+++ b/src/sys/unix/awakener.rs
@@ -41,15 +41,25 @@ mod pipe {
             }
         }
 
-        pub fn cleanup(&self) {
-            let mut buf = [0; 128];
+//        pub fn cleanup(&self) {
+//            let mut buf = [0; 128];
+//
+//            loop {
+//                // Consume data until all bytes are purged
+//                match (&self.reader).read(&mut buf) {
+//                    Ok(i) if i > 0 => {},
+//                    _ => return,
+//                }
+//            }
+//        }
 
-            loop {
-                // Consume data until all bytes are purged
-                match (&self.reader).read(&mut buf) {
-                    Ok(i) if i > 0 => {},
-                    _ => return,
-                }
+        pub fn take(&self) -> bool {
+            let mut buf = [0; 1];
+
+            // Consume data until all bytes are purged
+            match (&self.reader).read(&mut buf) {
+                Ok(i) if i > 0 => return true,
+                _ => return false,
             }
         }
 

--- a/src/sys/windows/awakener.rs
+++ b/src/sys/windows/awakener.rs
@@ -38,7 +38,8 @@ impl Awakener {
     }
 
     pub fn take(&self) -> bool {
-      // dummy, to be implemented
+        // dummy, to be implemented
+        return true;
     }
 }
 

--- a/src/sys/windows/awakener.rs
+++ b/src/sys/windows/awakener.rs
@@ -37,8 +37,8 @@ impl Awakener {
         Ok(())
     }
 
-    pub fn cleanup(&self) {
-        // noop
+    pub fn take(&self) -> bool {
+      // dummy, to be implemented
     }
 }
 

--- a/test/test_custom_evented.rs
+++ b/test/test_custom_evented.rs
@@ -123,6 +123,7 @@ mod stress {
                 for (i, &(ref r, _)) in registrations.iter().enumerate() {
                     r.reregister(poll.register(), Token(i), Ready::writable(), PollOpt::edge()).unwrap();
                 }
+                let mut events = Events::with_capacity(NUM_REGISTRATIONS);
 
                 poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
 
@@ -139,6 +140,8 @@ mod stress {
 
             // Final polls, until readiness-queue empty
             loop {
+                let mut events = Events::with_capacity(NUM_REGISTRATIONS);
+
                 poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
                 if events.is_empty() {
                     // no more events in readiness queue pending

--- a/test/test_custom_evented.rs
+++ b/test/test_custom_evented.rs
@@ -15,9 +15,9 @@ fn smoke() {
 
     set.set_readiness(Ready::readable()).unwrap();
 
-    poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
-    assert_eq!(events.iter().count(), 1);
-    assert_eq!(events.iter().next().unwrap().token(), Token(0));
+    //poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
+    //assert_eq!(events.iter().count(), 1);
+    //assert_eq!(events.iter().next().unwrap().token(), Token(0));
 }
 
 #[test]

--- a/test/test_custom_evented.rs
+++ b/test/test_custom_evented.rs
@@ -193,11 +193,15 @@ mod stress {
             });
         }
 
-        let mut events = Events::with_capacity(4);
+        // CHECKME: seems the events-list can not be cleared??
+        // let mut events = Events::with_capacity(4);
 
         barrier.wait();
 
         for _ in 0..ITER {
+            // FIXME: workaround as the events-list can not be cleared
+            let mut events = Events::with_capacity(4);
+
             poll.poll(&mut events, None).unwrap();
         }
 
@@ -207,6 +211,8 @@ mod stress {
 
 
         for _ in 0..5 {
+            // FIXME: workaround as the events-list can not be cleared
+            let mut events = Events::with_capacity(4);
             poll.poll(&mut events, None).unwrap();
 
             for event in &events {

--- a/test/test_custom_evented.rs
+++ b/test/test_custom_evented.rs
@@ -15,9 +15,9 @@ fn smoke() {
 
     set.set_readiness(Ready::readable()).unwrap();
 
-    //poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
-    //assert_eq!(events.iter().count(), 1);
-    //assert_eq!(events.iter().next().unwrap().token(), Token(0));
+    poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
+    assert_eq!(events.iter().count(), 1);
+    assert_eq!(events.iter().next().unwrap().token(), Token(0));
 }
 
 #[test]
@@ -35,14 +35,16 @@ fn set_readiness_before_register() {
         let b2 = b1.clone();
 
         let th = thread::spawn(move || {
-            b2.wait();
             set.set_readiness(Ready::readable()).unwrap();
-        });
+            b2.wait();
 
+        });
+        
         b1.wait();
 
         poll.register()
             .register(&r, Token(123), Ready::readable(), PollOpt::edge()).unwrap();
+
 
         loop {
             poll.poll(&mut events, None).unwrap();
@@ -51,6 +53,7 @@ fn set_readiness_before_register() {
             if n == 0 {
                 continue;
             }
+
 
             assert_eq!(n, 1);
             assert_eq!(events.iter().next().unwrap().token(), Token(123));


### PR DESCRIPTION
Hi,  I would like to ask you for comments, please do not merge yet.

After analysation of the Poll functionality I did a bit refactoring to balance system events and custom events. 

Now the sleep_marker is rotating token, the end_marker became obsolete. When the sleep_marker is back at tail, the routine will check for system events. Afterwards setting sleep_marker back to head of ReadinessQueue, defining the set of pending custom events for that period.

The test "with_small_events_collection" is still failing, seems a condition is not met yet. Will need some more time to finalize it.
Comments are welcome, maybe you see the flaw causing this test fail?