### PR TITLE
Fix TcpListener example

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -482,7 +482,7 @@ impl fmt::Debug for TcpStream {
 /// let mut events = Events::with_capacity(128);
 ///
 /// // Register the socket with `Poll`
-/// poll.register(&listener, Token(0), Ready::writable(),
+/// poll.register(&listener, Token(0), Ready::readable(),
 ///               PollOpt::edge())?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;


### PR DESCRIPTION
In real world we will register TcpListener for readable events. Let's make example reflect that as well.
See https://github.com/carllerche/mio/issues/884