### PR TITLE
Bump winapi dependency 0.2.1 -> 0.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ fuchsia-zircon-sys = "0.3.2"
 libc   = "0.2.19"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2.1"
+winapi = "0.2.6"
 miow   = "0.2.1"
 kernel32-sys = "0.2"
 


### PR DESCRIPTION
winapi versions earlier than 0.2.7 don't successfully compile with the
nightly compiler.

Discovered via `cargo update -Z minimal-versions`