### PR TITLE
Support vector I/O for UdpSocket on Unix

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -13,6 +13,8 @@ use poll::SelectorId;
 use std::fmt;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 
+use iovec::IoVec;
+
 /// A User Datagram Protocol socket.
 ///
 /// This is an implementation of a bound UDP socket. This supports both IPv4 and
@@ -541,6 +543,42 @@ impl UdpSocket {
     /// calls.
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         self.sys.take_error()
+    }
+
+    /// Receives a single datagram message socket previously bound with connect().
+    ///
+    /// This operation will attempt to read bytes from this socket and place
+    /// them into the list of buffers provided. Note that each buffer is an
+    /// `IoVec` which can be created from a byte slice.
+    ///
+    /// The buffers provided will be filled in sequentially. A buffer will be
+    /// entirely filled up before the next is written to.
+    ///
+    /// The number of bytes read is returned, if successful, or an error is
+    /// returned otherwise. If no bytes are available to be read yet then
+    /// a "would block" error is returned. This operation does not block.
+    ///
+    /// On Unix this corresponds to the `readv` syscall.
+    pub fn recv_bufs(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
+        self.sys.readv(bufs)
+    }
+
+    /// Sends data on the socket to the address previously bound via connect().
+    ///
+    /// This operation will attempt to send a list of byte buffers to this
+    /// socket in a single datagram. Note that each buffer is an `IoVec`
+    /// which can be created from a byte slice.
+    ///
+    /// The buffers provided will be written sequentially. A buffer will be
+    /// entirely written before the next is written.
+    ///
+    /// The number of bytes written is returned, if successful, or an error is
+    /// returned otherwise. If the socket is not currently writable then a
+    /// "would block" error is returned. This operation does not block.
+    ///
+    /// On Unix this corresponds to the `writev` syscall.
+    pub fn send_bufs(&self, bufs: &[&IoVec]) -> io::Result<usize> {
+        self.sys.writev(bufs)
     }
 }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -13,6 +13,7 @@ use poll::SelectorId;
 use std::fmt;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 
+#[cfg(all(unix, not(target_os = "fuchsia")))]
 use iovec::IoVec;
 
 /// A User Datagram Protocol socket.
@@ -559,6 +560,7 @@ impl UdpSocket {
     /// a "would block" error is returned. This operation does not block.
     ///
     /// On Unix this corresponds to the `readv` syscall.
+    #[cfg(all(unix, not(target_os = "fuchsia")))]
     pub fn recv_bufs(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
         self.sys.readv(bufs)
     }
@@ -577,6 +579,7 @@ impl UdpSocket {
     /// "would block" error is returned. This operation does not block.
     ///
     /// On Unix this corresponds to the `writev` syscall.
+    #[cfg(all(unix, not(target_os = "fuchsia")))]
     pub fn send_bufs(&self, bufs: &[&IoVec]) -> io::Result<usize> {
         self.sys.writev(bufs)
     }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -546,26 +546,28 @@ impl UdpSocket {
         self.sys.take_error()
     }
 
-    /// Receives a single datagram message socket previously bound with connect().
+    /// Receives a single datagram message socket previously bound with connect.
     ///
     /// This operation will attempt to read bytes from this socket and place
     /// them into the list of buffers provided. Note that each buffer is an
     /// `IoVec` which can be created from a byte slice.
     ///
-    /// The buffers provided will be filled in sequentially. A buffer will be
+    /// The buffers provided will be filled sequentially. A buffer will be
     /// entirely filled up before the next is written to.
     ///
     /// The number of bytes read is returned, if successful, or an error is
     /// returned otherwise. If no bytes are available to be read yet then
-    /// a "would block" error is returned. This operation does not block.
+    /// a [`WouldBlock`][link] error is returned. This operation does not block.
     ///
     /// On Unix this corresponds to the `readv` syscall.
+    ///
+    /// [link]: https://doc.rust-lang.org/nightly/std/io/enum.ErrorKind.html#variant.WouldBlock
     #[cfg(all(unix, not(target_os = "fuchsia")))]
     pub fn recv_bufs(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
         self.sys.readv(bufs)
     }
 
-    /// Sends data on the socket to the address previously bound via connect().
+    /// Sends data on the socket to the address previously bound via connect.
     ///
     /// This operation will attempt to send a list of byte buffers to this
     /// socket in a single datagram. Note that each buffer is an `IoVec`
@@ -576,9 +578,11 @@ impl UdpSocket {
     ///
     /// The number of bytes written is returned, if successful, or an error is
     /// returned otherwise. If the socket is not currently writable then a
-    /// "would block" error is returned. This operation does not block.
+    /// [`WouldBlock`][link] error is returned. This operation does not block.
     ///
     /// On Unix this corresponds to the `writev` syscall.
+    ///
+    /// [link]: https://doc.rust-lang.org/nightly/std/io/enum.ErrorKind.html#variant.WouldBlock
     #[cfg(all(unix, not(target_os = "fuchsia")))]
     pub fn send_bufs(&self, bufs: &[&IoVec]) -> io::Result<usize> {
         self.sys.writev(bufs)

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -37,7 +37,6 @@ pub use self::ready::{UnixReady, READY_ALL};
 pub use self::tcp::{TcpStream, TcpListener};
 pub use self::udp::UdpSocket;
 
-
 #[cfg(feature = "with-deprecated")]
 pub use self::uds::UnixSocket;
 

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -25,6 +25,7 @@ mod io;
 mod ready;
 mod tcp;
 mod udp;
+mod uio;
 
 #[cfg(feature = "with-deprecated")]
 mod uds;
@@ -35,6 +36,7 @@ pub use self::io::{Io, set_nonblock};
 pub use self::ready::{UnixReady, READY_ALL};
 pub use self::tcp::{TcpStream, TcpListener};
 pub use self::udp::UdpSocket;
+
 
 #[cfg(feature = "with-deprecated")]
 pub use self::uds::UnixSocket;

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use std::fmt;
 use std::io::{Read, Write};
 use std::net::{self, SocketAddr};
@@ -8,13 +7,13 @@ use std::time::Duration;
 use libc;
 use net2::TcpStreamExt;
 use iovec::IoVec;
-use iovec::unix as iovec;
 
 use {io, Ready, Poll, PollOpt, Token};
 use event::Evented;
 
 use sys::unix::eventedfd::EventedFd;
 use sys::unix::io::set_nonblock;
+use sys::unix::uio::VecIo;
 
 pub struct TcpStream {
     inner: net::TcpStream,
@@ -130,33 +129,11 @@ impl TcpStream {
     }
 
     pub fn readv(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
-        unsafe {
-            let slice = iovec::as_os_slice_mut(bufs);
-            let len = cmp::min(<libc::c_int>::max_value() as usize, slice.len());
-            let rc = libc::readv(self.inner.as_raw_fd(),
-                                 slice.as_ptr(),
-                                 len as libc::c_int);
-            if rc < 0 {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(rc as usize)
-            }
-        }
+        self.inner.readv(bufs)
     }
 
     pub fn writev(&self, bufs: &[&IoVec]) -> io::Result<usize> {
-        unsafe {
-            let slice = iovec::as_os_slice(bufs);
-            let len = cmp::min(<libc::c_int>::max_value() as usize, slice.len());
-            let rc = libc::writev(self.inner.as_raw_fd(),
-                                  slice.as_ptr(),
-                                  len as libc::c_int);
-            if rc < 0 {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(rc as usize)
-            }
-        }
+        self.inner.writev(bufs)
     }
 }
 

--- a/src/sys/unix/udp.rs
+++ b/src/sys/unix/udp.rs
@@ -1,12 +1,14 @@
 use {io, Ready, Poll, PollOpt, Token};
 use event::Evented;
 use unix::EventedFd;
+use sys::unix::uio::VecIo;
 use std::fmt;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::os::unix::io::{RawFd, IntoRawFd, AsRawFd, FromRawFd};
 
 #[allow(unused_imports)] // only here for Rust 1.8
 use net2::UdpSocketExt;
+use iovec::IoVec;
 
 pub struct UdpSocket {
     io: net::UdpSocket,
@@ -127,6 +129,14 @@ impl UdpSocket {
 
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         self.io.take_error()
+    }
+
+    pub fn readv(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
+        self.io.readv(bufs)
+    }
+
+    pub fn writev(&self, bufs: &[&IoVec]) -> io::Result<usize> {
+        self.io.writev(bufs)
     }
 }
 

--- a/src/sys/unix/uio.rs
+++ b/src/sys/unix/uio.rs
@@ -1,0 +1,43 @@
+use std::cmp;
+use std::io;
+use std::os::unix::io::AsRawFd;
+use iovec::IoVec;
+use iovec::unix as iovec;
+
+pub trait VecIo {
+    fn readv(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize>;
+
+    fn writev(&self, bufs: &[&IoVec]) -> io::Result<usize>;
+}
+
+impl<T: AsRawFd> VecIo for T {
+    fn readv(&self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
+        unsafe {
+            let slice = iovec::as_os_slice_mut(bufs);
+            let len = cmp::min(<libc::c_int>::max_value() as usize, slice.len());
+            let rc = libc::readv(self.as_raw_fd(),
+                                 slice.as_ptr(),
+                                 len as libc::c_int);
+            if rc < 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(rc as usize)
+            }
+        }
+    }
+
+    fn writev(&self, bufs: &[&IoVec]) -> io::Result<usize> {
+        unsafe {
+            let slice = iovec::as_os_slice(bufs);
+            let len = cmp::min(<libc::c_int>::max_value() as usize, slice.len());
+            let rc = libc::writev(self.as_raw_fd(),
+                                  slice.as_ptr(),
+                                  len as libc::c_int);
+            if rc < 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(rc as usize)
+            }
+        }
+    }
+}

--- a/src/sys/unix/uio.rs
+++ b/src/sys/unix/uio.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 use std::io;
 use std::os::unix::io::AsRawFd;
+use libc;
 use iovec::IoVec;
 use iovec::unix as iovec;
 

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -1,10 +1,11 @@
-use mio::{Events, Poll, PollOpt, Ready, Token};
+use bytes::{Buf, MutBuf, RingBuf, SliceBuf};
+use iovec::IoVec;
+use localhost;
 use mio::net::UdpSocket;
-use bytes::{Buf, RingBuf, SliceBuf, MutBuf};
+use mio::{Events, Poll, PollOpt, Ready, Token};
 use std::io::ErrorKind;
 use std::str;
 use std::time;
-use localhost;
 
 const LISTENER: Token = Token(0);
 const SENDER: Token = Token(1);
@@ -20,7 +21,7 @@ pub struct UdpHandlerSendRecv {
 }
 
 impl UdpHandlerSendRecv {
-    fn new(tx: UdpSocket, rx: UdpSocket, connected: bool, msg : &'static str) -> UdpHandlerSendRecv {
+    fn new(tx: UdpSocket, rx: UdpSocket, connected: bool, msg: &'static str) -> UdpHandlerSendRecv {
         UdpHandlerSendRecv {
             tx,
             rx,
@@ -33,10 +34,26 @@ impl UdpHandlerSendRecv {
     }
 }
 
-fn assert_send<T: Send>() {
-}
+fn assert_send<T: Send>() {}
 
-fn assert_sync<T: Sync>() {
+fn assert_sync<T: Sync>() {}
+
+#[cfg(test)]
+/// Returns the sender and the receiver
+fn connected_sockets() -> (UdpSocket, UdpSocket) {
+    let addr = localhost();
+    let any = localhost();
+
+    let tx = UdpSocket::bind(&any).unwrap();
+    let rx = UdpSocket::bind(&addr).unwrap();
+
+    let tx_addr = tx.local_addr().unwrap();
+    let rx_addr = rx.local_addr().unwrap();
+
+    assert!(tx.connect(rx_addr).is_ok());
+    assert!(rx.connect(tx_addr).is_ok());
+
+    (tx, rx)
 }
 
 #[cfg(test)]
@@ -49,13 +66,18 @@ fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
 
     // ensure that the sockets are non-blocking
     let mut buf = [0; 128];
-    assert_eq!(ErrorKind::WouldBlock, rx.recv_from(&mut buf).unwrap_err().kind());
+    assert_eq!(
+        ErrorKind::WouldBlock,
+        rx.recv_from(&mut buf).unwrap_err().kind()
+    );
 
     info!("Registering SENDER");
-    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge())
+        .unwrap();
 
     info!("Registering LISTENER");
-    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge()).unwrap();
+    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
+        .unwrap();
 
     let mut events = Events::with_capacity(1024);
 
@@ -77,7 +99,9 @@ fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
                         }
                     };
 
-                    unsafe { MutBuf::advance(&mut handler.rx_buf, cnt); }
+                    unsafe {
+                        MutBuf::advance(&mut handler.rx_buf, cnt);
+                    }
                     assert!(str::from_utf8(handler.rx_buf.bytes()).unwrap() == handler.msg);
                     handler.shutdown = true;
                 }
@@ -112,17 +136,7 @@ pub fn test_udp_socket() {
 
 #[test]
 pub fn test_udp_socket_send_recv() {
-    let addr = localhost();
-    let any = localhost();
-
-    let tx = UdpSocket::bind(&any).unwrap();
-    let rx = UdpSocket::bind(&addr).unwrap();
-
-    let tx_addr = tx.local_addr().unwrap();
-    let rx_addr = rx.local_addr().unwrap();
-
-    assert!(tx.connect(rx_addr).is_ok());
-    assert!(rx.connect(tx_addr).is_ok());
+    let (tx, rx) = connected_sockets();
 
     test_send_recv_udp(tx, rx, true);
 }
@@ -139,7 +153,7 @@ pub fn test_udp_socket_discard() {
 
     let tx_addr = tx.local_addr().unwrap();
     let rx_addr = rx.local_addr().unwrap();
- 
+
     assert!(tx.connect(rx_addr).is_ok());
     assert!(udp_outside.connect(rx_addr).is_ok());
     assert!(rx.connect(tx_addr).is_ok());
@@ -149,17 +163,98 @@ pub fn test_udp_socket_discard() {
     let r = udp_outside.send(b"hello world");
     assert!(r.is_ok() || r.unwrap_err().kind() == ErrorKind::WouldBlock);
 
-    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge()).unwrap();
-    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge()).unwrap();
+    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
+        .unwrap();
+    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge())
+        .unwrap();
 
     let mut events = Events::with_capacity(1024);
 
-    poll.poll(&mut events, Some(time::Duration::from_secs(5))).unwrap();
+    poll.poll(&mut events, Some(time::Duration::from_secs(5)))
+        .unwrap();
 
     for event in &events {
         if event.readiness().is_readable() {
             if let LISTENER = event.token() {
                 assert!(false, "Expected to no receive a packet but got something")
+            }
+        }
+    }
+}
+
+#[test]
+pub fn test_udp_socket_send_recv_bufs() {
+    let (tx, rx) = connected_sockets();
+
+    let poll = Poll::new().unwrap();
+
+    poll.register(&tx, SENDER, Ready::writable(), PollOpt::edge())
+        .unwrap();
+
+    poll.register(&rx, LISTENER, Ready::readable(), PollOpt::edge())
+        .unwrap();
+
+    let mut events = Events::with_capacity(1024);
+
+    let data = b"hello, world";
+    let write_bufs: Vec<_> = vec![b"hello, " as &[u8], b"world"]
+        .into_iter()
+        .flat_map(IoVec::from_bytes)
+        .collect();
+    let (a, b, c) = (
+        &mut [0u8; 4] as &mut [u8],
+        &mut [0u8; 6] as &mut [u8],
+        &mut [0u8; 8] as &mut [u8],
+    );
+    let mut read_bufs: Vec<_> = vec![a, b, c]
+        .into_iter()
+        .flat_map(IoVec::from_bytes_mut)
+        .collect();
+
+    let times = 5;
+    let mut rtimes = 0;
+    let mut wtimes = 0;
+
+    'outer: loop {
+        poll.poll(&mut events, None).unwrap();
+
+        for event in &events {
+            if event.readiness().is_readable() {
+                if let LISTENER = event.token() {
+                    loop {
+                        let cnt = match rx.recv_bufs(read_bufs.as_mut()) {
+                            Ok(cnt) => cnt,
+                            Err(ref e) if e.kind() == ErrorKind::WouldBlock => break,
+                            Err(e) => panic!("read error {}", e),
+                        };
+                        assert_eq!(cnt, data.len());
+                        let res: Vec<u8> = read_bufs
+                            .iter()
+                            .map(|buf| buf.iter())
+                            .flatten()
+                            .cloned()
+                            .collect();
+                        assert_eq!(&res[..cnt], &data[..cnt]);
+                        rtimes += 1;
+                        if rtimes == times {
+                            break 'outer;
+                        }
+                    }
+                }
+            }
+
+            if event.readiness().is_writable() {
+                if let SENDER = event.token() {
+                    while wtimes < times {
+                        let cnt = match tx.send_bufs(write_bufs.as_slice()) {
+                            Ok(cnt) => cnt,
+                            Err(ref e) if e.kind() == ErrorKind::WouldBlock => break,
+                            Err(e) => panic!("write error {}", e),
+                        };
+                        assert_eq!(cnt, data.len());
+                        wtimes += 1;
+                    }
+                }
             }
         }
     }

--- a/test/test_udp_socket.rs
+++ b/test/test_udp_socket.rs
@@ -101,7 +101,6 @@ fn test_send_recv_udp(tx: UdpSocket, rx: UdpSocket, connected: bool) {
 }
 
 /// Returns the sender and the receiver
-#[cfg(test)]
 fn connected_sockets() -> (UdpSocket, UdpSocket) {
     let addr = localhost();
     let any = localhost();


### PR DESCRIPTION
This add initial vector I/O support for UdpSocket on unix-likes. 

Fuchsia and Windows support is not included in this pr. 

As the udp implementation on windows is wrong at this time, maybe we need to fix that first...

See also #914 