### PR TITLE
Remove unnecessary constants definition for android

### DIFF
--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -5,19 +5,9 @@ use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use std::time::Duration;
 use std::{cmp, i32};
 
-use libc::c_int;
-use libc;
-use libc::{EPOLLERR, EPOLLHUP};
+use libc::{self, c_int};
+use libc::{EPOLLERR, EPOLLHUP, EPOLLRDHUP, EPOLLONESHOT};
 use libc::{EPOLLET, EPOLLOUT, EPOLLIN, EPOLLPRI};
-
-#[cfg(not(target_os = "android"))]
-use libc::{EPOLLRDHUP, EPOLLONESHOT};
-
-// libc doesn't define these constants on android, but they are supported.
-#[cfg(target_os = "android")]
-const EPOLLRDHUP: libc::c_int = 0x00002000;
-#[cfg(target_os = "android")]
-const EPOLLONESHOT: libc::c_int = 0x40000000;
 
 use {io, Ready, PollOpt, Token};
 use event_imp::Event;
@@ -80,9 +70,9 @@ impl Selector {
         unsafe {
             evts.events.set_len(0);
             let cnt = cvt(libc::epoll_wait(self.epfd,
-                                                evts.events.as_mut_ptr(),
-                                                evts.events.capacity() as i32,
-                                                timeout_ms))?;
+                                           evts.events.as_mut_ptr(),
+                                           evts.events.capacity() as i32,
+                                           timeout_ms))?;
             let cnt = cnt as usize;
             evts.events.set_len(cnt);
 


### PR DESCRIPTION
These constants had been added into `libc` for android.

https://github.com/rust-lang/libc/blob/master/src/unix/notbsd/android/mod.rs#L216

* Added `EPOLLONESHOT`: https://github.com/rust-lang/libc/commit/519c5ea963f858180bc3ee00f36a5e45e34aa436#diff-6715020cc6fb2db4609b70fbb4b0f3f5R175
* Added `EPOLLRDHUP`: https://github.com/rust-lang/libc/commit/4abc3cefef25eb2d5ad4ee780699872026eb9a4d#diff-6715020cc6fb2db4609b70fbb4b0f3f5R177