### PR TITLE
Add EPOLLPRI readiness to UnixReady on supported platforms

### DIFF
--- a/src/sys/unix/epoll.rs
+++ b/src/sys/unix/epoll.rs
@@ -145,6 +145,11 @@ fn ioevent_to_epoll(interest: Ready, opts: PollOpt) -> u32 {
         kind |= EPOLLRDHUP;
     }
 
+
+    if UnixReady::from(interest).is_priority() {
+        kind |= EPOLLPRI;
+    }
+
     if opts.is_edge() {
         kind |= EPOLLET;
     }
@@ -206,8 +211,12 @@ impl Events {
             let epoll = event.events as c_int;
             let mut kind = Ready::empty();
 
-            if (epoll & EPOLLIN) != 0 || (epoll & EPOLLPRI) != 0 {
+            if (epoll & EPOLLIN) != 0 {
                 kind = kind | Ready::readable();
+            }
+
+            if (epoll & EPOLLPRI) != 0 {
+                kind = kind | Ready::readable() | UnixReady::priority();
             }
 
             if (epoll & EPOLLOUT) != 0 {


### PR DESCRIPTION
Closes #835.

This branch adds `UnixReady::{priority, is_priority}` functions which
set and test for the `EPOLLPRI` flag, respectively, on platforms that
support `epoll`. Additionally, it modifies the `epoll` selector in
`mio::sys::unix::epoll` to support `UnixReady::priority()` as a distinct
interest type, and set the `priority` bit as well as the `readable` bit
on events where `EPOLLPRI` is set.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>