### PR TITLE
Illumos support 

### DIFF
--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -3,10 +3,10 @@ use libc::{self, c_int};
 #[macro_use]
 pub mod dlsym;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
 mod epoll;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
 pub use self::epoll::{Events, Selector};
 
 #[cfg(any(target_os = "bitrig", target_os = "dragonfly",


### PR DESCRIPTION
I have a PR to add EPOLL(5) to libc so mio and iovec could be built in Illumos.   As mio and iovec are using libc tag 0.2.19.  It's needed to wait until the PR is upstream in Master and that tag.
In the meantime, if some needs to build mio or iovec in Illumos he or she needs to use this dep.

libc =  { git = "https://github.com/cneira/libc.git", branch = "mio" }