### PR TITLE
Observe kernel limit of 1024 items for readv/writev calls

### DIFF
--- a/src/sys/fuchsia/net.rs
+++ b/src/sys/fuchsia/net.rs
@@ -135,7 +135,7 @@ impl TcpStream {
     pub fn readv(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
         unsafe {
             let slice = iovec::as_os_slice_mut(bufs);
-            let len = cmp::min(<libc::c_int>::max_value() as usize, slice.len());
+            let len = cmp::min(1024, slice.len());
             let rc = libc::readv(self.io.as_raw_fd(),
                                  slice.as_ptr(),
                                  len as libc::c_int);
@@ -150,7 +150,7 @@ impl TcpStream {
     pub fn writev(&self, bufs: &[&IoVec]) -> io::Result<usize> {
         unsafe {
             let slice = iovec::as_os_slice(bufs);
-            let len = cmp::min(<libc::c_int>::max_value() as usize, slice.len());
+            let len = cmp::min(1024, slice.len());
             let rc = libc::writev(self.io.as_raw_fd(),
                                   slice.as_ptr(),
                                   len as libc::c_int);

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -132,7 +132,7 @@ impl TcpStream {
     pub fn readv(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
         unsafe {
             let slice = iovec::as_os_slice_mut(bufs);
-            let len = cmp::min(<libc::c_int>::max_value() as usize, slice.len());
+            let len = cmp::min(1024, slice.len());
             let rc = libc::readv(self.inner.as_raw_fd(),
                                  slice.as_ptr(),
                                  len as libc::c_int);
@@ -147,7 +147,7 @@ impl TcpStream {
     pub fn writev(&self, bufs: &[&IoVec]) -> io::Result<usize> {
         unsafe {
             let slice = iovec::as_os_slice(bufs);
-            let len = cmp::min(<libc::c_int>::max_value() as usize, slice.len());
+            let len = cmp::min(1024, slice.len());
             let rc = libc::writev(self.inner.as_raw_fd(),
                                   slice.as_ptr(),
                                   len as libc::c_int);


### PR DESCRIPTION
This commit takes into account the kernel maximum of 1024 iov
items passed to a readv/writev call.

`man 2 readv`:

> To deal with the fact that IOV_MAX was so low on early versions of
>        Linux, the glibc wrapper functions for readv() and writev() did some
>        extra work if they detected that the underlying kernel system call
>        failed because this limit was exceeded.

> Starting with glibc version 2.9,
>        the wrapper functions provide this behavior only if the library
>        detects that the system is running a Linux kernel older than version
>        2.6.18 (an arbitrarily selected kernel version).  And since glibc
>        2.20 (which requires a minimum Linux kernel version of 2.6.32), the
>        glibc wrapper functions always just directly invoke the system calls.