### PR TITLE
Fix android-aarch64 build when using libc 0.2.42

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,18 +79,15 @@ matrix:
         - rustup target add $TARGET
 
     # Android aarch64-linux-android
-    #
-    # TODO: Re-enable once net2 is fixed.
-    #       https://github.com/rust-lang-nursery/net2-rs/pull/74
-    # - os: linux
-    #   env: TARGET=aarch64-linux-android
-    #   rust: stable
-    #   script:
-    #     - cargo build
-    #     - cargo build --no-default-features
-    #     - sh ci/run-docker.sh $TARGET;
-    #   install:
-    #     - rustup target add $TARGET
+    - os: linux
+      env: TARGET=aarch64-linux-android
+      rust: stable
+      script:
+        - cargo build
+        - cargo build --no-default-features
+        - sh ci/run-docker.sh $TARGET;
+      install:
+        - rustup target add $TARGET
 
     # NetBSD
     - os: linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ fuchsia-zircon = "0.3.2"
 fuchsia-zircon-sys = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]
-libc   = "0.2.19"
+libc   = "0.2.42"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.6"

--- a/ci/docker/aarch64-linux-android/Dockerfile
+++ b/ci/docker/aarch64-linux-android/Dockerfile
@@ -16,6 +16,7 @@ RUN dpkg --add-architecture i386 && \
   expect \
   openjdk-9-jre \
   libstdc++6:i386 \
+  libc++1 \
   gcc \
   libc6-dev \
   qt5-default zlib1g:i386 libx11-6:i386 \

--- a/src/sys/unix/uds.rs
+++ b/src/sys/unix/uds.rs
@@ -123,25 +123,12 @@ impl UnixSocket {
     }
 
     /// Bind the socket to the specified address
-    #[cfg(not(all(any(target_arch = "aarch64", target_arch = "x86_64"), target_os = "android")))]
     pub fn bind<P: AsRef<Path> + ?Sized>(&self, addr: &P) -> io::Result<()> {
         unsafe {
             let (addr, len) = sockaddr_un(addr.as_ref())?;
             cvt(libc::bind(self.as_raw_fd(),
                                 &addr as *const _ as *const _,
                                 len))?;
-            Ok(())
-        }
-    }
-
-    #[cfg(all(any(target_arch = "aarch64", target_arch = "x86_64"), target_os = "android"))]
-    pub fn bind<P: AsRef<Path> + ?Sized>(&self, addr: &P) -> io::Result<()> {
-        unsafe {
-            let (addr, len) = sockaddr_un(addr.as_ref())?;
-            let len_i32 = len as i32;
-            cvt(libc::bind(self.as_raw_fd(),
-                                &addr as *const _ as *const _,
-                                len_i32))?;
             Ok(())
         }
     }


### PR DESCRIPTION
socketlen_t is defined as an u32 in libc 0.2.42, this conditionnal
compilation is not needed anymore and creates a compilation error

(I ran the test on a real aarch64 android using [dinghy](https://github.com/snipsco/dinghy/) and they pass)