### PR TITLE
make Debug output for Tcp{Stream,Listener} and UdpSocket less verbose

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -7,7 +7,7 @@
 //!
 /// [portability guidelines]: ../struct.Poll.html#portability
 
-
+use std::fmt;
 use std::io::{Read, Write};
 use std::net::{self, SocketAddr, SocketAddrV4, SocketAddrV6, Ipv4Addr, Ipv6Addr};
 use std::time::Duration;
@@ -60,7 +60,6 @@ use poll::SelectorId;
 /// #     try_main().unwrap();
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct TcpStream {
     sys: sys::TcpStream,
     selector_id: SelectorId,
@@ -454,6 +453,12 @@ impl Evented for TcpStream {
     }
 }
 
+impl fmt::Debug for TcpStream {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.sys, f)
+    }
+}
+
 /*
  *
  * ===== TcpListener =====
@@ -490,7 +495,6 @@ impl Evented for TcpStream {
 /// #     try_main().unwrap();
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct TcpListener {
     sys: sys::TcpListener,
     selector_id: SelectorId,
@@ -664,6 +668,12 @@ impl Evented for TcpListener {
 
     fn deregister(&self, poll: &Poll) -> io::Result<()> {
         self.sys.deregister(poll)
+    }
+}
+
+impl fmt::Debug for TcpListener {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.sys, f)
     }
 }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -10,6 +10,7 @@
 use {io, sys, Ready, Poll, PollOpt, Token};
 use event::Evented;
 use poll::SelectorId;
+use std::fmt;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 /// A User Datagram Protocol socket.
@@ -85,7 +86,6 @@ use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 /// #   try_main().unwrap();
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct UdpSocket {
     sys: sys::UdpSocket,
     selector_id: SelectorId,
@@ -492,6 +492,12 @@ impl Evented for UdpSocket {
 
     fn deregister(&self, poll: &Poll) -> io::Result<()> {
         self.sys.deregister(poll)
+    }
+}
+
+impl fmt::Debug for UdpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.sys, f)
     }
 }
 

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+use std::fmt;
 use std::io::{Read, Write};
 use std::net::{self, SocketAddr};
 use std::os::unix::io::{RawFd, FromRawFd, IntoRawFd, AsRawFd};
@@ -15,12 +16,10 @@ use event::Evented;
 use sys::unix::eventedfd::EventedFd;
 use sys::unix::io::set_nonblock;
 
-#[derive(Debug)]
 pub struct TcpStream {
     inner: net::TcpStream,
 }
 
-#[derive(Debug)]
 pub struct TcpListener {
     inner: net::TcpListener,
 }
@@ -193,6 +192,12 @@ impl Evented for TcpStream {
     }
 }
 
+impl fmt::Debug for TcpStream {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
 impl FromRawFd for TcpStream {
     unsafe fn from_raw_fd(fd: RawFd) -> TcpStream {
         TcpStream {
@@ -273,6 +278,12 @@ impl Evented for TcpListener {
 
     fn deregister(&self, poll: &Poll) -> io::Result<()> {
         EventedFd(&self.as_raw_fd()).deregister(poll)
+    }
+}
+
+impl fmt::Debug for TcpListener {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
     }
 }
 

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,13 +1,13 @@
 use {io, Ready, Poll, PollOpt, Token};
 use event::Evented;
 use unix::EventedFd;
+use std::fmt;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::io::{RawFd, IntoRawFd, AsRawFd, FromRawFd};
 
 #[allow(unused_imports)] // only here for Rust 1.8
 use net2::UdpSocketExt;
 
-#[derive(Debug)]
 pub struct UdpSocket {
     io: net::UdpSocket,
 }
@@ -141,6 +141,12 @@ impl Evented for UdpSocket {
 
     fn deregister(&self, poll: &Poll) -> io::Result<()> {
         EventedFd(&self.as_raw_fd()).deregister(poll)
+    }
+}
+
+impl fmt::Debug for UdpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.io, f)
     }
 }
 


### PR DESCRIPTION
Before:

```
TcpStream { sys: TcpStream { inner: TcpStream { addr: V4(127.0.0.1:4140), peer: V4(127.0.0.1:41678), fd: 34 } }, selector_id: SelectorId { id: AtomicUsize(1) } }
```

After:

```
TcpStream { addr: V4(127.0.0.1:4140), peer: V4(127.0.0.1:41678), fd: 34 }
```