### PR TITLE
Switch FreeBSD's CI to cirrus-ci.com

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+freebsd_instance:
+  image: freebsd-11-2-release-amd64
+
+task:
+  name: FreeBSD 11.2 amd64
+  setup_script:
+    - pkg install -y curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh -y
+  cargo_cache:
+    folder: $CARGO_HOME/registry
+  build_script:
+    - . $HOME/.cargo/env
+    - cargo build
+    - cargo build --no-default-features
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo test
+    - cargo test --no-default-features
+  before_cache_script:
+    - rm -rf $CARGO_HOME/registry/index

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh -y
   cargo_cache:
-    folder: $CARGO_HOME/registry
+    folder: $HOME/.cargo/registry
   build_script:
     - . $HOME/.cargo/env
     - cargo build
@@ -18,4 +18,4 @@ task:
     - cargo test
     - cargo test --no-default-features
   before_cache_script:
-    - rm -rf $CARGO_HOME/registry/index
+    - rm -rf $HOME/.cargo/registry/index

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ overhead as possible over the OS abstractions.
 [![crates.io](http://meritbadge.herokuapp.com/mio)](https://crates.io/crates/mio)
 [![Build Status](https://travis-ci.org/carllerche/mio.svg?branch=master)](https://travis-ci.org/carllerche/mio)
 [![Build status](https://ci.appveyor.com/api/projects/status/ok90r1tcgkyndnvw/branch/master?svg=true)](https://ci.appveyor.com/project/carllerche/mio/branch/master)
+[![Build Status](https://api.cirrus-ci.com/github/carllerche/mio.svg)](https://cirrus-ci.com/github/carllerche/mio)
 
 **API documentation**
 


### PR DESCRIPTION
This change does the following:
1) Adds a CI build on cirrus-ci.com
2) Switches FreeBSD's CI from a jail to a full VM

This change does _not_ disable buildbot.  That must happen outside of
git.

Fixes #895