### PR TITLE
Fix links in EventedFd doc

### DIFF
--- a/src/sys/unix/eventedfd.rs
+++ b/src/sys/unix/eventedfd.rs
@@ -10,7 +10,7 @@ use std::os::unix::io::RawFd;
 
 #[derive(Debug)]
 
-/// Adapter for `RawFd` providing an [`Evented`] implementation.
+/// Adapter for [`RawFd`] providing an [`Evented`] implementation.
 ///
 /// `EventedFd` enables registering any type with an FD with [`Poll`].
 ///
@@ -53,7 +53,7 @@ use std::os::unix::io::RawFd;
 /// # }
 /// ```
 ///
-/// Implementing `Evented` for a custom type backed by a `RawFd`.
+/// Implementing [`Evented`] for a custom type backed by a [`RawFd`].
 ///
 /// ```
 /// use mio::{Ready, Poll, PollOpt, Token};
@@ -86,6 +86,7 @@ use std::os::unix::io::RawFd;
 /// }
 /// ```
 ///
+/// [`RawFd`]: https://doc.rust-lang.org/std/os/unix/io/type.RawFd.html
 /// [`Evented`]: ../event/trait.Evented.html
 /// [`Poll`]: ../struct.Poll.html
 /// [`Poll::register`]: ../struct.Poll.html#method.register


### PR DESCRIPTION
Fixes carllerche/mio#743

The issue reports that RawFd, Evented, and Poll links aren't working, but as of the latest master, Evented and Poll links already work.

This change converts two instances of `RawFd` in the EventedFd documentation into a link to the Rust std library documentation:

https://doc.rust-lang.org/std/os/unix/io/type.RawFd.html

The issue links to version 0.6.10 documentation of mio where `RawFd` was a broken link, but in master, `RawFd` was changed to simply an inline code. Nevertheless, I think it's still better to make it a link for the following reasons:

* Providing the link makes it immediately clear which type it's referring to.
* In the documentation for [`Poll`](https://docs.rs/mio/0.6.16/mio/struct.Poll.html), `WouldBlock` links to the Rust std library documentation so there's precedence.

The change also makes an instance of `Evented` into a link for consistency. The `&RawFd` in the documentation was not changed.

The only testing made with this change is to generate the docs locally, and verifying that the links are working.
