### PR TITLE
adapt bench_poll for split of poll and register

### DIFF
--- a/benches/bench_poll.rs
+++ b/benches/bench_poll.rs
@@ -46,10 +46,7 @@ fn bench_poll(bench: &mut Bencher) {
 
         while n < NUM {
             if poll.poll(&mut events, None).is_ok() {
-                // TBD: would be handy to have a method such as events.len()
-                for _ in events.iter() {
-                    n += 1;
-                }
+                n += events.iter().count();
             }
         }
     })

--- a/benches/bench_poll.rs
+++ b/benches/bench_poll.rs
@@ -13,18 +13,17 @@ fn bench_poll(bench: &mut Bencher) {
     const NUM: usize = 10_000;
     const THREADS: usize = 4;
 
-    let poll = Poll::new().unwrap();
+    let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(1024);
 
     let mut registrations = vec![];
     let mut set_readiness = vec![];
 
     for i in 0..NUM {
-        let (r, s) = Registration::new(
-            &poll,
-            Token(i),
-            Ready::readable(),
-            PollOpt::edge());
+        let (r, s) = Registration::new();
+
+         poll.register()
+            .register(&r, Token(i), Ready::readable(), PollOpt::edge()).unwrap();
 
         registrations.push(r);
         set_readiness.push(s);
@@ -43,10 +42,15 @@ fn bench_poll(bench: &mut Bencher) {
             });
         }
 
-        let mut n = 0;
+        let mut n: usize = 0;
 
         while n < NUM {
-            n += poll.poll(&mut events, None).unwrap();
+            if poll.poll(&mut events, None).is_ok() {
+                // TBD: would be handy to have a method such as events.len()
+                for _ in events.iter() {
+                    n += 1;
+                }
+            }
         }
     })
 }


### PR DESCRIPTION
Hi Carl, the fix looks a bit ugly. Any reason there is no Events::len() method?