### PR TITLE
lio_listio(2) support

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -550,10 +550,10 @@ fn test_debug_pollopt() {
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct Ready(usize);
 
-const READABLE: usize = 0b00001;
-const WRITABLE: usize = 0b00010;
-const ERROR: usize    = 0b00100;
-const HUP: usize      = 0b01000;
+const READABLE: usize = 0b000001;
+const WRITABLE: usize = 0b000010;
+const ERROR: usize    = 0b000100;
+const HUP: usize      = 0b001000;
 
 impl Ready {
     /// Returns the empty `Ready` set.

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -550,10 +550,10 @@ fn test_debug_pollopt() {
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct Ready(usize);
 
-const READABLE: usize = 0b000001;
-const WRITABLE: usize = 0b000010;
-const ERROR: usize    = 0b000100;
-const HUP: usize      = 0b001000;
+const READABLE: usize = 0b00001;
+const WRITABLE: usize = 0b00010;
+const ERROR: usize    = 0b00100;
+const HUP: usize      = 0b01000;
 
 impl Ready {
     /// Returns the empty `Ready` set.

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -298,6 +298,12 @@ impl Events {
                     event::kind_mut(&mut self.events[idx]).insert(UnixReady::aio());
                 }
             }
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+            {
+                if e.filter == libc::EVFILT_LIO {
+                    event::kind_mut(&mut self.events[idx]).insert(UnixReady::lio());
+                }
+            }
 
             if e.flags & libc::EV_EOF != 0 {
                 event::kind_mut(&mut self.events[idx]).insert(UnixReady::hup());

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -126,10 +126,9 @@ impl UnixReady {
     #[cfg(not(any(target_os = "dragonfly",
         target_os = "freebsd", target_os = "ios", target_os = "macos")))]
     #[deprecated(since = "0.6.12", note = "this function is now platform specific")]
-    #[cfg(feature = "with-deprecated")]
     #[doc(hidden)]
     pub fn aio() -> UnixReady {
-        UnixReady(0)
+        UnixReady(Ready::empty())
     }
 
     /// Returns a `Ready` representing error readiness.
@@ -396,6 +395,7 @@ impl fmt::Debug for UnixReady {
             (UnixReady(Ready::writable()), "Writable"),
             (UnixReady::error(), "Error"),
             (UnixReady::hup(), "Hup"),
+            #[allow(deprecated)]
             (UnixReady::aio(), "Aio")];
 
         for &(flag, msg) in &flags {

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -92,9 +92,10 @@ use std::fmt;
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub struct UnixReady(Ready);
 
-const ERROR: usize = 0b00100;
-const HUP: usize   = 0b01000;
-const AIO: usize   = 0b10000;
+const ERROR: usize = 0b000100;
+const HUP: usize   = 0b001000;
+const AIO: usize   = 0b010000;
+const LIO: usize   = 0b100000;
 
 impl UnixReady {
     /// Returns a `Ready` representing AIO completion readiness
@@ -172,6 +173,26 @@ impl UnixReady {
         UnixReady(ready_from_usize(HUP))
     }
 
+    /// Returns a `Ready` representing LIO completion readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::unix::UnixReady;
+    ///
+    /// let ready = UnixReady::lio();
+    ///
+    /// assert!(ready.is_lio());
+    /// ```
+    ///
+    /// [`Poll`]: struct.Poll.html
+    #[inline]
+    pub fn lio() -> UnixReady {
+        UnixReady(ready_from_usize(LIO))
+    }
+
     /// Returns true if `Ready` contains AIO readiness
     ///
     /// See [`Poll`] for more documentation on polling.
@@ -245,6 +266,24 @@ impl UnixReady {
     #[inline]
     pub fn is_hup(&self) -> bool {
         self.contains(ready_from_usize(HUP))
+    }
+
+    /// Returns true if `Ready` contains LIO readiness
+    ///
+    /// See [`Poll`] for more documentation on polling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::unix::UnixReady;
+    ///
+    /// let ready = UnixReady::lio();
+    ///
+    /// assert!(ready.is_lio());
+    /// ```
+    #[inline]
+    pub fn is_lio(&self) -> bool {
+        self.contains(ready_from_usize(LIO))
     }
 }
 

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -94,7 +94,10 @@ pub struct UnixReady(Ready);
 
 const ERROR: usize = 0b000100;
 const HUP: usize   = 0b001000;
+#[cfg(any(target_os = "dragonfly",
+    target_os = "freebsd", target_os = "ios", target_os = "macos"))]
 const AIO: usize   = 0b010000;
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
 const LIO: usize   = 0b100000;
 
 impl UnixReady {
@@ -114,6 +117,8 @@ impl UnixReady {
     ///
     /// [`Poll`]: ../struct.Poll.html
     #[inline]
+    #[cfg(any(target_os = "dragonfly",
+        target_os = "freebsd", target_os = "ios", target_os = "macos"))]
     pub fn aio() -> UnixReady {
         UnixReady(ready_from_usize(AIO))
     }
@@ -189,6 +194,7 @@ impl UnixReady {
     ///
     /// [`Poll`]: struct.Poll.html
     #[inline]
+    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
     pub fn lio() -> UnixReady {
         UnixReady(ready_from_usize(LIO))
     }
@@ -209,6 +215,8 @@ impl UnixReady {
     ///
     /// [`Poll`]: ../struct.Poll.html
     #[inline]
+    #[cfg(any(target_os = "dragonfly",
+        target_os = "freebsd", target_os = "ios", target_os = "macos"))]
     pub fn is_aio(&self) -> bool {
         self.contains(ready_from_usize(AIO))
     }
@@ -282,6 +290,7 @@ impl UnixReady {
     /// assert!(ready.is_lio());
     /// ```
     #[inline]
+    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
     pub fn is_lio(&self) -> bool {
         self.contains(ready_from_usize(LIO))
     }

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -123,6 +123,15 @@ impl UnixReady {
         UnixReady(ready_from_usize(AIO))
     }
 
+    #[cfg(not(any(target_os = "dragonfly",
+        target_os = "freebsd", target_os = "ios", target_os = "macos")))]
+    #[deprecated(since = "0.6.12", note = "this function is now platform specific")]
+    #[cfg(feature = "with-deprecated")]
+    #[doc(hidden)]
+    pub fn aio() -> UnixReady {
+        UnixReady(0)
+    }
+
     /// Returns a `Ready` representing error readiness.
     ///
     /// **Note that only readable and writable readiness is guaranteed to be
@@ -219,6 +228,15 @@ impl UnixReady {
         target_os = "freebsd", target_os = "ios", target_os = "macos"))]
     pub fn is_aio(&self) -> bool {
         self.contains(ready_from_usize(AIO))
+    }
+
+    #[deprecated(since = "0.6.12", note = "this function is now platform specific")]
+    #[cfg(feature = "with-deprecated")]
+    #[cfg(not(any(target_os = "dragonfly",
+        target_os = "freebsd", target_os = "ios", target_os = "macos")))]
+    #[doc(hidden)]
+    pub fn is_aio(&self) -> bool {
+        false
     }
 
     /// Returns true if the value includes error readiness


### PR DESCRIPTION
This PR adds support for lio_listio(2) on supported platforms.  It also `#[cfg()]` gates the existing aio-related methods for supported platforms only.

This replaces PR #736 .  I'm leaving that old PR online to maintain a record of the `BSDReady` approach.