### PR TITLE
Bitflagsify {PollOpt,Ready}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude       = [
 ]
 
 [dependencies]
+bitflags = "1.0"
 lazycell = "0.6.0"
 log      = "0.3.1"
 slab     = "0.3.0"

--- a/benches/bench_poll.rs
+++ b/benches/bench_poll.rs
@@ -23,7 +23,7 @@ fn bench_poll(bench: &mut Bencher) {
         let (r, s) = Registration::new(
             &poll,
             Token(i),
-            Ready::readable(),
+            Ready::READABLE,
             PollOpt::EDGE);
 
         registrations.push(r);
@@ -37,7 +37,7 @@ fn bench_poll(bench: &mut Bencher) {
             let set_readiness = set_readiness.clone();
             thread::spawn(move || {
                 while i < NUM {
-                    set_readiness[i].set_readiness(Ready::readable()).unwrap();
+                    set_readiness[i].set_readiness(Ready::READABLE).unwrap();
                     i += THREADS;
                 }
             });

--- a/benches/bench_poll.rs
+++ b/benches/bench_poll.rs
@@ -24,7 +24,7 @@ fn bench_poll(bench: &mut Bencher) {
             &poll,
             Token(i),
             Ready::readable(),
-            PollOpt::edge());
+            PollOpt::EDGE);
 
         registrations.push(r);
         set_readiness.push(s);

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -167,7 +167,7 @@ bitflags! {
     /// ```
     /// use mio::PollOpt;
     ///
-    /// let opts = PollOpt::edge() | PollOpt::oneshot();
+    /// let opts = PollOpt::EDGE | PollOpt::ONESHOT;
     ///
     /// assert!(opts.is_edge());
     /// assert!(opts.is_oneshot());
@@ -185,7 +185,7 @@ bitflags! {
         /// ```
         /// use mio::PollOpt;
         ///
-        /// let opt = PollOpt::edge();
+        /// let opt = PollOpt::EDGE;
         ///
         /// assert!(opt.is_edge());
         /// ```
@@ -201,7 +201,7 @@ bitflags! {
         /// ```
         /// use mio::PollOpt;
         ///
-        /// let opt = PollOpt::level();
+        /// let opt = PollOpt::LEVEL;
         ///
         /// assert!(opt.is_level());
         /// ```
@@ -217,7 +217,7 @@ bitflags! {
         /// ```
         /// use mio::PollOpt;
         ///
-        /// let opt = PollOpt::oneshot();
+        /// let opt = PollOpt::ONESHOT;
         ///
         /// assert!(opt.is_oneshot());
         /// ```
@@ -261,7 +261,7 @@ impl PollOpt {
     /// ```
     /// use mio::PollOpt;
     ///
-    /// let opt = PollOpt::edge();
+    /// let opt = PollOpt::EDGE;
     ///
     /// assert!(opt.is_edge());
     /// ```
@@ -281,7 +281,7 @@ impl PollOpt {
     /// ```
     /// use mio::PollOpt;
     ///
-    /// let opt = PollOpt::level();
+    /// let opt = PollOpt::LEVEL;
     ///
     /// assert!(opt.is_level());
     /// ```
@@ -301,7 +301,7 @@ impl PollOpt {
     /// ```
     /// use mio::PollOpt;
     ///
-    /// let opt = PollOpt::oneshot();
+    /// let opt = PollOpt::ONESHOT;
     ///
     /// assert!(opt.is_oneshot());
     /// ```
@@ -317,9 +317,9 @@ impl fmt::Display for PollOpt {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut one = false;
         let flags = [
-            (PollOpt::edge(), "Edge-Triggered"),
-            (PollOpt::level(), "Level-Triggered"),
-            (PollOpt::oneshot(), "OneShot")];
+            (PollOpt::EDGE, "Edge-Triggered"),
+            (PollOpt::LEVEL, "Level-Triggered"),
+            (PollOpt::ONESHOT, "OneShot")];
 
         for &(flag, msg) in &flags {
             if self.contains(flag) {
@@ -341,9 +341,9 @@ impl fmt::Display for PollOpt {
 #[test]
 fn test_debug_pollopt() {
     assert_eq!("(empty)", format!("{}", PollOpt::empty()));
-    assert_eq!("Edge-Triggered", format!("{}", PollOpt::edge()));
-    assert_eq!("Level-Triggered", format!("{}", PollOpt::level()));
-    assert_eq!("OneShot", format!("{}", PollOpt::oneshot()));
+    assert_eq!("Edge-Triggered", format!("{}", PollOpt::EDGE));
+    assert_eq!("Level-Triggered", format!("{}", PollOpt::LEVEL));
+    assert_eq!("OneShot", format!("{}", PollOpt::ONESHOT));
 }
 
 /// A set of readiness event kinds

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -154,108 +154,102 @@ pub trait Evented {
     fn deregister(&self, register: &Register) -> io::Result<()>;
 }
 
-/// Options supplied when registering an `Evented` handle with `Register`
-///
-/// `PollOpt` values can be combined together using the various bitwise
-/// operators.
-///
-/// For high level documentation on polling and poll options, see [`Poll`].
-///
-/// # Examples
-///
-/// ```
-/// use mio::PollOpt;
-///
-/// let opts = PollOpt::edge() | PollOpt::oneshot();
-///
-/// assert!(opts.is_edge());
-/// assert!(opts.is_oneshot());
-/// assert!(!opts.is_level());
-/// ```
-///
-/// [`Poll`]: struct.Poll.html
-#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord)]
-pub struct PollOpt(usize);
+bitflags! {
+    /// Options supplied when registering an `Evented` handle with `Register`
+    ///
+    /// `PollOpt` values can be combined together using the various bitwise
+    /// operators.
+    ///
+    /// For high level documentation on polling and poll options, see [`Poll`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mio::PollOpt;
+    ///
+    /// let opts = PollOpt::edge() | PollOpt::oneshot();
+    ///
+    /// assert!(opts.is_edge());
+    /// assert!(opts.is_oneshot());
+    /// assert!(!opts.is_level());
+    /// ```
+    ///
+    /// [`Poll`]: struct.Poll.html
+    pub struct PollOpt: usize {
+        /// `PollOpt` representing edge-triggered notifications.
+        ///
+        /// See [`Poll`] for more documentation on polling.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use mio::PollOpt;
+        ///
+        /// let opt = PollOpt::edge();
+        ///
+        /// assert!(opt.is_edge());
+        /// ```
+        ///
+        /// [`Poll`]: struct.Poll.html
+        const EDGE    = 0b0001;
+        /// `PollOpt` representing level-triggered notifications.
+        ///
+        /// See [`Poll`] for more documentation on polling.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use mio::PollOpt;
+        ///
+        /// let opt = PollOpt::level();
+        ///
+        /// assert!(opt.is_level());
+        /// ```
+        ///
+        /// [`Poll`]: struct.Poll.html
+        const LEVEL   = 0b0010;
+        /// `PollOpt` representing oneshot notifications.
+        ///
+        /// See [`Poll`] for more documentation on polling.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use mio::PollOpt;
+        ///
+        /// let opt = PollOpt::oneshot();
+        ///
+        /// assert!(opt.is_oneshot());
+        /// ```
+        ///
+        /// [`Poll`]: struct.Poll.html
+        const ONESHOT = 0b0100;
+    }
+}
 
 impl PollOpt {
-    /// Return a `PollOpt` representing no set options.
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::PollOpt;
-    ///
-    /// let opt = PollOpt::empty();
-    ///
-    /// assert!(!opt.is_level());
-    /// ```
-    ///
-    /// [`Poll`]: struct.Poll.html
-    #[inline]
-    pub fn empty() -> PollOpt {
-        PollOpt(0)
-    }
-
-    /// Return a `PollOpt` representing edge-triggered notifications.
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::PollOpt;
-    ///
-    /// let opt = PollOpt::edge();
-    ///
-    /// assert!(opt.is_edge());
-    /// ```
-    ///
-    /// [`Poll`]: struct.Poll.html
+    #[deprecated(since = "0.7.0", note = "use PollOpt::EDGE instead")]
+    #[cfg(feature = "with-deprecated")]
+    #[doc(hidden)]
     #[inline]
     pub fn edge() -> PollOpt {
-        PollOpt(0b0001)
+        Self::EDGE
     }
 
-    /// Return a `PollOpt` representing level-triggered notifications.
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::PollOpt;
-    ///
-    /// let opt = PollOpt::level();
-    ///
-    /// assert!(opt.is_level());
-    /// ```
-    ///
-    /// [`Poll`]: struct.Poll.html
+    #[deprecated(since = "0.7.0", note = "use PollOpt::LEVEL instead")]
+    #[cfg(feature = "with-deprecated")]
+    #[doc(hidden)]
     #[inline]
     pub fn level() -> PollOpt {
-        PollOpt(0b0010)
+        Self::LEVEL
     }
 
-    /// Return a `PollOpt` representing oneshot notifications.
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::PollOpt;
-    ///
-    /// let opt = PollOpt::oneshot();
-    ///
-    /// assert!(opt.is_oneshot());
-    /// ```
-    ///
-    /// [`Poll`]: struct.Poll.html
+    #[deprecated(since = "0.7.0", note = "use PollOpt::ONESHOT instead")]
+    #[cfg(feature = "with-deprecated")]
+    #[doc(hidden)]
     #[inline]
     pub fn oneshot() -> PollOpt {
-        PollOpt(0b0100)
+        Self::ONESHOT
     }
 
     /// Returns true if the options include edge-triggered notifications.
@@ -275,7 +269,7 @@ impl PollOpt {
     /// [`Poll`]: struct.Poll.html
     #[inline]
     pub fn is_edge(&self) -> bool {
-        self.contains(PollOpt::edge())
+        self.contains(Self::EDGE)
     }
 
     /// Returns true if the options include level-triggered notifications.
@@ -295,7 +289,7 @@ impl PollOpt {
     /// [`Poll`]: struct.Poll.html
     #[inline]
     pub fn is_level(&self) -> bool {
-        self.contains(PollOpt::level())
+        self.contains(Self::LEVEL)
     }
 
     /// Returns true if the options includes oneshot.
@@ -315,129 +309,11 @@ impl PollOpt {
     /// [`Poll`]: struct.Poll.html
     #[inline]
     pub fn is_oneshot(&self) -> bool {
-        self.contains(PollOpt::oneshot())
-    }
-
-    /// Returns true if `self` is a superset of `other`.
-    ///
-    /// `other` may represent more than one option, in which case the function
-    /// only returns true if `self` contains all of the options specified in
-    /// `other`.
-    ///
-    /// See [`Poll`] for more documentation on polling.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::PollOpt;
-    ///
-    /// let opt = PollOpt::oneshot();
-    ///
-    /// assert!(opt.contains(PollOpt::oneshot()));
-    /// assert!(!opt.contains(PollOpt::edge()));
-    /// ```
-    ///
-    /// ```
-    /// use mio::PollOpt;
-    ///
-    /// let opt = PollOpt::oneshot() | PollOpt::edge();
-    ///
-    /// assert!(opt.contains(PollOpt::oneshot()));
-    /// assert!(opt.contains(PollOpt::edge()));
-    /// ```
-    ///
-    /// ```
-    /// use mio::PollOpt;
-    ///
-    /// let opt = PollOpt::oneshot() | PollOpt::edge();
-    ///
-    /// assert!(!PollOpt::oneshot().contains(opt));
-    /// assert!(opt.contains(opt));
-    /// assert!((opt | PollOpt::level()).contains(opt));
-    /// ```
-    ///
-    /// [`Poll`]: struct.Poll.html
-    #[inline]
-    pub fn contains(&self, other: PollOpt) -> bool {
-        (*self & other) == other
-    }
-
-    /// Adds all options represented by `other` into `self`.
-    ///
-    /// This is equivalent to `*self = *self | other`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::PollOpt;
-    ///
-    /// let mut opt = PollOpt::empty();
-    /// opt.insert(PollOpt::oneshot());
-    ///
-    /// assert!(opt.is_oneshot());
-    /// ```
-    #[inline]
-    pub fn insert(&mut self, other: PollOpt) {
-        self.0 |= other.0;
-    }
-
-    /// Removes all options represented by `other` from `self`.
-    ///
-    /// This is equivalent to `*self = *self & !other`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mio::PollOpt;
-    ///
-    /// let mut opt = PollOpt::oneshot();
-    /// opt.remove(PollOpt::oneshot());
-    ///
-    /// assert!(!opt.is_oneshot());
-    /// ```
-    #[inline]
-    pub fn remove(&mut self, other: PollOpt) {
-        self.0 &= !other.0;
+        self.contains(Self::ONESHOT)
     }
 }
 
-impl ops::BitOr for PollOpt {
-    type Output = PollOpt;
-
-    #[inline]
-    fn bitor(self, other: PollOpt) -> PollOpt {
-        PollOpt(self.0 | other.0)
-    }
-}
-
-impl ops::BitXor for PollOpt {
-    type Output = PollOpt;
-
-    #[inline]
-    fn bitxor(self, other: PollOpt) -> PollOpt {
-        PollOpt(self.0 ^ other.0)
-    }
-}
-
-impl ops::BitAnd for PollOpt {
-    type Output = PollOpt;
-
-    #[inline]
-    fn bitand(self, other: PollOpt) -> PollOpt {
-        PollOpt(self.0 & other.0)
-    }
-}
-
-impl ops::Sub for PollOpt {
-    type Output = PollOpt;
-
-    #[inline]
-    fn sub(self, other: PollOpt) -> PollOpt {
-        PollOpt(self.0 & !other.0)
-    }
-}
-
-impl fmt::Debug for PollOpt {
+impl fmt::Display for PollOpt {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut one = false;
         let flags = [
@@ -464,10 +340,10 @@ impl fmt::Debug for PollOpt {
 
 #[test]
 fn test_debug_pollopt() {
-    assert_eq!("(empty)", format!("{:?}", PollOpt::empty()));
-    assert_eq!("Edge-Triggered", format!("{:?}", PollOpt::edge()));
-    assert_eq!("Level-Triggered", format!("{:?}", PollOpt::level()));
-    assert_eq!("OneShot", format!("{:?}", PollOpt::oneshot()));
+    assert_eq!("(empty)", format!("{}", PollOpt::empty()));
+    assert_eq!("Edge-Triggered", format!("{}", PollOpt::edge()));
+    assert_eq!("Level-Triggered", format!("{}", PollOpt::level()));
+    assert_eq!("OneShot", format!("{}", PollOpt::oneshot()));
 }
 
 /// A set of readiness event kinds
@@ -902,16 +778,8 @@ pub fn ready_as_usize(events: Ready) -> usize {
     events.0
 }
 
-pub fn opt_as_usize(opt: PollOpt) -> usize {
-    opt.0
-}
-
 pub fn ready_from_usize(events: usize) -> Ready {
     Ready(events)
-}
-
-pub fn opt_from_usize(opt: usize) -> PollOpt {
-    PollOpt(opt)
 }
 
 // Used internally to mutate an `Event` in place

--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -88,7 +88,7 @@ use std::{fmt, io};
 ///                 thread::sleep(when - now);
 ///             }
 ///
-///             set_readiness.set_readiness(Ready::readable());
+///             set_readiness.set_readiness(Ready::READABLE);
 ///         });
 ///
 ///         Deadline {
@@ -350,7 +350,7 @@ bitflags! {
     /// A set of readiness event kinds
     ///
     /// `Ready` is a set of operation descriptors indicating which kind of an
-    /// operation is ready to be performed. For example, `Ready::readable()`
+    /// operation is ready to be performed. For example, `Ready::READABLE`
     /// indicates that the associated `Evented` handle is ready to perform a
     /// `read` operation.
     ///
@@ -369,7 +369,7 @@ bitflags! {
     /// ```
     /// use mio::Ready;
     ///
-    /// let ready = Ready::readable() | Ready::writable();
+    /// let ready = Ready::READABLE | Ready::WRITABLE;
     ///
     /// assert!(ready.is_readable());
     /// assert!(ready.is_writable());
@@ -389,7 +389,7 @@ bitflags! {
         /// ```
         /// use mio::Ready;
         ///
-        /// let ready = Ready::readable();
+        /// let ready = Ready::READABLE;
         ///
         /// assert!(ready.is_readable());
         /// ```
@@ -405,7 +405,7 @@ bitflags! {
         /// ```
         /// use mio::Ready;
         ///
-        /// let ready = Ready::writable();
+        /// let ready = Ready::WRITABLE;
         ///
         /// assert!(ready.is_writable());
         /// ```
@@ -449,7 +449,7 @@ impl Ready {
     /// ```
     /// use mio::Ready;
     ///
-    /// let ready = Ready::readable();
+    /// let ready = Ready::READABLE;
     ///
     /// assert!(ready.is_readable());
     /// ```
@@ -469,7 +469,7 @@ impl Ready {
     /// ```
     /// use mio::Ready;
     ///
-    /// let ready = Ready::writable();
+    /// let ready = Ready::WRITABLE;
     ///
     /// assert!(ready.is_writable());
     /// ```
@@ -485,8 +485,8 @@ impl fmt::Display for Ready {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut one = false;
         let flags = [
-            (Ready::readable(), "Readable"),
-            (Ready::writable(), "Writable")];
+            (Ready::READABLE, "Readable"),
+            (Ready::WRITABLE, "Writable")];
 
         for &(flag, msg) in &flags {
             if self.contains(flag) {
@@ -508,8 +508,8 @@ impl fmt::Display for Ready {
 #[test]
 fn test_debug_ready() {
     assert_eq!("(empty)", format!("{}", Ready::empty()));
-    assert_eq!("Readable", format!("{}", Ready::readable()));
-    assert_eq!("Writable", format!("{}", Ready::writable()));
+    assert_eq!("Readable", format!("{}", Ready::READABLE));
+    assert_eq!("Writable", format!("{}", Ready::WRITABLE));
 }
 
 /// An readiness event returned by [`Poll::poll`].
@@ -525,9 +525,9 @@ fn test_debug_ready() {
 /// use mio::{Ready, Token};
 /// use mio::event::Event;
 ///
-/// let event = Event::new(Ready::readable() | Ready::writable(), Token(0));
+/// let event = Event::new(Ready::READABLE | Ready::WRITABLE, Token(0));
 ///
-/// assert_eq!(event.readiness(), Ready::readable() | Ready::writable());
+/// assert_eq!(event.readiness(), Ready::READABLE | Ready::WRITABLE);
 /// assert_eq!(event.token(), Token(0));
 /// ```
 ///
@@ -550,9 +550,9 @@ impl Event {
     /// use mio::{Ready, Token};
     /// use mio::event::Event;
     ///
-    /// let event = Event::new(Ready::readable() | Ready::writable(), Token(0));
+    /// let event = Event::new(Ready::READABLE | Ready::WRITABLE, Token(0));
     ///
-    /// assert_eq!(event.readiness(), Ready::readable() | Ready::writable());
+    /// assert_eq!(event.readiness(), Ready::READABLE | Ready::WRITABLE);
     /// assert_eq!(event.token(), Token(0));
     /// ```
     pub fn new(readiness: Ready, token: Token) -> Event {
@@ -570,9 +570,9 @@ impl Event {
     /// use mio::{Ready, Token};
     /// use mio::event::Event;
     ///
-    /// let event = Event::new(Ready::readable() | Ready::writable(), Token(0));
+    /// let event = Event::new(Ready::READABLE | Ready::WRITABLE, Token(0));
     ///
-    /// assert_eq!(event.readiness(), Ready::readable() | Ready::writable());
+    /// assert_eq!(event.readiness(), Ready::READABLE | Ready::WRITABLE);
     /// ```
     pub fn readiness(&self) -> Ready {
         self.kind
@@ -586,7 +586,7 @@ impl Event {
     /// use mio::{Ready, Token};
     /// use mio::event::Event;
     ///
-    /// let event = Event::new(Ready::readable() | Ready::writable(), Token(0));
+    /// let event = Event::new(Ready::READABLE | Ready::WRITABLE, Token(0));
     ///
     /// assert_eq!(event.token(), Token(0));
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,8 @@
 
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
+#[macro_use]
+extern crate bitflags;
 extern crate lazycell;
 extern crate net2;
 extern crate iovec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! // Start listening for incoming connections
 //! poll.register()
-//!     .register(&server, SERVER, Ready::readable(),
+//!     .register(&server, SERVER, Ready::READABLE,
 //!               PollOpt::EDGE).unwrap();
 //!
 //! // Setup the client socket
@@ -49,7 +49,7 @@
 //!
 //! // Register the socket
 //! poll.register()
-//!     .register(&sock, CLIENT, Ready::readable(),
+//!     .register(&sock, CLIENT, Ready::READABLE,
 //!               PollOpt::EDGE).unwrap();
 //!
 //! // Create storage for events

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! // Start listening for incoming connections
 //! poll.register()
 //!     .register(&server, SERVER, Ready::readable(),
-//!               PollOpt::edge()).unwrap();
+//!               PollOpt::EDGE).unwrap();
 //!
 //! // Setup the client socket
 //! let sock = TcpStream::connect(&addr).unwrap();
@@ -50,7 +50,7 @@
 //! // Register the socket
 //! poll.register()
 //!     .register(&sock, CLIENT, Ready::readable(),
-//!               PollOpt::edge()).unwrap();
+//!               PollOpt::EDGE).unwrap();
 //!
 //! // Create storage for events
 //! let mut events = Events::with_capacity(1024);

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -48,7 +48,7 @@ use poll::SelectorId;
 ///
 /// // Register the socket with `Poll`
 /// poll.register().register(
-///     &stream, Token(0), Ready::writable(),
+///     &stream, Token(0), Ready::WRITABLE,
 ///     PollOpt::EDGE)?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
@@ -440,7 +440,7 @@ impl Evented for TcpStream {
 ///
 /// // Register the socket with `Poll`
 /// poll.register()
-///     .register(&listener, Token(0), Ready::writable(),
+///     .register(&listener, Token(0), Ready::WRITABLE,
 ///               PollOpt::EDGE)?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -49,7 +49,7 @@ use poll::SelectorId;
 /// // Register the socket with `Poll`
 /// poll.register().register(
 ///     &stream, Token(0), Ready::writable(),
-///     PollOpt::edge())?;
+///     PollOpt::EDGE)?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
 ///
@@ -441,7 +441,7 @@ impl Evented for TcpStream {
 /// // Register the socket with `Poll`
 /// poll.register()
 ///     .register(&listener, Token(0), Ready::writable(),
-///               PollOpt::edge())?;
+///               PollOpt::EDGE)?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
 ///

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -50,9 +50,9 @@ use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 ///
 /// // We register our sockets here so that we can check if they are ready to be written/read.
 /// poll.register()
-///     .register(&sender_socket, SENDER, Ready::writable(), PollOpt::EDGE)?;
+///     .register(&sender_socket, SENDER, Ready::WRITABLE, PollOpt::EDGE)?;
 /// poll.register()
-///     .register(&echoer_socket, ECHOER, Ready::readable(), PollOpt::EDGE)?;
+///     .register(&echoer_socket, ECHOER, Ready::READABLE, PollOpt::EDGE)?;
 ///
 /// let msg_to_send = [9; 9];
 /// let mut buffer = [0; 9];

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -50,9 +50,9 @@ use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 ///
 /// // We register our sockets here so that we can check if they are ready to be written/read.
 /// poll.register()
-///     .register(&sender_socket, SENDER, Ready::writable(), PollOpt::edge())?;
+///     .register(&sender_socket, SENDER, Ready::writable(), PollOpt::EDGE)?;
 /// poll.register()
-///     .register(&echoer_socket, ECHOER, Ready::readable(), PollOpt::edge())?;
+///     .register(&echoer_socket, ECHOER, Ready::readable(), PollOpt::EDGE)?;
 ///
 /// let msg_to_send = [9; 9];
 /// let mut buffer = [0; 9];

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -107,7 +107,7 @@ use std::time::{Duration, Instant};
 ///
 /// // Register the stream with `Poll`
 /// poll.register()
-///     .register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+///     .register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE)?;
 ///
 /// // Wait for the socket to become ready. This has to happens in a loop to
 /// // handle spurious wakeups.
@@ -280,7 +280,7 @@ use std::time::{Duration, Instant};
 /// // The connect is not guaranteed to have started until it is registered at
 /// // this point
 /// poll.register()
-///     .register(&sock, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+///     .register(&sock, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE)?;
 /// #     Ok(())
 /// # }
 /// #
@@ -668,7 +668,7 @@ impl Poll {
                 poll.register(),
                 AWAKEN,
                 Ready::readable(),
-                PollOpt::edge())?;
+                PollOpt::EDGE)?;
 
         Ok(poll)
     }
@@ -742,7 +742,7 @@ impl Poll {
     ///
     /// // Register the stream with `Poll`
     /// poll.register()
-    ///     .register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+    ///     .register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE)?;
     ///
     /// // Wait for the socket to become ready. This has to happens in a loop to
     /// // handle spurious wakeups.
@@ -902,7 +902,7 @@ impl Register {
     ///
     /// // Register the socket with `poll`
     /// poll.register()
-    ///     .register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+    ///     .register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE)?;
     ///
     /// let mut events = Events::with_capacity(1024);
     /// let start = Instant::now();
@@ -987,13 +987,13 @@ impl Register {
     ///
     /// // Register the socket with `poll`, requesting readable
     /// poll.register()
-    ///     .register(&socket, Token(0), Ready::readable(), PollOpt::edge())?;
+    ///     .register(&socket, Token(0), Ready::readable(), PollOpt::EDGE)?;
     ///
     /// // Reregister the socket specifying a different token and write interest
-    /// // instead. `PollOpt::edge()` must be specified even though that value
+    /// // instead. `PollOpt::EDGE` must be specified even though that value
     /// // is not being changed.
     /// poll.register()
-    ///     .reregister(&socket, Token(2), Ready::writable(), PollOpt::edge())?;
+    ///     .reregister(&socket, Token(2), Ready::writable(), PollOpt::EDGE)?;
     /// #     Ok(())
     /// # }
     /// #
@@ -1047,7 +1047,7 @@ impl Register {
     ///
     /// // Register the socket with `poll`
     /// poll.register()
-    ///     .register(&socket, Token(0), Ready::readable(), PollOpt::edge())?;
+    ///     .register(&socket, Token(0), Ready::readable(), PollOpt::EDGE)?;
     ///
     /// poll.register().deregister(&socket)?;
     ///
@@ -1423,7 +1423,7 @@ impl Registration {
     ///
     /// let mut poll = Poll::new()?;
     /// poll.register()
-    ///     .register(&registration, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge())?;
+    ///     .register(&registration, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE)?;
     ///
     /// let mut events = Events::with_capacity(256);
     ///
@@ -1598,7 +1598,7 @@ impl SetReadiness {
     ///     .register(&registration,
     ///               Token(0),
     ///               Ready::readable(),
-    ///               PollOpt::edge())?;
+    ///               PollOpt::EDGE)?;
     ///
     /// // Set the readiness, then immediately poll to try to get the readiness
     /// // event

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,5 +1,5 @@
 use {sys, Token};
-use event_imp::{self as event, Ready, Event, Evented, PollOpt};
+use event_imp::{Ready, Event, Evented, PollOpt};
 use std::{fmt, io, ptr, usize};
 use std::cell::UnsafeCell;
 use std::{mem, ops, isize};
@@ -2380,7 +2380,7 @@ impl ReadinessState {
     // Create a `ReadinessState` initialized with the provided arguments
     #[inline]
     fn new(interest: Ready, opt: PollOpt) -> ReadinessState {
-        let interest = event::ready_as_usize(interest);
+        let interest = interest.bits();
         let opt = opt.bits();
 
         debug_assert!(interest <= MASK_4);
@@ -2406,7 +2406,7 @@ impl ReadinessState {
     #[inline]
     fn readiness(&self) -> Ready {
         let v = self.get(MASK_4, READINESS_SHIFT);
-        event::ready_from_usize(v)
+        Ready::new(v)
     }
 
     #[inline]
@@ -2417,20 +2417,20 @@ impl ReadinessState {
     /// Set the readiness
     #[inline]
     fn set_readiness(&mut self, v: Ready) {
-        self.set(event::ready_as_usize(v), MASK_4, READINESS_SHIFT);
+        self.set(v.bits(), MASK_4, READINESS_SHIFT);
     }
 
     /// Get the interest
     #[inline]
     fn interest(&self) -> Ready {
         let v = self.get(MASK_4, INTEREST_SHIFT);
-        event::ready_from_usize(v)
+        Ready::new(v)
     }
 
     /// Set the interest
     #[inline]
     fn set_interest(&mut self, v: Ready) {
-        self.set(event::ready_as_usize(v), MASK_4, INTEREST_SHIFT);
+        self.set(v.bits(), MASK_4, INTEREST_SHIFT);
     }
 
     #[inline]

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -2381,7 +2381,7 @@ impl ReadinessState {
     #[inline]
     fn new(interest: Ready, opt: PollOpt) -> ReadinessState {
         let interest = event::ready_as_usize(interest);
-        let opt = event::opt_as_usize(opt);
+        let opt = opt.bits();
 
         debug_assert!(interest <= MASK_4);
         debug_assert!(opt <= MASK_4);
@@ -2442,13 +2442,13 @@ impl ReadinessState {
     #[inline]
     fn poll_opt(&self) -> PollOpt {
         let v = self.get(MASK_4, POLL_OPT_SHIFT);
-        event::opt_from_usize(v)
+        PollOpt::from_bits_truncate(v)
     }
 
     /// Set the poll options
     #[inline]
     fn set_poll_opt(&mut self, v: PollOpt) {
-        self.set(event::opt_as_usize(v), MASK_4, POLL_OPT_SHIFT);
+        self.set(v.bits(), MASK_4, POLL_OPT_SHIFT);
     }
 
     #[inline]

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -107,7 +107,7 @@ use std::time::{Duration, Instant};
 ///
 /// // Register the stream with `Poll`
 /// poll.register()
-///     .register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE)?;
+///     .register(&stream, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE)?;
 ///
 /// // Wait for the socket to become ready. This has to happens in a loop to
 /// // handle spurious wakeups.
@@ -280,7 +280,7 @@ use std::time::{Duration, Instant};
 /// // The connect is not guaranteed to have started until it is registered at
 /// // this point
 /// poll.register()
-///     .register(&sock, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE)?;
+///     .register(&sock, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE)?;
 /// #     Ok(())
 /// # }
 /// #
@@ -397,7 +397,7 @@ struct Inner {
 ///                 thread::sleep(when - now);
 ///             }
 ///
-///             set_readiness.set_readiness(Ready::readable());
+///             set_readiness.set_readiness(Ready::READABLE);
 ///         });
 ///
 ///         Deadline {
@@ -667,7 +667,7 @@ impl Poll {
             .awakener.register(
                 poll.register(),
                 AWAKEN,
-                Ready::readable(),
+                Ready::READABLE,
                 PollOpt::EDGE)?;
 
         Ok(poll)
@@ -742,7 +742,7 @@ impl Poll {
     ///
     /// // Register the stream with `Poll`
     /// poll.register()
-    ///     .register(&stream, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE)?;
+    ///     .register(&stream, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE)?;
     ///
     /// // Wait for the socket to become ready. This has to happens in a loop to
     /// // handle spurious wakeups.
@@ -902,7 +902,7 @@ impl Register {
     ///
     /// // Register the socket with `poll`
     /// poll.register()
-    ///     .register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE)?;
+    ///     .register(&socket, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE)?;
     ///
     /// let mut events = Events::with_capacity(1024);
     /// let start = Instant::now();
@@ -987,13 +987,13 @@ impl Register {
     ///
     /// // Register the socket with `poll`, requesting readable
     /// poll.register()
-    ///     .register(&socket, Token(0), Ready::readable(), PollOpt::EDGE)?;
+    ///     .register(&socket, Token(0), Ready::READABLE, PollOpt::EDGE)?;
     ///
     /// // Reregister the socket specifying a different token and write interest
     /// // instead. `PollOpt::EDGE` must be specified even though that value
     /// // is not being changed.
     /// poll.register()
-    ///     .reregister(&socket, Token(2), Ready::writable(), PollOpt::EDGE)?;
+    ///     .reregister(&socket, Token(2), Ready::WRITABLE, PollOpt::EDGE)?;
     /// #     Ok(())
     /// # }
     /// #
@@ -1047,7 +1047,7 @@ impl Register {
     ///
     /// // Register the socket with `poll`
     /// poll.register()
-    ///     .register(&socket, Token(0), Ready::readable(), PollOpt::EDGE)?;
+    ///     .register(&socket, Token(0), Ready::READABLE, PollOpt::EDGE)?;
     ///
     /// poll.register().deregister(&socket)?;
     ///
@@ -1418,12 +1418,12 @@ impl Registration {
     ///     use std::time::Duration;
     ///     thread::sleep(Duration::from_millis(500));
     ///
-    ///     set_readiness.set_readiness(Ready::readable());
+    ///     set_readiness.set_readiness(Ready::READABLE);
     /// });
     ///
     /// let mut poll = Poll::new()?;
     /// poll.register()
-    ///     .register(&registration, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE)?;
+    ///     .register(&registration, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE)?;
     ///
     /// let mut events = Events::with_capacity(256);
     ///
@@ -1555,7 +1555,7 @@ impl SetReadiness {
     ///
     /// assert!(set_readiness.readiness().is_empty());
     ///
-    /// set_readiness.set_readiness(Ready::readable())?;
+    /// set_readiness.set_readiness(Ready::READABLE)?;
     /// assert!(set_readiness.readiness().is_readable());
     /// #     Ok(())
     /// # }
@@ -1597,12 +1597,12 @@ impl SetReadiness {
     /// poll.register()
     ///     .register(&registration,
     ///               Token(0),
-    ///               Ready::readable(),
+    ///               Ready::READABLE,
     ///               PollOpt::EDGE)?;
     ///
     /// // Set the readiness, then immediately poll to try to get the readiness
     /// // event
-    /// set_readiness.set_readiness(Ready::readable())?;
+    /// set_readiness.set_readiness(Ready::READABLE)?;
     ///
     /// let mut events = Events::with_capacity(1024);
     /// poll.poll(&mut events, None)?;
@@ -1634,7 +1634,7 @@ impl SetReadiness {
     ///
     /// assert!(set_readiness.readiness().is_empty());
     ///
-    /// set_readiness.set_readiness(Ready::readable())?;
+    /// set_readiness.set_readiness(Ready::READABLE)?;
     /// assert!(set_readiness.readiness().is_readable());
     /// #     Ok(())
     /// # }

--- a/src/sys/fuchsia/eventedfd.rs
+++ b/src/sys/fuchsia/eventedfd.rs
@@ -145,7 +145,7 @@ impl EventedFd {
         let needs_rereg = opts.is_level() && !opts.is_oneshot();
 
         // If we need to reregister, then each registration should be `oneshot`
-        let opts = opts | if needs_rereg { PollOpt::oneshot() } else { PollOpt::empty() };
+        let opts = opts | if needs_rereg { PollOpt::ONESHOT } else { PollOpt::empty() };
 
         let rereg_signals = if needs_rereg {
             Some((signals, poll_opts_to_wait_async(opts)))

--- a/src/sys/fuchsia/mod.rs
+++ b/src/sys/fuchsia/mod.rs
@@ -87,11 +87,11 @@ fn epoll_event_to_ready(epoll: u32) -> Ready {
     let mut kind = Ready::empty();
 
     if (epoll & libc::EPOLLIN) != 0 || (epoll & libc::EPOLLPRI) != 0 {
-        kind = kind | Ready::readable();
+        kind = kind | Ready::READABLE;
     }
 
     if (epoll & libc::EPOLLOUT) != 0 {
-        kind = kind | Ready::writable();
+        kind = kind | Ready::WRITABLE;
     }
 
     kind
@@ -99,11 +99,11 @@ fn epoll_event_to_ready(epoll: u32) -> Ready {
     /* TODO: support?
     // EPOLLHUP - Usually means a socket error happened
     if (epoll & libc::EPOLLERR) != 0 {
-        kind = kind | UnixReady::error();
+        kind = kind | UnixReady::ERROR;
     }
 
     if (epoll & libc::EPOLLRDHUP) != 0 || (epoll & libc::EPOLLHUP) != 0 {
-        kind = kind | UnixReady::hup();
+        kind = kind | UnixReady::HUP;
     }
     */
 }

--- a/src/sys/fuchsia/mod.rs
+++ b/src/sys/fuchsia/mod.rs
@@ -99,11 +99,11 @@ fn epoll_event_to_ready(epoll: u32) -> Ready {
     /* TODO: support?
     // EPOLLHUP - Usually means a socket error happened
     if (epoll & libc::EPOLLERR) != 0 {
-        kind = kind | UnixReady::ERROR;
+        kind = kind | *UnixReady::ERROR;
     }
 
     if (epoll & libc::EPOLLRDHUP) != 0 || (epoll & libc::EPOLLHUP) != 0 {
-        kind = kind | UnixReady::HUP;
+        kind = kind | *UnixReady::HUP;
     }
     */
 }

--- a/src/sys/fuchsia/ready.rs
+++ b/src/sys/fuchsia/ready.rs
@@ -14,12 +14,12 @@ use std::ops;
 #[inline]
 pub fn assert_fuchsia_ready_repr() {
     debug_assert!(
-        ZX_OBJECT_READABLE.bits() as usize == ready_as_usize(Ready::readable()),
-        "Zircon ZX_OBJECT_READABLE should have the same repr as Ready::readable()"
+        ZX_OBJECT_READABLE.bits() as usize == ready_as_usize(Ready::READABLE),
+        "Zircon ZX_OBJECT_READABLE should have the same repr as Ready::READABLE"
     );
     debug_assert!(
-        ZX_OBJECT_WRITABLE.bits() as usize == ready_as_usize(Ready::writable()),
-        "Zircon ZX_OBJECT_WRITABLE should have the same repr as Ready::writable()"
+        ZX_OBJECT_WRITABLE.bits() as usize == ready_as_usize(Ready::WRITABLE),
+        "Zircon ZX_OBJECT_WRITABLE should have the same repr as Ready::WRITABLE"
     );
 }
 

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -206,20 +206,20 @@ impl Events {
             let mut kind = Ready::empty();
 
             if (epoll & EPOLLIN) != 0 || (epoll & EPOLLPRI) != 0 {
-                kind = kind | Ready::readable();
+                kind = kind | Ready::READABLE;
             }
 
             if (epoll & EPOLLOUT) != 0 {
-                kind = kind | Ready::writable();
+                kind = kind | Ready::WRITABLE;
             }
 
             // EPOLLHUP - Usually means a socket error happened
             if (epoll & EPOLLERR) != 0 {
-                kind = kind | UnixReady::error();
+                kind = kind | UnixReady::ERROR;
             }
 
             if (epoll & EPOLLRDHUP) != 0 || (epoll & EPOLLHUP) != 0 {
-                kind = kind | UnixReady::hup();
+                kind = kind | UnixReady::HUP;
             }
 
             let token = self.events[idx].u64;

--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -215,11 +215,11 @@ impl Events {
 
             // EPOLLHUP - Usually means a socket error happened
             if (epoll & EPOLLERR) != 0 {
-                kind = kind | UnixReady::ERROR;
+                kind = kind | *UnixReady::ERROR;
             }
 
             if (epoll & EPOLLRDHUP) != 0 || (epoll & EPOLLHUP) != 0 {
-                kind = kind | UnixReady::HUP;
+                kind = kind | *UnixReady::HUP;
             }
 
             let token = self.events[idx].u64;

--- a/src/sys/unix/eventedfd.rs
+++ b/src/sys/unix/eventedfd.rs
@@ -46,7 +46,7 @@ use std::os::unix::io::RawFd;
 /// poll.register()
 ///     .register(
 ///         &EventedFd(&listener.as_raw_fd()),
-///         Token(0), Ready::readable(), PollOpt::edge())?;
+///         Token(0), Ready::readable(), PollOpt::EDGE)?;
 /// #     Ok(())
 /// # }
 /// #

--- a/src/sys/unix/eventedfd.rs
+++ b/src/sys/unix/eventedfd.rs
@@ -46,7 +46,7 @@ use std::os::unix::io::RawFd;
 /// poll.register()
 ///     .register(
 ///         &EventedFd(&listener.as_raw_fd()),
-///         Token(0), Ready::readable(), PollOpt::EDGE)?;
+///         Token(0), Ready::READABLE, PollOpt::EDGE)?;
 /// #     Ok(())
 /// # }
 /// #

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -95,8 +95,8 @@ impl Selector {
     pub fn register(&self, fd: RawFd, token: Token, interests: Ready, opts: PollOpt) -> io::Result<()> {
         trace!("registering; token={:?}; interests={:?}", token, interests);
 
-        let flags = if opts.contains(PollOpt::edge()) { libc::EV_CLEAR } else { 0 } |
-                    if opts.contains(PollOpt::oneshot()) { libc::EV_ONESHOT } else { 0 } |
+        let flags = if opts.contains(PollOpt::EDGE) { libc::EV_CLEAR } else { 0 } |
+                    if opts.contains(PollOpt::ONESHOT) { libc::EV_ONESHOT } else { 0 } |
                     libc::EV_RECEIPT;
 
         unsafe {
@@ -353,7 +353,7 @@ fn does_not_register_rw() {
     poll.register()
         .register(
             &kqf, Token(1234), Ready::readable(),
-            PollOpt::edge() | PollOpt::oneshot()).unwrap();
+            PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
 }
 
 #[cfg(any(target_os = "dragonfly",

--- a/src/sys/unix/kqueue.rs
+++ b/src/sys/unix/kqueue.rs
@@ -296,23 +296,23 @@ impl Events {
     target_os = "freebsd", target_os = "ios", target_os = "macos"))]
             {
                 if e.filter == libc::EVFILT_AIO {
-                    event::kind_mut(&mut self.events[idx]).insert(UnixReady::AIO);
+                    event::kind_mut(&mut self.events[idx]).insert(*UnixReady::AIO);
                 }
             }
 #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
             {
                 if e.filter == libc::EVFILT_LIO {
-                    event::kind_mut(&mut self.events[idx]).insert(UnixReady::LIO);
+                    event::kind_mut(&mut self.events[idx]).insert(*UnixReady::LIO);
                 }
             }
 
             if e.flags & libc::EV_EOF != 0 {
-                event::kind_mut(&mut self.events[idx]).insert(UnixReady::HUP);
+                event::kind_mut(&mut self.events[idx]).insert(*UnixReady::HUP);
 
                 // When the read end of the socket is closed, EV_EOF is set on
                 // flags, and fflags contains the error if there is one.
                 if e.fflags != 0 {
-                    event::kind_mut(&mut self.events[idx]).insert(UnixReady::ERROR);
+                    event::kind_mut(&mut self.events[idx]).insert(*UnixReady::ERROR);
                 }
             }
         }

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -29,7 +29,7 @@ bitflags! {
     /// use mio::Ready;
     /// use mio::unix::UnixReady;
     ///
-    /// let ready = Ready::readable() | UnixReady::hup();
+    /// let ready = Ready::READABLE | UnixReady::HUP;
     ///
     /// assert!(ready.is_readable());
     /// assert!(UnixReady::from(ready).is_hup());
@@ -42,12 +42,12 @@ bitflags! {
     /// use mio::unix::UnixReady;
     ///
     /// // Start with a portable ready
-    /// let ready = Ready::readable();
+    /// let ready = Ready::READABLE;
     ///
     /// // Convert to a unix ready, adding HUP
-    /// let mut unix_ready = UnixReady::from(ready) | UnixReady::hup();
+    /// let mut unix_ready = UnixReady::from(ready) | UnixReady::HUP;
     ///
-    /// unix_ready.insert(UnixReady::error());
+    /// unix_ready.insert(UnixReady::ERROR);
     ///
     /// // `unix_ready` maintains readable interest
     /// assert!(unix_ready.is_readable());
@@ -78,7 +78,7 @@ bitflags! {
     /// poll.register()
     ///     .register(&socket,
     ///               Token(0),
-    ///               Ready::readable() | UnixReady::error(),
+    ///               Ready::READABLE | UnixReady::ERROR,
     ///               PollOpt::EDGE)?;
     /// #     Ok(())
     /// # }
@@ -105,7 +105,7 @@ bitflags! {
         /// ```
         /// use mio::unix::UnixReady;
         ///
-        /// let ready = UnixReady::error();
+        /// let ready = UnixReady::ERROR;
         ///
         /// assert!(ready.is_error());
         /// ```
@@ -130,7 +130,7 @@ bitflags! {
         /// ```
         /// use mio::unix::UnixReady;
         ///
-        /// let ready = UnixReady::hup();
+        /// let ready = UnixReady::HUP;
         ///
         /// assert!(ready.is_hup());
         /// ```
@@ -149,7 +149,7 @@ bitflags! {
         /// ```
         /// use mio::unix::UnixReady;
         ///
-        /// let ready = UnixReady::aio();
+        /// let ready = UnixReady::AIO;
         ///
         /// assert!(ready.is_aio());
         /// ```
@@ -165,7 +165,7 @@ bitflags! {
         /// ```
         /// use mio::unix::UnixReady;
         ///
-        /// let ready = UnixReady::lio();
+        /// let ready = UnixReady::LIO;
         ///
         /// assert!(ready.is_lio());
         /// ```
@@ -229,7 +229,7 @@ impl UnixReady {
     /// ```
     /// use mio::unix::UnixReady;
     ///
-    /// let ready = UnixReady::aio();
+    /// let ready = UnixReady::AIO;
     ///
     /// assert!(ready.is_aio());
     /// ```
@@ -265,7 +265,7 @@ impl UnixReady {
     /// ```
     /// use mio::unix::UnixReady;
     ///
-    /// let ready = UnixReady::error();
+    /// let ready = UnixReady::ERROR;
     ///
     /// assert!(ready.is_error());
     /// ```
@@ -294,7 +294,7 @@ impl UnixReady {
     /// ```
     /// use mio::unix::UnixReady;
     ///
-    /// let ready = UnixReady::hup();
+    /// let ready = UnixReady::HUP;
     ///
     /// assert!(ready.is_hup());
     /// ```
@@ -315,7 +315,7 @@ impl UnixReady {
     /// ```
     /// use mio::unix::UnixReady;
     ///
-    /// let ready = UnixReady::lio();
+    /// let ready = UnixReady::LIO;
     ///
     /// assert!(ready.is_lio());
     /// ```

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -79,7 +79,7 @@ use std::fmt;
 ///     .register(&socket,
 ///               Token(0),
 ///               Ready::readable() | UnixReady::error(),
-///               PollOpt::edge())?;
+///               PollOpt::EDGE)?;
 /// #     Ok(())
 /// # }
 /// #

--- a/src/sys/unix/ready.rs
+++ b/src/sys/unix/ready.rs
@@ -29,7 +29,7 @@ bitflags! {
     /// use mio::Ready;
     /// use mio::unix::UnixReady;
     ///
-    /// let ready = Ready::READABLE | UnixReady::HUP;
+    /// let ready = Ready::READABLE | *UnixReady::HUP;
     ///
     /// assert!(ready.is_readable());
     /// assert!(UnixReady::from(ready).is_hup());
@@ -78,7 +78,7 @@ bitflags! {
     /// poll.register()
     ///     .register(&socket,
     ///               Token(0),
-    ///               Ready::READABLE | UnixReady::ERROR,
+    ///               Ready::READABLE | *UnixReady::ERROR,
     ///               PollOpt::EDGE)?;
     /// #     Ok(())
     /// # }

--- a/src/sys/windows/awakener.rs
+++ b/src/sys/windows/awakener.rs
@@ -45,7 +45,7 @@ impl Awakener {
 impl Evented for Awakener {
     fn register(&self, register: &Register, token: Token, events: Ready,
                 opts: PollOpt) -> io::Result<()> {
-        assert_eq!(opts, PollOpt::edge());
+        assert_eq!(opts, PollOpt::EDGE);
         assert_eq!(events, Ready::readable());
         *self.inner.lock().unwrap() = Some(AwakenerInner {
             selector: poll::selector(register).clone_ref(),

--- a/src/sys/windows/awakener.rs
+++ b/src/sys/windows/awakener.rs
@@ -46,7 +46,7 @@ impl Evented for Awakener {
     fn register(&self, register: &Register, token: Token, events: Ready,
                 opts: PollOpt) -> io::Result<()> {
         assert_eq!(opts, PollOpt::EDGE);
-        assert_eq!(events, Ready::readable());
+        assert_eq!(events, Ready::READABLE);
         *self.inner.lock().unwrap() = Some(AwakenerInner {
             selector: poll::selector(register).clone_ref(),
             token: token,

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -117,7 +117,7 @@
 //!
 //! First up, let's take a look at unimplemented portions of this module:
 //!
-//! * The `PollOpt::level()` option is currently entirely unimplemented.
+//! * The `PollOpt::LEVEL` option is currently entirely unimplemented.
 //! * Each `EventLoop` currently owns its completion port, but this prevents an
 //!   I/O handle from being added to multiple event loops (something that can be
 //!   done on Unix). Additionally, it hinders event loops moving across threads.

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -103,7 +103,7 @@ impl UdpSocket {
         }
 
         let interest = me.iocp.readiness();
-        me.iocp.set_readiness(interest - Ready::writable());
+        me.iocp.set_readiness(interest - Ready::WRITABLE);
 
         let mut owned_buf = me.iocp.get_buffer(64 * 1024);
         let amt = owned_buf.write(buf)?;
@@ -137,7 +137,7 @@ impl UdpSocket {
         }
 
         let interest = me.iocp.readiness();
-        me.iocp.set_readiness(interest - Ready::writable());
+        me.iocp.set_readiness(interest - Ready::WRITABLE);
 
         let mut owned_buf = me.iocp.get_buffer(64 * 1024);
         let amt = owned_buf.write(buf)?;
@@ -282,7 +282,7 @@ impl UdpSocket {
         // See comments in TcpSocket::post_register for what's going on here
         if interest.is_writable() {
             if let State::Empty = me.write {
-                self.imp.add_readiness(me, Ready::writable());
+                self.imp.add_readiness(me, Ready::WRITABLE);
             }
         }
     }
@@ -300,7 +300,7 @@ impl Imp {
         }
 
         let interest = me.iocp.readiness();
-        me.iocp.set_readiness(interest - Ready::readable());
+        me.iocp.set_readiness(interest - Ready::READABLE);
 
         let mut buf = me.iocp.get_buffer(64 * 1024);
         let res = unsafe {
@@ -317,7 +317,7 @@ impl Imp {
             }
             Err(e) => {
                 me.read = State::Error(e);
-                self.add_readiness(me, Ready::readable());
+                self.add_readiness(me, Ready::READABLE);
                 me.iocp.put_buffer(buf);
             }
         }
@@ -392,7 +392,7 @@ fn send_done(status: &OVERLAPPED_ENTRY) {
     };
     let mut me = me2.inner();
     me.write = State::Empty;
-    me2.add_readiness(&mut me, Ready::writable());
+    me2.add_readiness(&mut me, Ready::WRITABLE);
 }
 
 fn recv_done(status: &OVERLAPPED_ENTRY) {
@@ -410,5 +410,5 @@ fn recv_done(status: &OVERLAPPED_ENTRY) {
         buf.set_len(status.bytes_transferred() as usize);
     }
     me.read = State::Ready(buf);
-    me2.add_readiness(&mut me, Ready::readable());
+    me2.add_readiness(&mut me, Ready::READABLE);
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -43,7 +43,7 @@
 /// poll.register()
 ///     .register(&listener,
 ///               LISTENER,
-///               Ready::readable(),
+///               Ready::READABLE,
 ///               PollOpt::EDGE)?;
 ///
 /// // Spawn a thread that will connect a bunch of sockets then close them
@@ -90,7 +90,7 @@
 ///                             poll.register()
 ///                                 .register(&socket,
 ///                                          token,
-///                                          Ready::readable(),
+///                                          Ready::READABLE,
 ///                                          PollOpt::EDGE)?;
 ///
 ///                             // Store the socket

--- a/src/token.rs
+++ b/src/token.rs
@@ -44,7 +44,7 @@
 ///     .register(&listener,
 ///               LISTENER,
 ///               Ready::readable(),
-///               PollOpt::edge())?;
+///               PollOpt::EDGE)?;
 ///
 /// // Spawn a thread that will connect a bunch of sockets then close them
 /// let addr = listener.local_addr()?;
@@ -91,7 +91,7 @@
 ///                                 .register(&socket,
 ///                                          token,
 ///                                          Ready::readable(),
-///                                          PollOpt::edge())?;
+///                                          PollOpt::EDGE)?;
 ///
 ///                             // Store the socket
 ///                             sockets.insert(token, socket);

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -60,7 +60,7 @@ impl TestHandler {
             }
             _ => panic!("received unknown token {:?}", tok)
         }
-        poll.register().reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge()).unwrap();
+        poll.register().reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::EDGE).unwrap();
     }
 
     fn handle_write(&mut self, poll: &mut Poll, tok: Token, _: Ready) {
@@ -68,7 +68,7 @@ impl TestHandler {
             SERVER => panic!("received writable for token 0"),
             CLIENT => {
                 debug!("client connected");
-                poll.register().reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::edge()).unwrap();
+                poll.register().reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::EDGE).unwrap();
             }
             _ => panic!("received unknown token {:?}", tok)
         }
@@ -86,12 +86,12 @@ pub fn test_close_on_drop() {
     // == Create & setup server socket
     let srv = TcpListener::bind(&addr).unwrap();
 
-    poll.register().register(&srv, SERVER, Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&srv, SERVER, Ready::readable(), PollOpt::EDGE).unwrap();
 
     // == Create & setup client socket
     let sock = TcpStream::connect(&addr).unwrap();
 
-    poll.register().register(&sock, CLIENT, Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&sock, CLIENT, Ready::writable(), PollOpt::EDGE).unwrap();
 
     // == Create storage for events
     let mut events = Events::with_capacity(1024);

--- a/test/test_close_on_drop.rs
+++ b/test/test_close_on_drop.rs
@@ -60,7 +60,7 @@ impl TestHandler {
             }
             _ => panic!("received unknown token {:?}", tok)
         }
-        poll.register().reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::EDGE).unwrap();
+        poll.register().reregister(&self.cli, CLIENT, Ready::READABLE, PollOpt::EDGE).unwrap();
     }
 
     fn handle_write(&mut self, poll: &mut Poll, tok: Token, _: Ready) {
@@ -68,7 +68,7 @@ impl TestHandler {
             SERVER => panic!("received writable for token 0"),
             CLIENT => {
                 debug!("client connected");
-                poll.register().reregister(&self.cli, CLIENT, Ready::readable(), PollOpt::EDGE).unwrap();
+                poll.register().reregister(&self.cli, CLIENT, Ready::READABLE, PollOpt::EDGE).unwrap();
             }
             _ => panic!("received unknown token {:?}", tok)
         }
@@ -86,12 +86,12 @@ pub fn test_close_on_drop() {
     // == Create & setup server socket
     let srv = TcpListener::bind(&addr).unwrap();
 
-    poll.register().register(&srv, SERVER, Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&srv, SERVER, Ready::READABLE, PollOpt::EDGE).unwrap();
 
     // == Create & setup client socket
     let sock = TcpStream::connect(&addr).unwrap();
 
-    poll.register().register(&sock, CLIENT, Ready::writable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&sock, CLIENT, Ready::WRITABLE, PollOpt::EDGE).unwrap();
 
     // == Create storage for events
     let mut events = Events::with_capacity(1024);

--- a/test/test_custom_evented.rs
+++ b/test/test_custom_evented.rs
@@ -8,7 +8,7 @@ fn smoke() {
     let mut events = Events::with_capacity(128);
 
     let (r, set) = Registration::new();
-    r.register(poll.register(), Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+    r.register(poll.register(), Token(0), Ready::readable(), PollOpt::EDGE).unwrap();
 
     poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
     assert!(events.iter().next().is_none());
@@ -47,7 +47,7 @@ fn set_readiness_before_register() {
 
         // now register
         poll.register()
-            .register(&r, Token(123), Ready::readable(), PollOpt::edge()).unwrap();
+            .register(&r, Token(123), Ready::readable(), PollOpt::EDGE).unwrap();
 
         loop {
             poll.poll(&mut events, None).unwrap();
@@ -90,7 +90,7 @@ mod stress {
 
             let registrations: Vec<_> = (0..NUM_REGISTRATIONS).map(|i| {
                 let (r, s) = Registration::new();
-                r.register(poll.register(), Token(i), Ready::readable(), PollOpt::edge()).unwrap();
+                r.register(poll.register(), Token(i), Ready::readable(), PollOpt::EDGE).unwrap();
                 (r, s)
             }).collect();
 
@@ -126,7 +126,7 @@ mod stress {
             while remaining.load(Acquire) > 0 {
                 // Set interest
                 for (i, &(ref r, _)) in registrations.iter().enumerate() {
-                    r.reregister(poll.register(), Token(i), Ready::writable(), PollOpt::edge()).unwrap();
+                    r.reregister(poll.register(), Token(i), Ready::writable(), PollOpt::EDGE).unwrap();
                 }
 
                 poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
@@ -138,7 +138,7 @@ mod stress {
                 // Update registration
                 // Set interest
                 for (i, &(ref r, _)) in registrations.iter().enumerate() {
-                    r.reregister(poll.register(), Token(i), Ready::readable(), PollOpt::edge()).unwrap();
+                    r.reregister(poll.register(), Token(i), Ready::readable(), PollOpt::EDGE).unwrap();
                 }
             }
 
@@ -180,7 +180,7 @@ mod stress {
 
         for i in 0..N {
             let (registration, set_readiness) = Registration::new();
-            poll.register().register(&registration, Token(i), Ready::readable(), PollOpt::edge()).unwrap();
+            poll.register().register(&registration, Token(i), Ready::readable(), PollOpt::EDGE).unwrap();
 
             registrations.push(registration);
 
@@ -260,7 +260,7 @@ fn drop_registration_from_non_main_thread() {
     let mut index: usize = 0;
     for _ in 0..ITERS {
         let (registration, set_readiness) = Registration::new();
-        registration.register(poll.register(), Token(token_index), Ready::readable(), PollOpt::edge()).unwrap();
+        registration.register(poll.register(), Token(token_index), Ready::readable(), PollOpt::EDGE).unwrap();
         let _ = senders[index].send((registration, set_readiness));
 
         token_index += 1;
@@ -269,7 +269,7 @@ fn drop_registration_from_non_main_thread() {
             index = 0;
 
             let (registration, set_readiness) = Registration::new();
-            registration.register(poll.register(), Token(token_index), Ready::readable(), PollOpt::edge()).unwrap();
+            registration.register(poll.register(), Token(token_index), Ready::readable(), PollOpt::EDGE).unwrap();
             let _ = set_readiness.set_readiness(Ready::readable());
             drop(registration);
             drop(set_readiness);

--- a/test/test_double_register.rs
+++ b/test/test_double_register.rs
@@ -12,6 +12,6 @@ pub fn test_double_register() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::EDGE).unwrap();
-    assert!(poll.register().register(&l, Token(1), Ready::readable(), PollOpt::EDGE).is_err());
+    poll.register().register(&l, Token(0), Ready::READABLE, PollOpt::EDGE).unwrap();
+    assert!(poll.register().register(&l, Token(1), Ready::READABLE, PollOpt::EDGE).is_err());
 }

--- a/test/test_double_register.rs
+++ b/test/test_double_register.rs
@@ -12,6 +12,6 @@ pub fn test_double_register() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
-    assert!(poll.register().register(&l, Token(1), Ready::readable(), PollOpt::edge()).is_err());
+    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::EDGE).unwrap();
+    assert!(poll.register().register(&l, Token(1), Ready::readable(), PollOpt::EDGE).is_err());
 }

--- a/test/test_echo_server.rs
+++ b/test/test_echo_server.rs
@@ -48,7 +48,7 @@ impl EchoConn {
         poll.register()
             .reregister(
                 &self.sock, self.token.unwrap(), self.interest,
-                PollOpt::edge() | PollOpt::oneshot())
+                PollOpt::EDGE | PollOpt::ONESHOT)
     }
 
     fn readable(&mut self, poll: &mut Poll) -> io::Result<()> {
@@ -74,7 +74,7 @@ impl EchoConn {
         poll.register()
             .reregister(
                 &self.sock, self.token.unwrap(), self.interest,
-                PollOpt::edge())
+                PollOpt::EDGE)
     }
 }
 
@@ -97,7 +97,7 @@ impl EchoServer {
         poll.register()
             .register(
                 &self.conns[tok].sock, tok, Ready::readable(),
-                PollOpt::edge() | PollOpt::oneshot())
+                PollOpt::EDGE | PollOpt::ONESHOT)
             .ok().expect("could not register socket with event loop");
 
         Ok(())
@@ -189,7 +189,7 @@ impl EchoClient {
             poll.register()
                 .reregister(
                     &self.sock, self.token, self.interest,
-                    PollOpt::edge() | PollOpt::oneshot())?;
+                    PollOpt::EDGE | PollOpt::ONESHOT)?;
         }
 
         Ok(())
@@ -216,7 +216,7 @@ impl EchoClient {
             try!(poll.register()
                  .reregister(
                      &self.sock, self.token, self.interest,
-                     PollOpt::edge() | PollOpt::oneshot()));
+                     PollOpt::EDGE | PollOpt::ONESHOT));
         }
 
         Ok(())
@@ -238,7 +238,7 @@ impl EchoClient {
         poll.register()
             .reregister(
                 &self.sock, self.token, self.interest,
-                PollOpt::edge() | PollOpt::oneshot())
+                PollOpt::EDGE | PollOpt::ONESHOT)
     }
 }
 
@@ -271,7 +271,7 @@ pub fn test_echo_server() {
     poll.register()
         .register(
             &srv, SERVER, Ready::readable(),
-            PollOpt::edge() | PollOpt::oneshot()).unwrap();
+            PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
 
     let sock = TcpStream::connect(&addr).unwrap();
 
@@ -279,7 +279,7 @@ pub fn test_echo_server() {
     poll.register()
         .register(
             &sock, CLIENT, Ready::writable(),
-            PollOpt::edge() | PollOpt::oneshot()).unwrap();
+            PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
 
     // == Create storage for events
     let mut events = Events::with_capacity(1024);

--- a/test/test_fuchsia_handles.rs
+++ b/test/test_fuchsia_handles.rs
@@ -14,7 +14,7 @@ pub fn test_fuchsia_channel() {
     let (channel0, channel1) = zircon::Channel::create(zircon::ChannelOpts::Normal).unwrap();
     let channel1_evented = unsafe { EventedHandle::new(channel1.raw_handle()) };
 
-    poll.register(&channel1_evented, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register(&channel1_evented, Token(1), Ready::READABLE, PollOpt::EDGE).unwrap();
 
     poll.poll(event_buffer, Some(Duration::from_millis(MS))).unwrap();
     assert_eq!(event_buffer.len(), 0);

--- a/test/test_fuchsia_handles.rs
+++ b/test/test_fuchsia_handles.rs
@@ -14,7 +14,7 @@ pub fn test_fuchsia_channel() {
     let (channel0, channel1) = zircon::Channel::create(zircon::ChannelOpts::Normal).unwrap();
     let channel1_evented = unsafe { EventedHandle::new(channel1.raw_handle()) };
 
-    poll.register(&channel1_evented, Token(1), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register(&channel1_evented, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
 
     poll.poll(event_buffer, Some(Duration::from_millis(MS))).unwrap();
     assert_eq!(event_buffer.len(), 0);

--- a/test/test_local_addr_ready.rs
+++ b/test/test_local_addr_ready.rs
@@ -23,13 +23,13 @@ fn local_addr_ready() {
     poll.register()
         .register(
             &server, LISTEN, Ready::readable(),
-            PollOpt::edge()).unwrap();
+            PollOpt::EDGE).unwrap();
 
     let sock = TcpStream::connect(&addr).unwrap();
     poll.register()
         .register(
             &sock, CLIENT, Ready::readable(),
-            PollOpt::edge()).unwrap();
+            PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
 
@@ -51,7 +51,7 @@ fn local_addr_ready() {
                         .register(&sock,
                                   SERVER,
                                   Ready::writable(),
-                                  PollOpt::edge()).unwrap();
+                                  PollOpt::EDGE).unwrap();
                     handler.accepted = Some(sock);
                 }
                 SERVER => {

--- a/test/test_local_addr_ready.rs
+++ b/test/test_local_addr_ready.rs
@@ -22,13 +22,13 @@ fn local_addr_ready() {
     let mut poll = Poll::new().unwrap();
     poll.register()
         .register(
-            &server, LISTEN, Ready::readable(),
+            &server, LISTEN, Ready::READABLE,
             PollOpt::EDGE).unwrap();
 
     let sock = TcpStream::connect(&addr).unwrap();
     poll.register()
         .register(
-            &sock, CLIENT, Ready::readable(),
+            &sock, CLIENT, Ready::READABLE,
             PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -50,7 +50,7 @@ fn local_addr_ready() {
                     poll.register()
                         .register(&sock,
                                   SERVER,
-                                  Ready::writable(),
+                                  Ready::WRITABLE,
                                   PollOpt::EDGE).unwrap();
                     handler.accepted = Some(sock);
                 }

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -86,10 +86,10 @@ pub fn test_multicast() {
     rx.join_multicast_v4(&"227.1.1.101".parse().unwrap(), &any).unwrap();
 
     info!("Registering SENDER");
-    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::EDGE).unwrap();
 
     info!("Registering LISTENER");
-    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
 

--- a/test/test_multicast.rs
+++ b/test/test_multicast.rs
@@ -86,10 +86,10 @@ pub fn test_multicast() {
     rx.join_multicast_v4(&"227.1.1.101".parse().unwrap(), &any).unwrap();
 
     info!("Registering SENDER");
-    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&tx, SENDER, Ready::WRITABLE, PollOpt::EDGE).unwrap();
 
     info!("Registering LISTENER");
-    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&rx, LISTENER, Ready::READABLE, PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
 

--- a/test/test_oneshot.rs
+++ b/test/test_oneshot.rs
@@ -16,17 +16,17 @@ pub fn test_tcp_edge_oneshot() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::LEVEL).unwrap();
+    poll.register().register(&l, Token(0), Ready::READABLE, PollOpt::LEVEL).unwrap();
 
     // Connect a socket, we are going to write to it
     let mut s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register().register(&s1, Token(1), Ready::writable(), PollOpt::LEVEL).unwrap();
+    poll.register().register(&s1, Token(1), Ready::WRITABLE, PollOpt::LEVEL).unwrap();
 
     wait_for(&mut poll, &mut events, Token(0));
 
     // Get pair
     let (mut s2, _) = l.accept().unwrap();
-    poll.register().register(&s2, Token(2), Ready::readable(), PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
+    poll.register().register(&s2, Token(2), Ready::READABLE, PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
 
     wait_for(&mut poll, &mut events, Token(1));
 
@@ -41,10 +41,10 @@ pub fn test_tcp_edge_oneshot() {
         assert_eq!(1, s2.read(&mut buf).unwrap());
         assert_eq!(*byte, buf[0]);
 
-        poll.register().reregister(&s2, Token(2), Ready::readable(), PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
+        poll.register().reregister(&s2, Token(2), Ready::READABLE, PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
 
         if *byte == b'o' {
-            poll.register().reregister(&s2, Token(2), Ready::readable(), PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
+            poll.register().reregister(&s2, Token(2), Ready::READABLE, PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
         }
     }
 }

--- a/test/test_oneshot.rs
+++ b/test/test_oneshot.rs
@@ -16,17 +16,17 @@ pub fn test_tcp_edge_oneshot() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::level()).unwrap();
+    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::LEVEL).unwrap();
 
     // Connect a socket, we are going to write to it
     let mut s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register().register(&s1, Token(1), Ready::writable(), PollOpt::level()).unwrap();
+    poll.register().register(&s1, Token(1), Ready::writable(), PollOpt::LEVEL).unwrap();
 
     wait_for(&mut poll, &mut events, Token(0));
 
     // Get pair
     let (mut s2, _) = l.accept().unwrap();
-    poll.register().register(&s2, Token(2), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    poll.register().register(&s2, Token(2), Ready::readable(), PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
 
     wait_for(&mut poll, &mut events, Token(1));
 
@@ -41,10 +41,10 @@ pub fn test_tcp_edge_oneshot() {
         assert_eq!(1, s2.read(&mut buf).unwrap());
         assert_eq!(*byte, buf[0]);
 
-        poll.register().reregister(&s2, Token(2), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+        poll.register().reregister(&s2, Token(2), Ready::readable(), PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
 
         if *byte == b'o' {
-            poll.register().reregister(&s2, Token(2), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+            poll.register().reregister(&s2, Token(2), Ready::readable(), PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
         }
     }
 }

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -9,7 +9,7 @@ fn test_poll_closes_fd() {
         let (registration, set_readiness) = Registration::new();
 
         poll.register()
-            .register(&registration, Token(0), Ready::readable(), PollOpt::EDGE).unwrap();
+            .register(&registration, Token(0), Ready::READABLE, PollOpt::EDGE).unwrap();
         poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
 
         drop(poll);

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -9,7 +9,7 @@ fn test_poll_closes_fd() {
         let (registration, set_readiness) = Registration::new();
 
         poll.register()
-            .register(&registration, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+            .register(&registration, Token(0), Ready::readable(), PollOpt::EDGE).unwrap();
         poll.poll(&mut events, Some(Duration::from_millis(0))).unwrap();
 
         drop(poll);

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -34,7 +34,7 @@ impl TestHandler {
                 trace!("handle_read; token=CLIENT");
                 assert!(self.state == 0, "unexpected state {}", self.state);
                 self.state = 1;
-                poll.register().reregister(&self.client, CLIENT, Ready::writable(), PollOpt::LEVEL).unwrap();
+                poll.register().reregister(&self.client, CLIENT, Ready::WRITABLE, PollOpt::LEVEL).unwrap();
             }
             _ => panic!("unexpected token"),
         }
@@ -65,12 +65,12 @@ pub fn test_register_deregister() {
     let server = TcpListener::bind(&addr).unwrap();
 
     info!("register server socket");
-    poll.register().register(&server, SERVER, Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&server, SERVER, Ready::READABLE, PollOpt::EDGE).unwrap();
 
     let client = TcpStream::connect(&addr).unwrap();
 
     // Register client socket only as writable
-    poll.register().register(&client, CLIENT, Ready::readable(), PollOpt::LEVEL).unwrap();
+    poll.register().register(&client, CLIENT, Ready::READABLE, PollOpt::LEVEL).unwrap();
 
     let mut handler = TestHandler::new(server, client);
 
@@ -114,9 +114,9 @@ pub fn test_register_empty_interest() {
     assert!(events.iter().next().is_none(), "Received unexpected event: {:?}", events.iter().next().unwrap());
 
     // now sock is reregistered with readable, we should receive the pending event
-    poll.register().reregister(&sock, Token(0), Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().reregister(&sock, Token(0), Ready::READABLE, PollOpt::EDGE).unwrap();
     expect_events(&mut poll, &mut events, 2, vec![
-        Event::new(Ready::readable(), Token(0))
+        Event::new(Ready::READABLE, Token(0))
     ]);
 
     poll.register().reregister(&sock, Token(0), Ready::empty(), PollOpt::EDGE).unwrap();

--- a/test/test_register_deregister.rs
+++ b/test/test_register_deregister.rs
@@ -34,7 +34,7 @@ impl TestHandler {
                 trace!("handle_read; token=CLIENT");
                 assert!(self.state == 0, "unexpected state {}", self.state);
                 self.state = 1;
-                poll.register().reregister(&self.client, CLIENT, Ready::writable(), PollOpt::level()).unwrap();
+                poll.register().reregister(&self.client, CLIENT, Ready::writable(), PollOpt::LEVEL).unwrap();
             }
             _ => panic!("unexpected token"),
         }
@@ -65,12 +65,12 @@ pub fn test_register_deregister() {
     let server = TcpListener::bind(&addr).unwrap();
 
     info!("register server socket");
-    poll.register().register(&server, SERVER, Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&server, SERVER, Ready::readable(), PollOpt::EDGE).unwrap();
 
     let client = TcpStream::connect(&addr).unwrap();
 
     // Register client socket only as writable
-    poll.register().register(&client, CLIENT, Ready::readable(), PollOpt::level()).unwrap();
+    poll.register().register(&client, CLIENT, Ready::readable(), PollOpt::LEVEL).unwrap();
 
     let mut handler = TestHandler::new(server, client);
 
@@ -101,23 +101,23 @@ pub fn test_register_empty_interest() {
 
     let sock = TcpListener::bind(&addr).unwrap();
 
-    poll.register().register(&sock, Token(0), Ready::empty(), PollOpt::edge()).unwrap();
+    poll.register().register(&sock, Token(0), Ready::empty(), PollOpt::EDGE).unwrap();
 
     let client = TcpStream::connect(&addr).unwrap();
 
     // The connect is not guaranteed to have started until it is registered
     // https://docs.rs/mio/0.6.10/mio/struct.Poll.html#registering-handles
-    poll.register().register(&client, Token(1), Ready::empty(), PollOpt::edge()).unwrap();
+    poll.register().register(&client, Token(1), Ready::empty(), PollOpt::EDGE).unwrap();
 
     // sock is registered with empty interest, we should not receive any event
     poll.poll(&mut events, Some(Duration::from_millis(100))).unwrap();
     assert!(events.iter().next().is_none(), "Received unexpected event: {:?}", events.iter().next().unwrap());
 
     // now sock is reregistered with readable, we should receive the pending event
-    poll.register().reregister(&sock, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().reregister(&sock, Token(0), Ready::readable(), PollOpt::EDGE).unwrap();
     expect_events(&mut poll, &mut events, 2, vec![
         Event::new(Ready::readable(), Token(0))
     ]);
 
-    poll.register().reregister(&sock, Token(0), Ready::empty(), PollOpt::edge()).unwrap();
+    poll.register().reregister(&sock, Token(0), Ready::empty(), PollOpt::EDGE).unwrap();
 }

--- a/test/test_register_multiple_event_loops.rs
+++ b/test/test_register_multiple_event_loops.rs
@@ -9,33 +9,33 @@ fn test_tcp_register_multiple_event_loops() {
     let listener = TcpListener::bind(&addr).unwrap();
 
     let poll1 = Poll::new().unwrap();
-    poll1.register().register(&listener, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
+    poll1.register().register(&listener, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
 
     let poll2 = Poll::new().unwrap();
 
     // Try registering the same socket with the initial one
-    let res = poll2.register().register(&listener, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&listener, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try cloning the socket and registering it again
     let listener2 = listener.try_clone().unwrap();
-    let res = poll2.register().register(&listener2, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&listener2, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try the stream
     let stream = TcpStream::connect(&addr).unwrap();
 
-    poll1.register().register(&stream, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
+    poll1.register().register(&stream, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
 
-    let res = poll2.register().register(&stream, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&stream, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try cloning the socket and registering it again
     let stream2 = stream.try_clone().unwrap();
-    let res = poll2.register().register(&stream2, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&stream2, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 }
@@ -46,18 +46,18 @@ fn test_udp_register_multiple_event_loops() {
     let socket = UdpSocket::bind(&addr).unwrap();
 
     let poll1 = Poll::new().unwrap();
-    poll1.register().register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
+    poll1.register().register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
 
     let poll2 = Poll::new().unwrap();
 
     // Try registering the same socket with the initial one
-    let res = poll2.register().register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try cloning the socket and registering it again
     let socket2 = socket.try_clone().unwrap();
-    let res = poll2.register().register(&socket2, Token(0), Ready::readable() | Ready::writable(), PollOpt::edge());
+    let res = poll2.register().register(&socket2, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 }

--- a/test/test_register_multiple_event_loops.rs
+++ b/test/test_register_multiple_event_loops.rs
@@ -9,33 +9,33 @@ fn test_tcp_register_multiple_event_loops() {
     let listener = TcpListener::bind(&addr).unwrap();
 
     let poll1 = Poll::new().unwrap();
-    poll1.register().register(&listener, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
+    poll1.register().register(&listener, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE).unwrap();
 
     let poll2 = Poll::new().unwrap();
 
     // Try registering the same socket with the initial one
-    let res = poll2.register().register(&listener, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE);
+    let res = poll2.register().register(&listener, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try cloning the socket and registering it again
     let listener2 = listener.try_clone().unwrap();
-    let res = poll2.register().register(&listener2, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE);
+    let res = poll2.register().register(&listener2, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try the stream
     let stream = TcpStream::connect(&addr).unwrap();
 
-    poll1.register().register(&stream, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
+    poll1.register().register(&stream, Token(1), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE).unwrap();
 
-    let res = poll2.register().register(&stream, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE);
+    let res = poll2.register().register(&stream, Token(1), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try cloning the socket and registering it again
     let stream2 = stream.try_clone().unwrap();
-    let res = poll2.register().register(&stream2, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE);
+    let res = poll2.register().register(&stream2, Token(1), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 }
@@ -46,18 +46,18 @@ fn test_udp_register_multiple_event_loops() {
     let socket = UdpSocket::bind(&addr).unwrap();
 
     let poll1 = Poll::new().unwrap();
-    poll1.register().register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
+    poll1.register().register(&socket, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE).unwrap();
 
     let poll2 = Poll::new().unwrap();
 
     // Try registering the same socket with the initial one
-    let res = poll2.register().register(&socket, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE);
+    let res = poll2.register().register(&socket, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 
     // Try cloning the socket and registering it again
     let socket2 = socket.try_clone().unwrap();
-    let res = poll2.register().register(&socket2, Token(0), Ready::readable() | Ready::writable(), PollOpt::EDGE);
+    let res = poll2.register().register(&socket2, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE);
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::Other);
 }

--- a/test/test_reregister_without_poll.rs
+++ b/test/test_reregister_without_poll.rs
@@ -14,14 +14,14 @@ pub fn test_reregister_different_without_poll() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
 
     let s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register().register(&s1, Token(2), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&s1, Token(2), Ready::readable(), PollOpt::EDGE).unwrap();
 
     sleep_ms(MS);
 
-    poll.register().reregister(&l, Token(0), Ready::writable(), PollOpt::edge() | PollOpt::oneshot()).unwrap();
+    poll.register().reregister(&l, Token(0), Ready::writable(), PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
 
     poll.poll(&mut events, Some(Duration::from_millis(MS))).unwrap();
     assert!(events.iter().next().is_none());

--- a/test/test_reregister_without_poll.rs
+++ b/test/test_reregister_without_poll.rs
@@ -14,14 +14,14 @@ pub fn test_reregister_different_without_poll() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
+    poll.register().register(&l, Token(0), Ready::READABLE, PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
 
     let s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register().register(&s1, Token(2), Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&s1, Token(2), Ready::READABLE, PollOpt::EDGE).unwrap();
 
     sleep_ms(MS);
 
-    poll.register().reregister(&l, Token(0), Ready::writable(), PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
+    poll.register().reregister(&l, Token(0), Ready::WRITABLE, PollOpt::EDGE | PollOpt::ONESHOT).unwrap();
 
     poll.poll(&mut events, Some(Duration::from_millis(MS))).unwrap();
     assert!(events.iter().next().is_none());

--- a/test/test_smoke.rs
+++ b/test/test_smoke.rs
@@ -16,7 +16,7 @@ fn add_then_drop() {
     let mut events = Events::with_capacity(1024);
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let mut poll = Poll::new().unwrap();
-    poll.register().register(&l, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&l, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
     drop(l);
     poll.poll(&mut events, Some(Duration::from_millis(100))).unwrap();
 

--- a/test/test_smoke.rs
+++ b/test/test_smoke.rs
@@ -16,7 +16,7 @@ fn add_then_drop() {
     let mut events = Events::with_capacity(1024);
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let mut poll = Poll::new().unwrap();
-    poll.register().register(&l, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&l, Token(1), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE).unwrap();
     drop(l);
     poll.poll(&mut events, Some(Duration::from_millis(100))).unwrap();
 

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -26,7 +26,7 @@ fn accept() {
 
     let mut poll = Poll::new().unwrap();
 
-    poll.register().register(&l, Token(1), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&l, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -66,7 +66,7 @@ fn connect() {
     let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register().register(&s, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&s, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -127,7 +127,7 @@ fn read() {
     let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register().register(&s, Token(1), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&s, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -175,7 +175,7 @@ fn peek() {
     let s = TcpStream::connect(&addr).unwrap();
 
     poll.register()
-        .register(&s, Token(1), Ready::readable(), PollOpt::edge()).unwrap();
+        .register(&s, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -231,7 +231,7 @@ fn read_bufs() {
 
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register().register(&s, Token(1), Ready::readable(), PollOpt::level()).unwrap();
+    poll.register().register(&s, Token(1), Ready::readable(), PollOpt::LEVEL).unwrap();
 
     let b1 = &mut [0; 10][..];
     let b2 = &mut [0; 383][..];
@@ -302,7 +302,7 @@ fn write() {
     let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register().register(&s, Token(1), Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&s, Token(1), Ready::writable(), PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -355,7 +355,7 @@ fn write_bufs() {
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(128);
     let s = TcpStream::connect(&addr).unwrap();
-    poll.register().register(&s, Token(1), Ready::writable(), PollOpt::level()).unwrap();
+    poll.register().register(&s, Token(1), Ready::writable(), PollOpt::LEVEL).unwrap();
 
     let b1 = &[1; 10][..];
     let b2 = &[1; 383][..];
@@ -391,8 +391,8 @@ fn connect_then_close() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let s = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
 
-    poll.register().register(&l, Token(1), Ready::readable(), PollOpt::edge()).unwrap();
-    poll.register().register(&s, Token(2), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&l, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&s, Token(2), Ready::readable(), PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -405,7 +405,7 @@ fn connect_then_close() {
                 let s = h.listener.accept().unwrap().0;
                 poll.register()
                     .register(&s, Token(3), Ready::readable() | Ready::writable(),
-                                        PollOpt::edge()).unwrap();
+                                        PollOpt::EDGE).unwrap();
                 drop(s);
             } else if event.token() == Token(2) {
                 h.shutdown = true;
@@ -419,7 +419,7 @@ fn listen_then_close() {
     let mut poll = Poll::new().unwrap();
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
-    poll.register().register(&l, Token(1), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&l, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
     drop(l);
 
     let mut events = Events::with_capacity(128);
@@ -478,7 +478,7 @@ fn multiple_writes_immediate_success() {
 
     let mut poll = Poll::new().unwrap();
     let mut s = TcpStream::connect(&addr).unwrap();
-    poll.register().register(&s, Token(1), Ready::writable(), PollOpt::level()).unwrap();
+    poll.register().register(&s, Token(1), Ready::writable(), PollOpt::LEVEL).unwrap();
     let mut events = Events::with_capacity(16);
 
     // Wait for our TCP stream to connect
@@ -519,10 +519,10 @@ fn connection_reset_by_peer() {
     let client = TcpStream::from_stream(client).unwrap();
 
     // Register server
-    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::EDGE).unwrap();
 
     // Register interest in the client
-    poll.register().register(&client, Token(1), Ready::readable() | Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&client, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
 
     // Wait for listener to be ready
     let mut server;
@@ -551,7 +551,7 @@ fn connection_reset_by_peer() {
     thread::sleep(Duration::from_millis(100));
 
     // Register interest in the server socket
-    poll.register().register(&server, Token(3), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&server, Token(3), Ready::readable(), PollOpt::EDGE).unwrap();
 
 
     loop {
@@ -582,7 +582,7 @@ fn connect_error() {
 
     // Pick a "random" port that shouldn't be in use.
     let l = TcpStream::connect(&"127.0.0.1:38381".parse().unwrap()).unwrap();
-    poll.register().register(&l, Token(0), Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&l, Token(0), Ready::writable(), PollOpt::EDGE).unwrap();
 
     'outer:
     loop {
@@ -618,7 +618,7 @@ fn write_error() {
         .register(&s,
                   Token(0),
                   Ready::readable() | Ready::writable(),
-                  PollOpt::edge()).unwrap();
+                  PollOpt::EDGE).unwrap();
 
     let mut wait_writable = || {
         'outer:

--- a/test/test_tcp.rs
+++ b/test/test_tcp.rs
@@ -26,7 +26,7 @@ fn accept() {
 
     let mut poll = Poll::new().unwrap();
 
-    poll.register().register(&l, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&l, Token(1), Ready::READABLE, PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -66,7 +66,7 @@ fn connect() {
     let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register().register(&s, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&s, Token(1), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -127,7 +127,7 @@ fn read() {
     let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register().register(&s, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&s, Token(1), Ready::READABLE, PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -175,7 +175,7 @@ fn peek() {
     let s = TcpStream::connect(&addr).unwrap();
 
     poll.register()
-        .register(&s, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
+        .register(&s, Token(1), Ready::READABLE, PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -231,7 +231,7 @@ fn read_bufs() {
 
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register().register(&s, Token(1), Ready::readable(), PollOpt::LEVEL).unwrap();
+    poll.register().register(&s, Token(1), Ready::READABLE, PollOpt::LEVEL).unwrap();
 
     let b1 = &mut [0; 10][..];
     let b2 = &mut [0; 383][..];
@@ -302,7 +302,7 @@ fn write() {
     let mut poll = Poll::new().unwrap();
     let s = TcpStream::connect(&addr).unwrap();
 
-    poll.register().register(&s, Token(1), Ready::writable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&s, Token(1), Ready::WRITABLE, PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -355,7 +355,7 @@ fn write_bufs() {
     let mut poll = Poll::new().unwrap();
     let mut events = Events::with_capacity(128);
     let s = TcpStream::connect(&addr).unwrap();
-    poll.register().register(&s, Token(1), Ready::writable(), PollOpt::LEVEL).unwrap();
+    poll.register().register(&s, Token(1), Ready::WRITABLE, PollOpt::LEVEL).unwrap();
 
     let b1 = &[1; 10][..];
     let b2 = &[1; 383][..];
@@ -391,8 +391,8 @@ fn connect_then_close() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let s = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
 
-    poll.register().register(&l, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
-    poll.register().register(&s, Token(2), Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&l, Token(1), Ready::READABLE, PollOpt::EDGE).unwrap();
+    poll.register().register(&s, Token(2), Ready::READABLE, PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(128);
 
@@ -404,7 +404,7 @@ fn connect_then_close() {
             if event.token() == Token(1) {
                 let s = h.listener.accept().unwrap().0;
                 poll.register()
-                    .register(&s, Token(3), Ready::readable() | Ready::writable(),
+                    .register(&s, Token(3), Ready::READABLE | Ready::WRITABLE,
                                         PollOpt::EDGE).unwrap();
                 drop(s);
             } else if event.token() == Token(2) {
@@ -419,7 +419,7 @@ fn listen_then_close() {
     let mut poll = Poll::new().unwrap();
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
-    poll.register().register(&l, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&l, Token(1), Ready::READABLE, PollOpt::EDGE).unwrap();
     drop(l);
 
     let mut events = Events::with_capacity(128);
@@ -478,7 +478,7 @@ fn multiple_writes_immediate_success() {
 
     let mut poll = Poll::new().unwrap();
     let mut s = TcpStream::connect(&addr).unwrap();
-    poll.register().register(&s, Token(1), Ready::writable(), PollOpt::LEVEL).unwrap();
+    poll.register().register(&s, Token(1), Ready::WRITABLE, PollOpt::LEVEL).unwrap();
     let mut events = Events::with_capacity(16);
 
     // Wait for our TCP stream to connect
@@ -519,10 +519,10 @@ fn connection_reset_by_peer() {
     let client = TcpStream::from_stream(client).unwrap();
 
     // Register server
-    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&l, Token(0), Ready::READABLE, PollOpt::EDGE).unwrap();
 
     // Register interest in the client
-    poll.register().register(&client, Token(1), Ready::readable() | Ready::writable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&client, Token(1), Ready::READABLE | Ready::WRITABLE, PollOpt::EDGE).unwrap();
 
     // Wait for listener to be ready
     let mut server;
@@ -551,7 +551,7 @@ fn connection_reset_by_peer() {
     thread::sleep(Duration::from_millis(100));
 
     // Register interest in the server socket
-    poll.register().register(&server, Token(3), Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&server, Token(3), Ready::READABLE, PollOpt::EDGE).unwrap();
 
 
     loop {
@@ -582,7 +582,7 @@ fn connect_error() {
 
     // Pick a "random" port that shouldn't be in use.
     let l = TcpStream::connect(&"127.0.0.1:38381".parse().unwrap()).unwrap();
-    poll.register().register(&l, Token(0), Ready::writable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&l, Token(0), Ready::WRITABLE, PollOpt::EDGE).unwrap();
 
     'outer:
     loop {
@@ -617,7 +617,7 @@ fn write_error() {
     poll.register()
         .register(&s,
                   Token(0),
-                  Ready::readable() | Ready::writable(),
+                  Ready::READABLE | Ready::WRITABLE,
                   PollOpt::EDGE).unwrap();
 
     let mut wait_writable = || {

--- a/test/test_tcp_level.rs
+++ b/test/test_tcp_level.rs
@@ -16,10 +16,10 @@ pub fn test_tcp_listener_level_triggered() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::level()).unwrap();
+    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::LEVEL).unwrap();
 
     let s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register().register(&s1, Token(1), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&s1, Token(1), Ready::readable(), PollOpt::EDGE).unwrap();
 
     while filter(&pevents, Token(0)).len() == 0 {
         poll.poll(&mut pevents, Some(Duration::from_millis(MS))).unwrap();
@@ -42,7 +42,7 @@ pub fn test_tcp_listener_level_triggered() {
     assert!(events.is_empty(), "actual={:?}", events);
 
     let s3 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register().register(&s3, Token(2), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&s3, Token(2), Ready::readable(), PollOpt::EDGE).unwrap();
 
     while filter(&pevents, Token(0)).len() == 0 {
         poll.poll(&mut pevents, Some(Duration::from_millis(MS))).unwrap();
@@ -69,10 +69,10 @@ pub fn test_tcp_stream_level_triggered() {
     let l = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
     // Register the listener with `Poll`
-    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&l, Token(0), Ready::readable(), PollOpt::EDGE).unwrap();
 
     let mut s1 = TcpStream::connect(&l.local_addr().unwrap()).unwrap();
-    poll.register().register(&s1, Token(1), Ready::readable() | Ready::writable(), PollOpt::level()).unwrap();
+    poll.register().register(&s1, Token(1), Ready::readable() | Ready::writable(), PollOpt::LEVEL).unwrap();
 
     // Sleep a bit to ensure it arrives at dest
     sleep_ms(250);
@@ -93,7 +93,7 @@ pub fn test_tcp_stream_level_triggered() {
     ]);
 
     // Register the socket
-    poll.register().register(&s1_tx, Token(123), Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&s1_tx, Token(123), Ready::readable(), PollOpt::EDGE).unwrap();
 
     debug!("writing some data ----------");
 

--- a/test/test_udp_level.rs
+++ b/test/test_udp_level.rs
@@ -13,14 +13,14 @@ pub fn test_udp_level_triggered() {
     let tx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let rx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
-    poll.register().register(&tx, Token(0), Ready::readable() | Ready::writable(), PollOpt::LEVEL).unwrap();
-    poll.register().register(&rx, Token(1), Ready::readable() | Ready::writable(), PollOpt::LEVEL).unwrap();
+    poll.register().register(&tx, Token(0), Ready::READABLE | Ready::WRITABLE, PollOpt::LEVEL).unwrap();
+    poll.register().register(&rx, Token(1), Ready::READABLE | Ready::WRITABLE, PollOpt::LEVEL).unwrap();
 
 
     for _ in 0..2 {
         expect_events(&mut poll, events, 2, vec![
-            Event::new(Ready::writable(), Token(0)),
-            Event::new(Ready::writable(), Token(1)),
+            Event::new(Ready::WRITABLE, Token(0)),
+            Event::new(Ready::WRITABLE, Token(1)),
         ]);
     }
 
@@ -30,7 +30,7 @@ pub fn test_udp_level_triggered() {
 
     for _ in 0..2 {
         expect_events(&mut poll, events, 2, vec![
-            Event::new(Ready::readable() | Ready::writable(), Token(1))
+            Event::new(Ready::READABLE | Ready::WRITABLE, Token(1))
         ]);
     }
 
@@ -38,14 +38,14 @@ pub fn test_udp_level_triggered() {
     while rx.recv_from(&mut buf).is_ok() {}
 
     for _ in 0..2 {
-        expect_events(&mut poll, events, 4, vec![Event::new(Ready::writable(), Token(1))]);
+        expect_events(&mut poll, events, 4, vec![Event::new(Ready::WRITABLE, Token(1))]);
     }
 
     tx.send_to(b"hello world!", &rx.local_addr().unwrap()).unwrap();
     sleep_ms(250);
 
     expect_events(&mut poll, events, 10,
-                  vec![Event::new(Ready::readable() | Ready::writable(), Token(1))]);
+                  vec![Event::new(Ready::READABLE | Ready::WRITABLE, Token(1))]);
 
     drop(rx);
 }

--- a/test/test_udp_level.rs
+++ b/test/test_udp_level.rs
@@ -13,8 +13,8 @@ pub fn test_udp_level_triggered() {
     let tx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let rx = UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
 
-    poll.register().register(&tx, Token(0), Ready::readable() | Ready::writable(), PollOpt::level()).unwrap();
-    poll.register().register(&rx, Token(1), Ready::readable() | Ready::writable(), PollOpt::level()).unwrap();
+    poll.register().register(&tx, Token(0), Ready::readable() | Ready::writable(), PollOpt::LEVEL).unwrap();
+    poll.register().register(&rx, Token(1), Ready::readable() | Ready::writable(), PollOpt::LEVEL).unwrap();
 
 
     for _ in 0..2 {

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -52,10 +52,10 @@ fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
     assert_eq!(ErrorKind::WouldBlock, rx.recv_from(&mut buf).unwrap_err().kind());
 
     info!("Registering SENDER");
-    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&tx, SENDER, Ready::WRITABLE, PollOpt::EDGE).unwrap();
 
     info!("Registering LISTENER");
-    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&rx, LISTENER, Ready::READABLE, PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
 
@@ -155,8 +155,8 @@ pub fn test_udp_socket_discard() {
     let r = udp_outside.send("hello world".as_bytes());
     assert!(r.is_ok() || r.unwrap_err().kind() == ErrorKind::WouldBlock);
 
-    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::EDGE).unwrap();
-    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&rx, LISTENER, Ready::READABLE, PollOpt::EDGE).unwrap();
+    poll.register().register(&tx, SENDER, Ready::WRITABLE, PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
 

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -52,10 +52,10 @@ fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
     assert_eq!(ErrorKind::WouldBlock, rx.recv_from(&mut buf).unwrap_err().kind());
 
     info!("Registering SENDER");
-    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::EDGE).unwrap();
 
     info!("Registering LISTENER");
-    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
 
@@ -155,8 +155,8 @@ pub fn test_udp_socket_discard() {
     let r = udp_outside.send("hello world".as_bytes());
     assert!(r.is_ok() || r.unwrap_err().kind() == ErrorKind::WouldBlock);
 
-    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::edge()).unwrap();
-    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register().register(&rx, LISTENER, Ready::readable(), PollOpt::EDGE).unwrap();
+    poll.register().register(&tx, SENDER, Ready::writable(), PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
 

--- a/test/test_write_then_drop.rs
+++ b/test/test_write_then_drop.rs
@@ -17,11 +17,11 @@ fn write_then_drop() {
     a.register(poll.register(),
                Token(1),
                Ready::readable(),
-               PollOpt::edge()).unwrap();
+               PollOpt::EDGE).unwrap();
     s.register(poll.register(),
                Token(3),
                Ready::empty(),
-               PollOpt::edge()).unwrap();
+               PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
     while events.iter().next().is_none() {
@@ -35,7 +35,7 @@ fn write_then_drop() {
     s2.register(poll.register(),
                 Token(2),
                 Ready::writable(),
-                PollOpt::edge()).unwrap();
+                PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
     while events.iter().count() == 0 {
@@ -50,7 +50,7 @@ fn write_then_drop() {
     s.reregister(poll.register(),
                  Token(3),
                  Ready::readable(),
-                 PollOpt::edge()).unwrap();
+                 PollOpt::EDGE).unwrap();
     let mut events = Events::with_capacity(1024);
     while events.iter().count() == 0 {
         poll.poll(&mut events, None).unwrap();
@@ -76,11 +76,11 @@ fn write_then_deregister() {
     a.register(poll.register(),
                Token(1),
                Ready::readable(),
-               PollOpt::edge()).unwrap();
+               PollOpt::EDGE).unwrap();
     s.register(poll.register(),
                Token(3),
                Ready::empty(),
-               PollOpt::edge()).unwrap();
+               PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
     while events.iter().count() == 0 {
@@ -94,7 +94,7 @@ fn write_then_deregister() {
     s2.register(poll.register(),
                 Token(2),
                 Ready::writable(),
-                PollOpt::edge()).unwrap();
+                PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
     while events.iter().count() == 0 {
@@ -109,7 +109,7 @@ fn write_then_deregister() {
     s.reregister(poll.register(),
                  Token(3),
                  Ready::readable(),
-                 PollOpt::edge()).unwrap();
+                 PollOpt::EDGE).unwrap();
     let mut events = Events::with_capacity(1024);
     while events.iter().count() == 0 {
         poll.poll(&mut events, None).unwrap();

--- a/test/test_write_then_drop.rs
+++ b/test/test_write_then_drop.rs
@@ -16,7 +16,7 @@ fn write_then_drop() {
 
     a.register(poll.register(),
                Token(1),
-               Ready::readable(),
+               Ready::READABLE,
                PollOpt::EDGE).unwrap();
     s.register(poll.register(),
                Token(3),
@@ -34,7 +34,7 @@ fn write_then_drop() {
 
     s2.register(poll.register(),
                 Token(2),
-                Ready::writable(),
+                Ready::WRITABLE,
                 PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -49,7 +49,7 @@ fn write_then_drop() {
 
     s.reregister(poll.register(),
                  Token(3),
-                 Ready::readable(),
+                 Ready::READABLE,
                  PollOpt::EDGE).unwrap();
     let mut events = Events::with_capacity(1024);
     while events.iter().count() == 0 {
@@ -75,7 +75,7 @@ fn write_then_deregister() {
 
     a.register(poll.register(),
                Token(1),
-               Ready::readable(),
+               Ready::READABLE,
                PollOpt::EDGE).unwrap();
     s.register(poll.register(),
                Token(3),
@@ -93,7 +93,7 @@ fn write_then_deregister() {
 
     s2.register(poll.register(),
                 Token(2),
-                Ready::writable(),
+                Ready::WRITABLE,
                 PollOpt::EDGE).unwrap();
 
     let mut events = Events::with_capacity(1024);
@@ -108,7 +108,7 @@ fn write_then_deregister() {
 
     s.reregister(poll.register(),
                  Token(3),
-                 Ready::readable(),
+                 Ready::READABLE,
                  PollOpt::EDGE).unwrap();
     let mut events = Events::with_capacity(1024);
     while events.iter().count() == 0 {


### PR DESCRIPTION
Uses [bitflags] to provide associated consts for bitflag-like types.

Fixes #661.
Closes #698, which looks trapped in history hell.

I found it useful to separate the manual steps from the automated steps; see commits.