### PR TITLE
prefer mio-extras

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,12 +112,12 @@ mod token;
 
 pub mod net;
 
-#[deprecated(since = "0.6.5", note = "use mio-more instead")]
+#[deprecated(since = "0.6.5", note = "use mio-extras instead")]
 #[cfg(feature = "with-deprecated")]
 #[doc(hidden)]
 pub mod channel;
 
-#[deprecated(since = "0.6.5", note = "use mio-more instead")]
+#[deprecated(since = "0.6.5", note = "use mio-extras instead")]
 #[cfg(feature = "with-deprecated")]
 #[doc(hidden)]
 pub mod timer;


### PR DESCRIPTION
Point users of deprecated code at `mio-extras` rather than `mio-more`.

`mio-more` is unmaintained.  `mio-extras` is a fork that I intend to maintain - at least to the modest extent of updating dependencies and accepting bug fixes.  (See also [here](https://github.com/carllerche/mio-more/pull/5#issuecomment-353403482)).  

Therefore people should prefer `mio-extras`.

While I'd be happy to see this pull request accepted, I'd also be happy to see it rejected - if the reason is that `mio-more` is not quite dead!