### PR TITLE
Implement AsRawSocket and FromRawSocket on Windows for TcpListener, T…

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -735,3 +735,46 @@ impl FromRawFd for TcpListener {
         }
     }
 }
+
+/*
+ *
+ * ===== Windows ext =====
+ *
+ */
+
+#[cfg(windows)]
+use std::os::windows::io::{AsRawSocket, FromRawSocket, RawSocket};
+
+#[cfg(windows)]
+impl AsRawSocket for TcpStream {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.sys.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl FromRawSocket for TcpStream {
+    unsafe fn from_raw_socket(socket: RawSocket) -> TcpStream {
+        TcpStream {
+            sys: FromRawSocket::from_raw_socket(socket),
+            selector_id: SelectorId::new(),
+        }
+    }
+}
+
+#[cfg(windows)]
+impl AsRawSocket for TcpListener {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.sys.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl FromRawSocket for TcpListener {
+    unsafe fn from_raw_socket(socket: RawSocket) -> TcpListener {
+        TcpListener {
+            sys: FromRawSocket::from_raw_socket(socket),
+            selector_id: SelectorId::new(),
+        }
+    }
+}

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -598,3 +598,28 @@ impl FromRawFd for UdpSocket {
     }
 }
 
+/*
+ *
+ * ===== Windows ext =====
+ *
+ */
+
+#[cfg(windows)]
+use std::os::windows::io::{AsRawSocket, FromRawSocket, RawSocket};
+
+#[cfg(windows)]
+impl AsRawSocket for UdpSocket {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.sys.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl FromRawSocket for UdpSocket {
+    unsafe fn from_raw_socket(socket: RawSocket) -> UdpSocket {
+        UdpSocket {
+            sys: FromRawSocket::from_raw_socket(socket),
+            selector_id: SelectorId::new(),
+        }
+    }
+}

--- a/src/sys/windows/tcp.rs
+++ b/src/sys/windows/tcp.rs
@@ -623,6 +623,18 @@ impl fmt::Debug for TcpStream {
     }
 }
 
+impl FromRawSocket for TcpStream {
+    unsafe fn from_raw_socket(socket: RawSocket) -> TcpStream {
+        TcpStream::from_stream(net::TcpStream::from_raw_socket(socket))
+    }
+}
+
+impl AsRawSocket for TcpStream {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.imp.inner.socket.as_raw_socket()
+    }
+}
+
 impl Drop for TcpStream {
     fn drop(&mut self) {
         // If we're still internally reading, we're no longer interested. Note
@@ -829,6 +841,19 @@ impl fmt::Debug for TcpListener {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("TcpListener")
             .finish()
+    }
+}
+
+impl FromRawSocket for TcpListener {
+    unsafe fn from_raw_socket(fd: RawSocket) -> TcpListener {
+        TcpListener::new(net::TcpListener::from_raw_socket(fd))
+            .expect("Can't create listener from raw socket")
+    }
+}
+
+impl AsRawSocket for TcpListener {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.imp.inner.socket.as_raw_socket()
     }
 }
 

--- a/src/sys/windows/udp.rs
+++ b/src/sys/windows/udp.rs
@@ -8,6 +8,7 @@ use std::io::prelude::*;
 use std::io;
 use std::mem;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::os::windows::prelude::*;
 use std::sync::{Mutex, MutexGuard};
 
 #[allow(unused_imports)]
@@ -359,6 +360,19 @@ impl fmt::Debug for UdpSocket {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("UdpSocket")
             .finish()
+    }
+}
+
+impl FromRawSocket for UdpSocket {
+    unsafe fn from_raw_socket(socket: RawSocket) -> UdpSocket {
+        // new() can't possibly fail
+        UdpSocket::new(net::UdpSocket::from_raw_socket(socket)).unwrap()
+    }
+}
+
+impl AsRawSocket for UdpSocket {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.imp.inner.socket.as_raw_socket()
     }
 }
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -324,3 +324,29 @@ impl FromRawFd for UdpSocket {
         }
     }
 }
+
+/*
+ *
+ * ===== Windows ext =====
+ *
+ */
+
+#[cfg(windows)]
+use std::os::windows::io::{AsRawSocket, FromRawSocket, RawSocket};
+
+#[cfg(windows)]
+impl AsRawSocket for UdpSocket {
+    fn as_raw_socket(&self) -> RawSocket {
+        self.sys.as_raw_socket()
+    }
+}
+
+#[cfg(windows)]
+impl FromRawSocket for UdpSocket {
+    unsafe fn from_raw_socket(socket: RawSocket) -> UdpSocket {
+        UdpSocket {
+            sys: FromRawSocket::from_raw_socket(socket),
+            selector_id: SelectorId::new(),
+        }
+    }
+}


### PR DESCRIPTION
…cpStream and UdpSocket

IntoRawSocket can't be easily implemented as we do reference counting
for the underlying socket and as such can't move the socket out of the
struct.