### PR TITLE
Add travis_wait to iOS CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
 
     # iOS
     - os: osx
-      osx_image: xcode8.2
+      osx_image: xcode9.4
       env: TARGET=x86_64-apple-ios
       rust: stable
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
       rust: stable
       script:
         - cargo build
-        - CARGO_TARGET_DIR=`pwd` sh ci/run-ios.sh $TARGET
+        - CARGO_TARGET_DIR=`pwd` travis_wait 30 ci/run-ios.sh $TARGET
       install:
         - rustup target add $TARGET
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
       rust: stable
       script:
         - cargo build
-        - CARGO_TARGET_DIR=`pwd` sh ci/run-ios.sh $TARGET
+        - CARGO_TARGET_DIR=`pwd` travis_wait sh ci/run-ios.sh $TARGET
       install:
         - rustup target add $TARGET
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
       rust: stable
       script:
         - cargo build
-        - CARGO_TARGET_DIR=`pwd` travis_wait sh ci/run-ios.sh $TARGET
+        - CARGO_TARGET_DIR=`pwd` sh ci/run-ios.sh $TARGET
       install:
         - rustup target add $TARGET
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
       rust: stable
       script:
         - cargo build
-        - CARGO_TARGET_DIR=`pwd` travis_wait 30 ci/run-ios.sh $TARGET
+        - CARGO_TARGET_DIR=`pwd` sh ci/run-ios.sh $TARGET
       install:
         - rustup target add $TARGET
 

--- a/ci/ios/Cargo.toml
+++ b/ci/ios/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ios"
+version = "0.1.0"
+authors = ["Eliza Weisman <eliza@buoyant.io>"]
+
+[dependencies]
+tokio = "0.1.7"
+tokio-process = "0.2.2"

--- a/ci/ios/deploy_and_run_on_ios_simulator.rs
+++ b/ci/ios/deploy_and_run_on_ios_simulator.rs
@@ -31,20 +31,6 @@ macro_rules! t {
     })
 }
 
-// If we're running on Travis CI, launch `c` with `travis_wait`, to
-// prevent Travis from timing out.
-fn command_with_travis_wait<S: AsRef<OsStr>>(c: S) -> Command {
-    if let Ok("true") = env::var("TRAVIS")
-        .as_ref()
-        .map(String::as_ref)
-    {
-        let mut command = Command::new("travis_wait");
-        command.arg("20").arg(c.as_ref());
-        command
-    } else {
-        Command::new(c)
-    }
-}
 
 // Step one: Wrap as an app
 fn package_as_simulator_app(crate_name: &str, test_binary_path: &Path) {
@@ -133,7 +119,7 @@ fn run_app_on_simulator() {
     use std::io::{self, Read, Write};
 
     println!("Running app");
-    let mut child = t!(command_with_travis_wait("xcrun")
+    let mut child = t!(Command::new("xcrun")
                     .arg("simctl")
                     .arg("launch")
                     .arg("--console")

--- a/ci/ios/src/bin/deploy_and_run_on_ios_simulator.rs
+++ b/ci/ios/src/bin/deploy_and_run_on_ios_simulator.rs
@@ -49,7 +49,7 @@ macro_rules! t {
 fn tick_until<F: Future>(at: Instant, every: Duration, until: F)
     -> impl Future<Item = F::Item, Error = F::Error>
 {
-    Interval::new(at, every)
+    Interval::new(at + every, every)
         .for_each(move |_| {
             println!("\tstill waiting... (for {} seconds)", at.elapsed().as_secs());
             future::ok(())
@@ -193,7 +193,7 @@ fn run_app_on_simulator() {
     // });
 
     println!("Waiting for cmd to finish");
-    let f = tick_until(t0, Duration::from_secs(30), child)
+    let f = tick_until(t0, Duration::from_secs(5), child)
         .map_err(|e| panic!("error: {:?}", e))
         .map(|output| {
             let stdout = String::from_utf8_lossy(&output.stdout);

--- a/ci/run-ios.sh
+++ b/ci/run-ios.sh
@@ -22,8 +22,12 @@ case "$TARGET" in
     # Find the file to run
     TEST_FILE="$(find $TARGET/debug -maxdepth 1 -type f -name test-* | head -1)";
 
-    rustc -O ./ci/ios/deploy_and_run_on_ios_simulator.rs;
-    ./deploy_and_run_on_ios_simulator $TEST_FILE;
+    # rustc -O ./ci/ios/deploy_and_run_on_ios_simulator.rs;
+    # ./deploy_and_run_on_ios_simulator $TEST_FILE;
+    cargo run \
+      --manifest-path=ci/ios/Cargo.toml \
+      --bin=deploy_and_run_on_ios_simulator \
+      -- $TEST_FILE;
 
     ;;
 


### PR DESCRIPTION
It seems like the iOS test run can take longer than 10 minutes on
Travis. This branch instructs Travis to wait 20 minutes before failing
the build.

This may not be ready to merge yet. I'm opening the PR to trigger a CI
build, in order to verify this change.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>