### PR TITLE
Add tests for poll blocking/unblocking

### DIFF
--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -1,9 +1,7 @@
 use mio::*;
 use std::time::Duration;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 
 #[test]

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -1,5 +1,10 @@
 use mio::*;
 use std::time::Duration;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::thread;
 
 #[test]
 fn test_poll_closes_fd() {
@@ -16,3 +21,91 @@ fn test_poll_closes_fd() {
         drop(registration);
     }
 }
+
+#[test]
+fn test_poll_duration_none_blocks() {
+    let is_blocked = Arc::new(AtomicBool::new(true));
+
+    let poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(4);
+    let (registration, _) = Registration::new2();
+
+    poll.register(&registration, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+
+    let is_blocked2 = is_blocked.clone();
+    let _join = thread::spawn(move || {
+        poll.poll(&mut events, None).unwrap();
+        is_blocked2.store(false, Ordering::SeqCst);
+    });
+
+    assert!(is_blocked.load(Ordering::SeqCst));
+
+}
+
+#[test]
+fn test_poll_duration_0_doesnt_block() {
+    let is_blocked = Arc::new(AtomicBool::new(true));
+
+    let poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(4);
+    let (registration, _) = Registration::new2();
+
+    poll.register(&registration, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+
+    let is_blocked2 = is_blocked.clone();
+    let _join = thread::spawn(move || {
+        poll.poll(&mut events, Some(Duration::new(0, 0))).unwrap();
+        is_blocked2.store(false, Ordering::SeqCst);
+    });
+
+    thread::sleep(Duration::from_millis(1));
+    assert_eq!(is_blocked.load(Ordering::SeqCst), false);
+
+}
+
+#[test]
+fn test_poll_unblocks() {
+    let is_blocked = Arc::new(AtomicBool::new(true));
+
+    let poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(4);
+    let (registration, set_readiness) = Registration::new2();
+
+    poll.register(&registration, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+
+    let is_blocked2 = is_blocked.clone();
+    let _join = thread::spawn(move || {
+        poll.poll(&mut events, None).unwrap();
+        is_blocked2.store(false, Ordering::SeqCst);
+    });
+
+    assert!(is_blocked.load(Ordering::SeqCst));
+    set_readiness.set_readiness(Ready::readable()).unwrap();
+    thread::sleep(Duration::from_millis(1));
+    assert_eq!(is_blocked.load(Ordering::SeqCst), false);
+
+}
+
+
+#[test]
+fn test_poll_timeout() {
+    let is_blocked = Arc::new(AtomicBool::new(true));
+
+    let poll = Poll::new().unwrap();
+    let mut events = Events::with_capacity(4);
+    let (registration, _) = Registration::new2();
+
+    poll.register(&registration, Token(0), Ready::readable(), PollOpt::edge()).unwrap();
+
+    let is_blocked2 = is_blocked.clone();
+    let _join = thread::spawn(move || {
+        poll.poll(&mut events, Some(Duration::from_millis(500))).unwrap();
+        is_blocked2.store(false, Ordering::SeqCst);
+    });
+
+    assert!(is_blocked.load(Ordering::SeqCst));
+    thread::sleep(Duration::from_millis(600));
+    assert_eq!(is_blocked.load(Ordering::SeqCst), false);
+
+}
+

--- a/test/test_poll.rs
+++ b/test/test_poll.rs
@@ -56,7 +56,7 @@ fn test_poll_duration_0_doesnt_block() {
         is_blocked2.store(false, Ordering::SeqCst);
     });
 
-    thread::sleep(Duration::from_millis(1));
+    thread::sleep(Duration::from_millis(100));
     assert_eq!(is_blocked.load(Ordering::SeqCst), false);
 
 }
@@ -79,7 +79,7 @@ fn test_poll_unblocks() {
 
     assert!(is_blocked.load(Ordering::SeqCst));
     set_readiness.set_readiness(Ready::readable()).unwrap();
-    thread::sleep(Duration::from_millis(1));
+    thread::sleep(Duration::from_millis(100));
     assert_eq!(is_blocked.load(Ordering::SeqCst), false);
 
 }


### PR DESCRIPTION
This branch adds tests in `tests/test_poll.rs` which assert that calls
to `poll` with various timeouts block and unblock the calling thread as
expected.

This is primarily an attempt to reproduce #860, and as I can't reproduce
the behavior therein described on my Mac, I'm opening this PR primarily
to get it to run on more platforms on CI; it doesn't need to be reviewed or
merged. However, these simple tests might be worth having on master 
as well, so I'd be happy to merge this branch if desired.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>