### PR TITLE
Add Evented impls for container types

### DIFF
--- a/src/event_imp.rs
+++ b/src/event_imp.rs
@@ -154,6 +154,48 @@ pub trait Evented {
     fn deregister(&self, poll: &Poll) -> io::Result<()>;
 }
 
+impl Evented for Box<Evented> {
+    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        self.as_ref().register(poll, token, interest, opts)
+    }
+
+    fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        self.as_ref().reregister(poll, token, interest, opts)
+    }
+
+    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+        self.as_ref().deregister(poll)
+    }
+}
+
+impl<T: Evented> Evented for Box<T> {
+    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        self.as_ref().register(poll, token, interest, opts)
+    }
+
+    fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        self.as_ref().reregister(poll, token, interest, opts)
+    }
+
+    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+        self.as_ref().deregister(poll)
+    }
+}
+
+impl<T: Evented> Evented for ::std::sync::Arc<T> {
+    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        self.as_ref().register(poll, token, interest, opts)
+    }
+
+    fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+        self.as_ref().reregister(poll, token, interest, opts)
+    }
+
+    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+        self.as_ref().deregister(poll)
+    }
+}
+
 /// Options supplied when registering an `Evented` handle with `Poll`
 ///
 /// `PollOpt` values can be combined together using the various bitwise


### PR DESCRIPTION
This makes `Arc<Evented>` and `Box<Evented>` both implementations of `Evented`.

I need this in Notify to be able to generically use different `Evented` drivers from a common core. Basically, I'm getting both unix-kernelspace `EventedFd` and userspace `Registration` (and possibly other kinds) over a trait method, so I firstly needed them to be compatible with a `Box<Evented>` trait objects. Also due to implementation details I needed an `Arc<Evented>` so I included it.

Could possibly also add `Rc<Evented>`? I don't have a use for it but while we're at it...