### PR TITLE
Add `Ready::all` as well as `usize` conversions.

### DIFF
--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -13,6 +13,9 @@ pub use self::unix::{
 };
 
 #[cfg(all(unix, not(target_os = "fuchsia")))]
+pub use self::unix::READY_ALL;
+
+#[cfg(all(unix, not(target_os = "fuchsia")))]
 #[cfg(feature = "with-deprecated")]
 pub use self::unix::UnixSocket;
 
@@ -48,3 +51,6 @@ pub use self::fuchsia::{
 
 #[cfg(target_os = "fuchsia")]
 pub mod fuchsia;
+
+#[cfg(not(all(unix, not(target_os = "fuchsia"))))]
+pub const READY_ALL: usize = 0;

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -32,7 +32,7 @@ mod uds;
 pub use self::awakener::Awakener;
 pub use self::eventedfd::EventedFd;
 pub use self::io::{Io, set_nonblock};
-pub use self::ready::UnixReady;
+pub use self::ready::{UnixReady, READY_ALL};
 pub use self::tcp::{TcpStream, TcpListener};
 pub use self::udp::UdpSocket;
 

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -94,11 +94,23 @@ pub struct UnixReady(Ready);
 
 const ERROR: usize = 0b000100;
 const HUP: usize   = 0b001000;
+
 #[cfg(any(target_os = "dragonfly",
     target_os = "freebsd", target_os = "ios", target_os = "macos"))]
 const AIO: usize   = 0b010000;
+
+#[cfg(not(any(target_os = "dragonfly",
+    target_os = "freebsd", target_os = "ios", target_os = "macos")))]
+const AIO: usize   = 0b000000;
+
 #[cfg(any(target_os = "freebsd"))]
 const LIO: usize   = 0b100000;
+
+#[cfg(not(any(target_os = "freebsd")))]
+const LIO: usize   = 0b000000;
+
+// Export to support `Ready::all`
+pub const READY_ALL: usize = ERROR | HUP | AIO | LIO;
 
 impl UnixReady {
     /// Returns a `Ready` representing AIO completion readiness


### PR DESCRIPTION
This patch provides a new constructor for `Ready` that returns a
value representing readiness for all operations. This is useful for
registering interest on all operations or for using the value as a mask.

This patch also provides `usize` conversions for `Ready`. This allows
storing and loading a `Ready` value in an `AtomicUsize`.

This PR does not include any work for Fuschia.

cc @cramertj 