### PR TITLE
Fix the tests in FreeBSD jails

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -145,6 +145,11 @@ impl UdpSocket {
     ///
     /// # Examples
     ///
+    // This assertion is almost, but not quite, universal.  It fails on
+    // shared-IP FreeBSD jails.  It's hard for mio to know whether we're jailed,
+    // so simply disable the test on FreeBSD.
+    #[cfg_attr(not(target_os = "freebsd"), doc = " ```")]
+    #[cfg_attr(target_os = "freebsd", doc = " ```no_run")]
     /// ```
     /// # use std::error::Error;
     /// #


### PR DESCRIPTION
In a shared-IP FreeBSD jail, "127.0.0.1" is just an alias for the jail's
IP, causing the net::udp::UdpSocket::local_addr test to fail.  Disable
that test on FreeBSD.