### PR TITLE
libc 0.2.42 changed definition of bind to use socklen_t on aarch64-linux-android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ fuchsia-zircon = "0.3.2"
 fuchsia-zircon-sys = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]
-libc   = "0.2.19"
+libc   = "0.2.42"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.6"

--- a/src/sys/unix/uds.rs
+++ b/src/sys/unix/uds.rs
@@ -123,25 +123,12 @@ impl UnixSocket {
     }
 
     /// Bind the socket to the specified address
-    #[cfg(not(all(any(target_arch = "aarch64", target_arch = "x86_64"), target_os = "android")))]
     pub fn bind<P: AsRef<Path> + ?Sized>(&self, addr: &P) -> io::Result<()> {
         unsafe {
             let (addr, len) = sockaddr_un(addr.as_ref())?;
             cvt(libc::bind(self.as_raw_fd(),
                                 &addr as *const _ as *const _,
                                 len))?;
-            Ok(())
-        }
-    }
-
-    #[cfg(all(any(target_arch = "aarch64", target_arch = "x86_64"), target_os = "android"))]
-    pub fn bind<P: AsRef<Path> + ?Sized>(&self, addr: &P) -> io::Result<()> {
-        unsafe {
-            let (addr, len) = sockaddr_un(addr.as_ref())?;
-            let len_i32 = len as i32;
-            cvt(libc::bind(self.as_raw_fd(),
-                                &addr as *const _ as *const _,
-                                len_i32))?;
             Ok(())
         }
     }


### PR DESCRIPTION
https://github.com/rust-lang-nursery/net2-rs/pull/74 is also needed to get mio compiling for aarch64-linux-android again