### PR TITLE
Misc test fixes discovered on FreeBSD

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -36,7 +36,7 @@ use poll::SelectorId;
 /// # use std::error::Error;
 /// #
 /// # fn try_main() -> Result<(), Box<Error>> {
-/// #     let _listener = TcpListener::bind("127.0.0.1:3454")?;
+/// #     let _listener = TcpListener::bind("127.0.0.1:34254")?;
 /// use mio::{Events, Ready, Poll, PollOpt, Token};
 /// use mio::net::TcpStream;
 /// use std::time::Duration;
@@ -476,7 +476,7 @@ impl fmt::Debug for TcpStream {
 /// use mio::net::TcpListener;
 /// use std::time::Duration;
 ///
-/// let listener = TcpListener::bind(&"127.0.0.1:34254".parse()?)?;
+/// let listener = TcpListener::bind(&"127.0.0.1:34255".parse()?)?;
 ///
 /// let poll = Poll::new()?;
 /// let mut events = Events::with_capacity(128);

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -55,7 +55,8 @@ impl TestHandler {
 
                 match self.cli.try_read_buf(&mut buf) {
                     Ok(Some(0)) => self.shutdown = true,
-                    _ => panic!("the client socket should not be readable")
+                    Ok(_) => panic!("the client socket should not be readable"),
+                    Err(e) => panic!("Unexpected error {:?}", e)
                 }
             }
             _ => panic!("received unknown token {:?}", tok)
@@ -77,6 +78,7 @@ impl TestHandler {
 
 #[test]
 pub fn test_close_on_drop() {
+    let _ = ::env_logger::init();
     debug!("Starting TEST_CLOSE_ON_DROP");
     let mut poll = Poll::new().unwrap();
 

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -579,7 +579,15 @@ fn connect_error() {
     let mut events = Events::with_capacity(16);
 
     // Pick a "random" port that shouldn't be in use.
-    let l = TcpStream::connect(&"127.0.0.1:38381".parse().unwrap()).unwrap();
+    let l = match TcpStream::connect(&"127.0.0.1:38381".parse().unwrap()) {
+        Ok(l) => l,
+        Err(ref e) if e.kind() == io::ErrorKind::ConnectionRefused => {
+            // Connection failed synchronously.  This is not a bug, but it
+            // unfortunately doesn't get us the code coverage we want.
+            return;
+        },
+        Err(e) => panic!("TcpStream::connect unexpected error {:?}", e)
+    };
     poll.register(&l, Token(0), Ready::writable(), PollOpt::edge()).unwrap();
 
     'outer:


### PR DESCRIPTION
All of these issues could theoretically affect any operating system,
especially the duplicate port assignment.
* Fix a port mismatch in TcpStream doc test
* Fix a duplicate port assignment in another tcp doc test
* Better debuggabilty in test_close_on_drop
* Don't fail connect_error if connect(2) fails synchronously