### PR TITLE
TcpListener::from_std does not require the addr

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -529,9 +529,17 @@ impl TcpListener {
         // listen
         let listener = sock.listen(1024)?;
         Ok(TcpListener {
-            sys: sys::TcpListener::new(listener, addr)?,
+            sys: sys::TcpListener::new(listener)?,
             selector_id: SelectorId::new(),
         })
+    }
+
+    #[deprecated(since = "0.6.13", note = "use from_std instead")]
+    #[cfg(feature = "with-deprecated")]
+    #[doc(hidden)]
+    pub fn from_listener(listener: net::TcpListener, _: &SocketAddr)
+                         -> io::Result<TcpListener> {
+        TcpListener::from_std(listener)
     }
 
     /// Creates a new `TcpListener` from an instance of a
@@ -543,9 +551,8 @@ impl TcpListener {
     /// loop.
     ///
     /// The address provided must be the address that the listener is bound to.
-    pub fn from_listener(listener: net::TcpListener, addr: &SocketAddr)
-                         -> io::Result<TcpListener> {
-        sys::TcpListener::new(listener, addr).map(|s| {
+    pub fn from_std(listener: net::TcpListener) -> io::Result<TcpListener> {
+        sys::TcpListener::new(listener).map(|s| {
             TcpListener {
                 sys: s,
                 selector_id: SelectorId::new(),

--- a/src/sys/fuchsia/net.rs
+++ b/src/sys/fuchsia/net.rs
@@ -209,7 +209,7 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
-    pub fn new(inner: net::TcpListener, _addr: &SocketAddr) -> io::Result<TcpListener> {
+    pub fn new(inner: net::TcpListener) -> io::Result<TcpListener> {
         set_nonblock(inner.as_raw_fd())?;
 
         let evented_fd = unsafe { EventedFd::new(inner.as_raw_fd()) };

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -214,7 +214,7 @@ impl AsRawFd for TcpStream {
 }
 
 impl TcpListener {
-    pub fn new(inner: net::TcpListener, _addr: &SocketAddr) -> io::Result<TcpListener> {
+    pub fn new(inner: net::TcpListener) -> io::Result<TcpListener> {
         set_nonblock(inner.as_raw_fd())?;
         Ok(TcpListener {
             inner: inner,

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -645,9 +645,10 @@ impl Drop for TcpStream {
 }
 
 impl TcpListener {
-    pub fn new(socket: net::TcpListener, addr: &SocketAddr)
+    pub fn new(socket: net::TcpListener)
                -> io::Result<TcpListener> {
-        Ok(TcpListener::new_family(socket, match *addr {
+        let addr = socket.local_addr()?;
+        Ok(TcpListener::new_family(socket, match addr {
             SocketAddr::V4(..) => Family::V4,
             SocketAddr::V6(..) => Family::V6,
         }))


### PR DESCRIPTION
The current API for converting a std TcpListener to a mio TcpListener
requires passing in a SocketAddr. This is because Windows requires the
address family when initialzing the listener.

However, the TcpListener already knows its socket address at this point,
so it should not be a required argument.