### PR TITLE
Remove lio_listio(2) support for DragonFly - Fix compile

### DIFF
--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -299,7 +299,7 @@ impl Events {
                     event::kind_mut(&mut self.events[idx]).insert(UnixReady::aio());
                 }
             }
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+#[cfg(any(target_os = "freebsd"))]
             {
                 if e.filter == libc::EVFILT_LIO {
                     event::kind_mut(&mut self.events[idx]).insert(UnixReady::lio());

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -97,7 +97,7 @@ const HUP: usize   = 0b001000;
 #[cfg(any(target_os = "dragonfly",
     target_os = "freebsd", target_os = "ios", target_os = "macos"))]
 const AIO: usize   = 0b010000;
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+#[cfg(any(target_os = "freebsd"))]
 const LIO: usize   = 0b100000;
 
 impl UnixReady {
@@ -202,7 +202,7 @@ impl UnixReady {
     ///
     /// [`Poll`]: struct.Poll.html
     #[inline]
-    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+    #[cfg(any(target_os = "freebsd"))]
     pub fn lio() -> UnixReady {
         UnixReady(ready_from_usize(LIO))
     }
@@ -307,7 +307,7 @@ impl UnixReady {
     /// assert!(ready.is_lio());
     /// ```
     #[inline]
-    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+    #[cfg(any(target_os = "freebsd"))]
     pub fn is_lio(&self) -> bool {
         self.contains(ready_from_usize(LIO))
     }


### PR DESCRIPTION
There is no EVFILT_LIO on DragonFly. Commit 00d85730 failed to
compile on DragonFly. There seems to be no (official) LIO support,
at least it is not mentioned anywhere in manpages etc.

With this commit, mio can be build again on DragonFly and all tests pass.