### PR TITLE
Bump mio version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,8 @@ fuchsia-zircon-sys = "0.3.2"
 libc   = "0.2.42"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2.6"
-miow   = "0.2.1"
-kernel32-sys = "0.2"
+winapi = "0.3.4"
+miow   = "0.3.1"
 
 [dev-dependencies]
 env_logger = { version = "0.4.0", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,9 +114,6 @@ extern crate miow;
 #[cfg(windows)]
 extern crate winapi;
 
-#[cfg(windows)]
-extern crate kernel32;
-
 #[macro_use]
 extern crate log;
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -138,9 +138,9 @@
 
 use std::io;
 use std::os::windows::prelude::*;
-
-use kernel32;
-use winapi;
+use winapi::shared::ntdef::*;
+use winapi::um::winbase::*;
+use winapi::um::ioapiset::*;
 
 mod awakener;
 #[macro_use]
@@ -162,8 +162,8 @@ enum Family {
 
 unsafe fn cancel(socket: &AsRawSocket,
                  overlapped: &Overlapped) -> io::Result<()> {
-    let handle = socket.as_raw_socket() as winapi::HANDLE;
-    let ret = kernel32::CancelIoEx(handle, overlapped.as_mut_ptr());
+    let handle = socket.as_raw_socket() as HANDLE;
+    let ret = CancelIoEx(handle, overlapped.as_mut_ptr());
     if ret == 0 {
         Err(io::Error::last_os_error())
     } else {
@@ -171,15 +171,15 @@ unsafe fn cancel(socket: &AsRawSocket,
     }
 }
 
-unsafe fn no_notify_on_instant_completion(handle: winapi::HANDLE) -> io::Result<()> {
+unsafe fn no_notify_on_instant_completion(handle: HANDLE) -> io::Result<()> {
     // TODO: move those to winapi
-    const FILE_SKIP_COMPLETION_PORT_ON_SUCCESS: winapi::UCHAR = 1;
-    const FILE_SKIP_SET_EVENT_ON_HANDLE: winapi::UCHAR = 2;
+    const FILE_SKIP_COMPLETION_PORT_ON_SUCCESS: UCHAR = 1;
+    const FILE_SKIP_SET_EVENT_ON_HANDLE: UCHAR = 2;
 
     let flags = FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE;
 
-    let r = kernel32::SetFileCompletionNotificationModes(handle, flags);
-    if r == winapi::TRUE {
+    let r = SetFileCompletionNotificationModes(handle, flags);
+    if r == TRUE as i32 {
         Ok(())
     } else {
         Err(io::Error::last_os_error())

--- a/src/sys/windows/selector.rs
+++ b/src/sys/windows/selector.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 
 use lazycell::AtomicLazyCell;
 
-use winapi::*;
+use winapi::shared::winerror::*;
+use winapi::um::minwinbase::*;
 use miow;
 use miow::iocp::{CompletionPort, CompletionStatus};
 

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -12,7 +12,8 @@ use std::sync::{Mutex, MutexGuard};
 
 #[allow(unused_imports)]
 use net2::{UdpBuilder, UdpSocketExt};
-use winapi::*;
+use winapi::shared::winerror::*;
+use winapi::um::minwinbase::*;
 use miow::iocp::CompletionStatus;
 use miow::net::SocketAddrBuf;
 use miow::net::UdpSocketExt as MiowUdpSocketExt;


### PR DESCRIPTION
Warning: Only compilation is tested, runtime isn't

I first thought these changes were required for Redox support (#844) because I thought we'd need to modify miow. But we don't, since cargo is nice enough to automatically select newer, semver compatible, versions. Since I already did this, I'm sending it here. But really, I don't care if you don't merge it