### PR TITLE
Improve deprecation message and fix example for Registration

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -424,7 +424,7 @@ pub struct Poll {
 ///     }
 ///
 ///     fn deregister(&self, poll: &Poll) -> io::Result<()> {
-///         self.registration.deregister(poll)
+///         poll.deregister(&self.registration)
 ///     }
 /// }
 /// ```
@@ -1659,7 +1659,7 @@ impl Registration {
         self.inner.update(poll, token, interest, opts)
     }
 
-    #[deprecated(since = "0.6.5", note = "use `Evented` impl")]
+    #[deprecated(since = "0.6.5", note = "use `Poll::deregister` instead")]
     #[cfg(feature = "with-deprecated")]
     #[doc(hidden)]
     pub fn deregister(&self, poll: &Poll) -> io::Result<()> {


### PR DESCRIPTION
Fixes carllerche/mio#817

Some of the suggestions in the issue discussion are:

1. Remove deprecation
1. Improve deprecation message
1. Update example in the documentation of `Registration` to use `deregister` of `Poll`

This PR does 2 and 3. It changes the deprecation message from "use `Evented` impl" to "use `Poll::deregister` instead". It also updates the example in the doc to use:

```
poll.deregister(&self.registration)
```

Please let me know if removing the deprecation is more preferable than improving the deprecation message.
